### PR TITLE
提供baseMapper.selectCount()方法对distinct的支持

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
@@ -65,7 +65,7 @@ public enum SqlMethod {
     SELECT_BY_MAP("selectByMap", "根据columnMap 查询一条数据", "<script>\nSELECT %s FROM %s %s\n</script>"),
     SELECT_BATCH_BY_IDS("selectBatchIds", "根据ID集合，批量查询数据", "<script>\nSELECT %s FROM %s WHERE %s IN (%s)\n</script>"),
     SELECT_ONE("selectOne", "查询满足条件一条数据", "<script>\nSELECT %s FROM %s %s\n</script>"),
-    SELECT_COUNT("selectCount", "查询满足条件总记录数", "<script>\nSELECT COUNT(1) FROM %s %s\n</script>"),
+    SELECT_COUNT("selectCount", "查询满足条件总记录数", "<script>\nSELECT COUNT(%s) FROM %s %s\n</script>"),
     SELECT_LIST("selectList", "查询满足条件所有数据", "<script>\nSELECT %s FROM %s %s\n</script>"),
     SELECT_PAGE("selectPage", "查询满足条件所有数据（并翻页）", "<script>\nSELECT %s FROM %s %s\n</script>"),
     SELECT_MAPS("selectMaps", "查询满足条件所有数据", "<script>\nSELECT %s FROM %s %s\n</script>"),

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
@@ -116,6 +116,18 @@ public abstract class AbstractMethod implements Constants {
 
     /**
      * <p>
+     * SQL 查询记录行数
+     * </p>
+     *
+     * @return count sql 脚本
+     */
+    protected String sqlCount() {
+        return SqlScriptUtils.convertChoose(String.format("%s != null and %s != null", WRAPPER, Q_WRAPPER_SQL_SELECT),
+            SqlScriptUtils.unSafeParam(Q_WRAPPER_SQL_SELECT), ONE);
+    }
+
+    /**
+     * <p>
      * SQL 设置selectObj sql select
      * </p>
      *

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectCount.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectCount.java
@@ -34,7 +34,7 @@ public class SelectCount extends AbstractMethod {
     @Override
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_COUNT;
-        String sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(), this.sqlWhereEntityWrapper(true, tableInfo));
+        String sql = String.format(sqlMethod.getSql(), this.sqlCount(), tableInfo.getTableName(), this.sqlWhereEntityWrapper(true, tableInfo));
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
         return this.addSelectMappedStatement(mapperClass, sqlMethod.getMethod(), sqlSource, Integer.class, null);
     }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/injector/methods/LogicSelectCount.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/injector/methods/LogicSelectCount.java
@@ -34,7 +34,7 @@ public class LogicSelectCount extends AbstractLogicMethod {
     @Override
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_COUNT;
-        String sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo));
+        String sql = String.format(sqlMethod.getSql(), this.sqlCount(), tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo));
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
         return addSelectMappedStatement(mapperClass, sqlMethod.getMethod(), sqlSource, Integer.class, null);
     }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/mysql/SelectCountDistinctTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/mysql/SelectCountDistinctTest.java
@@ -1,0 +1,141 @@
+package com.baomidou.mybatisplus.test.mysql;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.baomidou.mybatisplus.test.base.entity.CommonData;
+import com.baomidou.mybatisplus.test.base.entity.CommonLogicData;
+import com.baomidou.mybatisplus.test.base.mapper.commons.CommonDataMapper;
+import com.baomidou.mybatisplus.test.base.mapper.commons.CommonLogicDataMapper;
+import com.baomidou.mybatisplus.test.mysql.config.MysqlDb;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.annotation.Resource;
+import java.sql.SQLException;
+import java.util.List;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@ContextConfiguration(locations = {"classpath:mysql/spring-test-mysql.xml"})
+public class SelectCountDistinctTest {
+
+    @Resource
+    private CommonLogicDataMapper commonLogicMapper;
+    @Resource
+    private CommonDataMapper commonDataMapper;
+
+    @Before
+    public void init() throws SQLException {
+        MysqlDb.initMysqlData();
+        insertLogic();
+        insertCommon();
+        System.out.println("init table and data success");
+    }
+
+    private void insertLogic() {
+        commonLogicMapper.insert(new CommonLogicData().setTestInt(25).setTestStr("test"));
+        commonLogicMapper.insert(new CommonLogicData().setTestInt(25).setTestStr("test"));
+    }
+
+    private void insertCommon() {
+        commonDataMapper.insert(new CommonData().setTestInt(25).setTestStr("test"));
+        commonDataMapper.insert(new CommonData().setTestInt(25).setTestStr("test"));
+    }
+
+    @Test
+    public void testCountDistinct() {
+        QueryWrapper<CommonData> distinct = new QueryWrapper<>();
+        distinct.select("distinct test_int");
+        distinct.eq("test_int", 25).or().eq("test_str", "test");
+        int count = commonDataMapper.selectCount(distinct);
+        Assert.assertEquals(1, count);
+    }
+
+    @Test
+    public void testCountDistinctTwoColumn() {
+        QueryWrapper<CommonData> distinct = new QueryWrapper<>();
+        distinct.select("distinct test_int, test_str");
+        distinct.eq("test_int", 25).or().eq("test_str", "test");
+        int count = commonDataMapper.selectCount(distinct);
+        Assert.assertEquals(1, count);
+    }
+
+    @Test
+    public void testLogicCountDistinct() {
+        QueryWrapper<CommonLogicData> distinct = new QueryWrapper<>();
+        distinct.select("distinct test_int");
+        distinct.eq("test_int", 25).or().eq("test_str", "test");
+        int count = commonLogicMapper.selectCount(distinct);
+        Assert.assertEquals(1, count);
+    }
+
+    @Test
+    public void testLogicSelectList() {
+        QueryWrapper<CommonLogicData> commonQuery = new QueryWrapper<>();
+        List<CommonLogicData> commonLogicDataList = commonLogicMapper.selectList(commonQuery);
+        CommonLogicData commonLogicData = commonLogicDataList.get(0);
+        Assert.assertEquals(25, commonLogicData.getTestInt().intValue());
+        Assert.assertEquals("test", commonLogicData.getTestStr());
+    }
+
+    @Test
+    public void testLogicCountDistinctUseLambda() {
+        LambdaQueryWrapper<CommonLogicData> lambdaQueryWrapper =
+            new QueryWrapper<CommonLogicData>().select("distinct test_int").lambda();
+        int count = commonLogicMapper.selectCount(lambdaQueryWrapper);
+        Assert.assertEquals(1, count);
+    }
+
+    @Test
+    public void testCountDistinctUseLambda() {
+        LambdaQueryWrapper<CommonData> lambdaQueryWrapper =
+            new QueryWrapper<CommonData>().select("distinct test_int, test_str").lambda();
+        int count = commonDataMapper.selectCount(lambdaQueryWrapper);
+        Assert.assertEquals(1, count);
+    }
+
+    @Test
+    public void testLogicSelectCountWithoutDistinct() {
+        QueryWrapper<CommonLogicData> queryWrapper = new QueryWrapper<>();
+        queryWrapper.eq("test_int", 25).or().eq("test_str", "test");
+        int count = commonLogicMapper.selectCount(queryWrapper);
+        Assert.assertEquals(2, count);
+    }
+
+    @Test
+    public void testCountDistinctWithoutDistinct() {
+        QueryWrapper<CommonData> queryWrapper = new QueryWrapper<>();
+        queryWrapper.eq("test_int", 25).or().eq("test_str", "test");
+        int count = commonDataMapper.selectCount(queryWrapper);
+        Assert.assertEquals(2, count);
+    }
+
+    @Test
+    public void testSelectPageWithoutDistinct() {
+        QueryWrapper<CommonData> queryWrapper = new QueryWrapper<>();
+        queryWrapper.eq("test_int", 25).or().eq("test_str", "test");
+        IPage<CommonData> page = commonDataMapper.selectPage(new Page<CommonData>(1, 10), queryWrapper);
+        Assert.assertEquals(2, page.getTotal());
+        Assert.assertNotNull(page.getRecords().get(0));
+        Assert.assertNotNull(page.getRecords().get(1));
+    }
+
+    @Test
+    public void testSelectPageWithDistinct() {
+        QueryWrapper<CommonData> queryWrapper = new QueryWrapper<>();
+        queryWrapper.select("distinct test_int, test_str");
+        queryWrapper.eq("test_int", 25).or().eq("test_str", "test");
+        IPage<CommonData> page = commonDataMapper.selectPage(new Page<CommonData>(1, 10), queryWrapper);
+        Assert.assertEquals(1, page.getTotal());
+        Assert.assertNotNull(page.getRecords().get(0));
+    }
+
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue

#742 

### 修改描述

解决baseMapper.selectCount()方法对distinct的支持，已经指定SelectSql的QueryWrapper不再是Count(1)


添加了SqlMethod中的SELECT_COUNT的SQL占位符
添加SelectCount和LogicSelectCount，在SQL组装时，对新占位符的填充
添加新Count语句生成方法，放在了AbstractMethod下的sqlCount

### 测试用例

测试用例不知道放在哪里，目前放在了com.baomidou.mybatisplus.test.mysql下SelectCountDistinctTest

### 修复效果的截屏

测试已经通过，并且已经验证不会对未指定SelectSQL的queryWrapper造成影响

未指定Select SQL的测试情况，跟以前一样SQL为Count(1)

```
19:23:54.981 [main] DEBUG c.b.m.t.b.m.c.C.selectCount - ==>  Preparing: SELECT COUNT(1) FROM common_data WHERE common_data.tenant_id = 1 AND (test_int = ? OR test_str = ?) 
19:23:54.981 [main] DEBUG c.b.m.t.b.m.c.C.selectCount - ==> Parameters: 25(Integer), test(String)
19:23:54.982 [main] DEBUG c.b.m.t.b.m.c.C.selectCount - <==      Total: 1
```

指定Select SQL为DISTINCT test_int的测试情况

```
19:23:54.229 [main] DEBUG c.b.m.t.b.m.c.C.selectCount - ==>  Preparing: SELECT COUNT(DISTINCT test_int) FROM common_data WHERE common_data.tenant_id = 1 AND (test_int = ? OR test_str = ?) 
19:23:54.230 [main] DEBUG c.b.m.t.b.m.c.C.selectCount - ==> Parameters: 25(Integer), test(String)
19:23:54.260 [main] DEBUG c.b.m.t.b.m.c.C.selectCount - <==      Total: 1
```