### PR TITLE
Fix Issue 528 531,当使用mybatis-config.xml的时候，MybatisPlusAutoConfigurati…

### DIFF
--- a/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
+++ b/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
@@ -186,7 +186,9 @@ public class MybatisPlusAutoConfiguration {
         if (null != configuration) {
             configuration.setDefaultScriptingLanguage(MybatisXMLLanguageDriver.class);
         }
-        factory.setConfiguration(configuration.init(this.properties.getGlobalConfig()));
+        if (null != configuration) {
+            factory.setConfiguration(configuration.init(this.properties.getGlobalConfig()));
+        }
     }
 
     @Bean


### PR DESCRIPTION
### 该Pull Request关联的Issue
528 531

### 修改描述
MybatisPlusAutoConfiguration的私有方法applyConfiguration(MybatisSqlSessionFactoryBean factory) 的
factory.setConfiguration(configuration.init(this.properties.getGlobalConfig()));这一句，由于使用的是mybatis-config.xml配置文件的形式，configuration是为null的，导致这一句NPE

application.yml中使用mybatis-plus.config-location的方式的时候会出现这个问题。
application.yml中使用mybatis-plus.configuration没问题。


### 测试用例
- application.yml
```yaml
spring:
  datasource:
    driver-class-name: org.h2.Driver
    schema: classpath:db/schema-h2.sql
    data: classpath:db/data-h2.sql
    url: jdbc:h2:mem:test;MODE=MYSQL;DB_CLOSE_DELAY=-1
    username: sa
    password: 123456
mybatis-plus:
  mapper-locations: classpath:mybatis/mapper/**/*.xml
  type-aliases-package: cn.jaychang.mybatisplusdemo.entity
#  configuration:
#    map-underscore-to-camel-case: true
#    use-generated-keys: true
  global-config:
    banner: false
  #目前config-location有问题，报NPE
  config-location: classpath:mybatis/mybatis-config.xml
```

- mybaits-config.xml
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<!DOCTYPE configuration
        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
        "http://mybatis.org/dtd/mybatis-3-config.dtd">

<configuration>
    <settings>
        <setting name="mapUnderscoreToCamelCase" value="true"/>
        <setting name="useGeneratedKeys" value="true"/>
    </settings>
</configuration>
```

### 修复效果的截屏
修复完，可使用mybatis-config.xml mybatis配置文件的形式，正常启动
```java
  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::        (v2.0.5.RELEASE)

2018-10-06 14:08:43.649  INFO 8688 --- [           main] c.j.mybatisplusdemo.dao.UserMapperTest   : Starting UserMapperTest on WIN-NRSLQON20B9 with PID 8688 (started by Administrator in D:\WorkSpace\IdeaWorkSpace\springboot-learn\springboot-mybatisplus-demo)
2018-10-06 14:08:43.650  INFO 8688 --- [           main] c.j.mybatisplusdemo.dao.UserMapperTest   : No active profile set, falling back to default profiles: default
2018-10-06 14:08:43.689  INFO 8688 --- [           main] o.s.w.c.s.GenericWebApplicationContext   : Refreshing org.springframework.web.context.support.GenericWebApplicationContext@b672aa8: startup date [Sat Oct 06 14:08:43 CST 2018]; root of context hierarchy
2018-10-06 14:08:45.118  INFO 8688 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'org.springframework.transaction.annotation.ProxyTransactionManagementConfiguration' of type [org.springframework.transaction.annotation.ProxyTransactionManagementConfiguration$$EnhancerBySpringCGLIB$$92a32538] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
2018-10-06 14:08:45.348  INFO 8688 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
2018-10-06 14:08:45.580  INFO 8688 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
2018-10-06 14:08:45.590  INFO 8688 --- [           main] o.s.jdbc.datasource.init.ScriptUtils     : Executing SQL script from class path resource [db/schema-h2.sql]
2018-10-06 14:08:45.610  INFO 8688 --- [           main] o.s.jdbc.datasource.init.ScriptUtils     : Executed SQL script from class path resource [db/schema-h2.sql] in 20 ms.
2018-10-06 14:08:45.610  INFO 8688 --- [           main] o.s.jdbc.datasource.init.ScriptUtils     : Executing SQL script from class path resource [db/data-h2.sql]
2018-10-06 14:08:45.620  INFO 8688 --- [           main] o.s.jdbc.datasource.init.ScriptUtils     : Executed SQL script from class path resource [db/data-h2.sql] in 10 ms.
{cn.jaychang.mybatisplusdemo.dao.UserMapper.selectById} Has been loaded by XML or SqlProvider, ignoring the injection of the SQL.
2018-10-06 14:08:54.920  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/mybatisplusdemo/identity-card],methods=[POST]}" onto public org.springframework.http.ResponseEntity cn.jaychang.mybatisplusdemo.web.controller.IdentityCardController.add(cn.jaychang.mybatisplusdemo.entity.IdentityCard)
2018-10-06 14:08:54.920  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/mybatisplusdemo/identity-card/{id}],methods=[PUT]}" onto public org.springframework.http.ResponseEntity<cn.jaychang.mybatisplusdemo.entity.IdentityCard> cn.jaychang.mybatisplusdemo.web.controller.IdentityCardController.update(cn.jaychang.mybatisplusdemo.entity.IdentityCard)
2018-10-06 14:08:54.920  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/mybatisplusdemo/identity-card/{id}],methods=[DELETE]}" onto public org.springframework.http.ResponseEntity cn.jaychang.mybatisplusdemo.web.controller.IdentityCardController.delete(java.lang.Long)
2018-10-06 14:08:54.920  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/mybatisplusdemo/identity-card],methods=[GET]}" onto public org.springframework.http.ResponseEntity<com.baomidou.mybatisplus.core.metadata.IPage<cn.jaychang.mybatisplusdemo.entity.IdentityCard>> cn.jaychang.mybatisplusdemo.web.controller.IdentityCardController.list(java.lang.Integer,java.lang.Integer)
2018-10-06 14:08:54.920  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/mybatisplusdemo/identity-card/{id}],methods=[GET]}" onto public org.springframework.http.ResponseEntity<cn.jaychang.mybatisplusdemo.entity.IdentityCard> cn.jaychang.mybatisplusdemo.web.controller.IdentityCardController.detail(java.lang.Long)
2018-10-06 14:08:54.920  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/swagger-resources/configuration/ui]}" onto public org.springframework.http.ResponseEntity<springfox.documentation.swagger.web.UiConfiguration> springfox.documentation.swagger.web.ApiResourceController.uiConfiguration()
2018-10-06 14:08:54.920  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/swagger-resources]}" onto public org.springframework.http.ResponseEntity<java.util.List<springfox.documentation.swagger.web.SwaggerResource>> springfox.documentation.swagger.web.ApiResourceController.swaggerResources()
2018-10-06 14:08:54.920  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/swagger-resources/configuration/security]}" onto public org.springframework.http.ResponseEntity<springfox.documentation.swagger.web.SecurityConfiguration> springfox.documentation.swagger.web.ApiResourceController.securityConfiguration()
2018-10-06 14:08:54.930  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/error]}" onto public org.springframework.http.ResponseEntity<java.util.Map<java.lang.String, java.lang.Object>> org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController.error(javax.servlet.http.HttpServletRequest)
2018-10-06 14:08:54.930  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped "{[/error],produces=[text/html]}" onto public org.springframework.web.servlet.ModelAndView org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController.errorHtml(javax.servlet.http.HttpServletRequest,javax.servlet.http.HttpServletResponse)
2018-10-06 14:08:55.120  INFO 8688 --- [           main] pertySourcedRequestMappingHandlerMapping : Mapped URL path [/v2/api-docs] onto method [public org.springframework.http.ResponseEntity<springfox.documentation.spring.web.json.Json> springfox.documentation.swagger2.web.Swagger2Controller.getDocumentation(java.lang.String,javax.servlet.http.HttpServletRequest)]
2018-10-06 14:08:55.440  INFO 8688 --- [           main] o.s.w.s.handler.SimpleUrlHandlerMapping  : Mapped URL path [/**/favicon.ico] onto handler of type [class org.springframework.web.servlet.resource.ResourceHttpRequestHandler]
2018-10-06 14:08:55.630  INFO 8688 --- [           main] s.w.s.m.m.a.RequestMappingHandlerAdapter : Looking for @ControllerAdvice: org.springframework.web.context.support.GenericWebApplicationContext@b672aa8: startup date [Sat Oct 06 14:08:43 CST 2018]; root of context hierarchy
2018-10-06 14:08:55.720  INFO 8688 --- [           main] o.s.w.s.handler.SimpleUrlHandlerMapping  : Mapped URL path [/webjars/**] onto handler of type [class org.springframework.web.servlet.resource.ResourceHttpRequestHandler]
2018-10-06 14:08:55.720  INFO 8688 --- [           main] o.s.w.s.handler.SimpleUrlHandlerMapping  : Mapped URL path [/**] onto handler of type [class org.springframework.web.servlet.resource.ResourceHttpRequestHandler]
2018-10-06 14:08:56.096  INFO 8688 --- [           main] o.s.c.support.DefaultLifecycleProcessor  : Starting beans in phase 2147483647
2018-10-06 14:08:56.097  INFO 8688 --- [           main] d.s.w.p.DocumentationPluginsBootstrapper : Context refreshed
2018-10-06 14:08:56.117  INFO 8688 --- [           main] d.s.w.p.DocumentationPluginsBootstrapper : Found 1 custom documentation plugin(s)
2018-10-06 14:08:56.167  INFO 8688 --- [           main] s.d.s.w.s.ApiListingReferenceScanner     : Scanning for api listing references
2018-10-06 14:08:56.357  INFO 8688 --- [           main] c.j.mybatisplusdemo.dao.UserMapperTest   : Started UserMapperTest in 13.112 seconds (JVM running for 14.682)
User(id=1, name=Jone, age=null, email=null)
User(id=2, name=Jack, age=null, email=null)
2018-10-06 14:08:56.627  INFO 8688 --- [       Thread-3] o.s.w.c.s.GenericWebApplicationContext   : Closing org.springframework.web.context.support.GenericWebApplicationContext@b672aa8: startup date [Sat Oct 06 14:08:43 CST 2018]; root of context hierarchy
2018-10-06 14:08:56.637  INFO 8688 --- [       Thread-3] o.s.c.support.DefaultLifecycleProcessor  : Stopping beans in phase 2147483647
2018-10-06 14:08:56.637  INFO 8688 --- [       Thread-3] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
Disconnected from the target VM, address: '127.0.0.1:50937', transport: 'socket'
2018-10-06 14:08:56.647  INFO 8688 --- [       Thread-3] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
```

