### PR TITLE
新增一处判空，否则可能会报空指针异常

### DIFF
--- a/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
+++ b/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
@@ -185,8 +185,8 @@ public class MybatisPlusAutoConfiguration {
         // TODO 自定义配置
         if (null != configuration) {
             configuration.setDefaultScriptingLanguage(MybatisXMLLanguageDriver.class);
+            factory.setConfiguration(configuration.init(this.properties.getGlobalConfig()));
         }
-        factory.setConfiguration(configuration.init(this.properties.getGlobalConfig()));
     }
 
     @Bean


### PR DESCRIPTION
mybatis-plus.configuration.*的时候，会报空指针异常，所以需要对这里的configuration进行判空

### 该Pull Request关联的Issue
#492 

### 修改描述
mybatis-plus.configuration.*的时候，会报空指针异常，所以需要对这里的configuration进行判空


### 测试用例



### 修复效果的截屏



