### PR TITLE
更改table.fieldNames获取只获取数据库中的字段，而不加AS转换

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableInfo.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableInfo.java
@@ -229,9 +229,9 @@ public class TableInfo {
             for (int i = 0; i < fields.size(); i++) {
                 TableField fd = fields.get(i);
                 if (i == fields.size() - 1) {
-                    names.append(cov2col(fd));
+                    names.append(fd.getName());
                 } else {
-                    names.append(cov2col(fd)).append(", ");
+                    names.append(fd.getName()).append(", ");
                 }
             }
             fieldNames = names.toString();


### PR DESCRIPTION
在resultMap中的类型为`column="create_time"`
```
<resultMap id="BaseResultMap" type="com.baomidou.test.entity.Account">
		<id column="id" property="id" />
		<result column="name" property="name" />
		<result column="create_time" property="createTime" />
		<result column="update_time" property="updateTime" />
</resultMap>
```
那么在sql中应该也是`create_time"`而非`createTime`,所以在通用column中，不用加AS