### PR TITLE
修复SQL Server数据库在大小写敏感的情况下，不能自动生成代码的BUG

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/SqlServerQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/SqlServerQuery.java
@@ -46,21 +46,21 @@ public class SqlServerQuery extends AbstractDbQuery {
 
     @Override
     public String tableFieldsSql() {
-        return "SELECT  cast(a.NAME AS VARCHAR(500)) AS TABLE_NAME,cast(b.NAME AS VARCHAR(500)) AS COLUMN_NAME, "
-            + "cast(c.VALUE AS VARCHAR(500)) AS COMMENTS,cast(sys.types.NAME AS VARCHAR (500)) AS DATA_TYPE,"
+        return "SELECT  cast(a.name AS VARCHAR(500)) AS TABLE_NAME,cast(b.name AS VARCHAR(500)) AS COLUMN_NAME, "
+            + "cast(c.VALUE AS VARCHAR(500)) AS COMMENTS,cast(sys.types.name AS VARCHAR (500)) AS DATA_TYPE,"
             + "(" + " SELECT CASE count(1) WHEN 1 then 'PRI' ELSE '' END"
             + " FROM syscolumns,sysobjects,sysindexes,sysindexkeys,systypes "
-            + " WHERE syscolumns.xusertype = systypes.xusertype AND syscolumns.id = object_id (A.NAME) AND sysobjects.xtype = 'PK'"
+            + " WHERE syscolumns.xusertype = systypes.xusertype AND syscolumns.id = object_id (a.name) AND sysobjects.xtype = 'PK'"
             + " AND sysobjects.parent_obj = syscolumns.id " + " AND sysindexes.id = syscolumns.id "
-            + " AND sysobjects.NAME = sysindexes.NAME AND sysindexkeys.id = syscolumns.id "
+            + " AND sysobjects.name = sysindexes.name AND sysindexkeys.id = syscolumns.id "
             + " AND sysindexkeys.indid = sysindexes.indid "
-            + " AND syscolumns.colid = sysindexkeys.colid AND syscolumns.NAME = B.NAME) as 'KEY',"
+            + " AND syscolumns.colid = sysindexkeys.colid AND syscolumns.name = b.name) as 'KEY',"
             + "  b.is_identity isIdentity "
             + " FROM ( select name,object_id from sys.tables UNION all select name,object_id from sys.views ) a "
-            + " INNER JOIN sys.COLUMNS b ON b.object_id = a.object_id "
+            + " INNER JOIN sys.columns b ON b.object_id = a.object_id "
             + " LEFT JOIN sys.types ON b.user_type_id = sys.types.user_type_id   "
             + " LEFT JOIN sys.extended_properties c ON c.major_id = b.object_id AND c.minor_id = b.column_id "
-            + " WHERE a.NAME = '%s' and sys.types.NAME !='sysname' ";
+            + " WHERE a.name = '%s' and sys.types.name !='sysname' ";
     }
 
     @Override


### PR DESCRIPTION
### 该Pull Request关联的Issue
无Issue

### 修改描述
SQL Server如果开启表名大小写敏感，sys架构下的表大部分是以小写命名。但Mybatis-Plus的代码生成器中使用了大写，造成报错。


### 测试用例
SQL Server 2008，数据库排序规则设置为Chinese_PRC_BIN，使用Mybatis-Plus代码生成器，提示
Invalid object name 'sys.COLUMNS'，模板引擎报空指针错误


### 修复效果的截屏
成功生成代码


