### PR TITLE
:sparkles: 支持 .orderBy(<column>).asc() 这种排序写法

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
@@ -335,6 +335,15 @@ public interface Func<This, R> extends Serializable {
     This orderBy(boolean condition, boolean isAsc, R... columns);
 
     /**
+     * 排序：ORDER BY 字段 ASC/DESC
+     * 例：orderBy("user").asc()
+     * @param columns 字段
+     */
+    default OrderBy<This, R> orderBy(R columns) {
+        return new OrderBy<>((This) this, columns);
+    }
+
+    /**
      * ignore
      */
     default This having(String sqlHaving, Object... params) {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/OrderBy.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/OrderBy.java
@@ -1,0 +1,36 @@
+package com.baomidou.mybatisplus.core.conditions.interfaces;
+
+import lombok.RequiredArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * <p>
+ * 排序条件封装
+ * </p>
+ *
+ * @author Cat73
+ * @since 2018-12-26
+ */
+@SuppressWarnings("unchecked")
+@RequiredArgsConstructor
+public class OrderBy<This, R> implements Serializable {
+    private final This self;
+    private final R column;
+
+    /**
+     * 升序排序
+     */
+    public This asc() {
+        ((Func) self).orderByAsc(column);
+        return this.self;
+    }
+
+    /**
+     * 降序排序
+     */
+    public This desc() {
+        ((Func) self).orderByDesc(column);
+        return this.self;
+    }
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue
[#720](https://github.com/baomidou/mybatis-plus/issues/720)

### 修改描述
增加一种排序条件的写法

### 测试用例
不太熟这个项目的测试写法，望亲们能领着入下门😂

感觉似乎也不太需要测试吧😂

### 修复效果的截屏
```java
/**
 * 实体类
 */
@Data
private static class User {
    private String username;
    private String idx;
}

/**
 * 新的排序写法示例
 */
public void foo() {
    LambdaQueryWrapper wrapper = Wrappers.<User>lambdaQuery()
        .orderBy(User::getIdx).desc() // 不会警告 0.0
        .orderBy(User::getUsername).asc();
}
```


