### PR TITLE
:bug: 修复 ktQuery、ktUpdate 一定会挂掉的问题

### DIFF
--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/IServiceExtension.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/IServiceExtension.kt
@@ -38,7 +38,7 @@ private fun <T : Any> IService<T>.entityClass() =
         (entityClassCache.getOrPut(this) {
             // 理论上不可能找不到，除非用户的代码直接就没继承 ServiceImpl
             // 理论上 as 转换时不可能出现异常，除非用的不知道什么鬼家的 JVM？
-            (this::class.supertypes.first { it == ServiceImpl::class }.arguments[1].type?.javaType) as Class<*>
+            (this::class.supertypes.first { it.classifier == ServiceImpl::class }.arguments[1].type?.javaType) as Class<*>
         }) as Class<T>
 
 /**


### PR DESCRIPTION
### 该Pull Request关联的Issue
none

### 修改描述
最早写的是 [0]，即固定找第一个父类，因此不兼容有其他父类间接继承的情况

而后来改的兼容多级间接继承的未经测试，实际是不能用的，这次是把这个问题修改掉了

### 测试用例
自己私有项目里的单元测试已通过

### 修复效果的截屏
无
