### PR TITLE
Update controller.java.ftl

### DIFF
--- a/mybatis-plus-generate/src/main/resources/templates/controller.java.ftl
+++ b/mybatis-plus-generate/src/main/resources/templates/controller.java.ftl
@@ -33,7 +33,7 @@ class ${table.controllerName}<#if superControllerClass??> : ${superControllerCla
 public class ${table.controllerName} extends ${superControllerClass} {
 <#else>
 public class ${table.controllerName} {
+</#if>
 
 }
-</#if>
 </#if>


### PR DESCRIPTION
用 freemarker 模板引擎生成Controller
带superControllerClass的Controller生成缺少最后的花括号“}”