### PR TITLE
支持SQL注释

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
@@ -25,6 +25,7 @@ import com.baomidou.mybatisplus.core.enums.SqlKeyword;
 import com.baomidou.mybatisplus.core.enums.SqlLike;
 import com.baomidou.mybatisplus.core.toolkit.*;
 import com.baomidou.mybatisplus.core.toolkit.sql.SqlUtils;
+import com.baomidou.mybatisplus.core.toolkit.sql.StringEscape;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,6 +73,10 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
      * 实体类型
      */
     protected Class<T> entityClass;
+    /**
+     * SQL注释
+     */
+    private String sqlCommentBody;
 
     @Override
     public T getEntity() {
@@ -93,6 +98,27 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
     protected Class<T> getCheckEntityClass() {
         Assert.notNull(entityClass, "entityClass must not null,please set entity before use this method!");
         return entityClass;
+    }
+
+    protected String getSqlCommentBody() {
+        return sqlCommentBody;
+    }
+
+    /**
+     * @param sqlCommentBody SQL注释body
+     */
+    public Children setSqlCommentBody(String sqlCommentBody) {
+        this.sqlCommentBody = sqlCommentBody;
+        return typedThis;
+    }
+
+    @Override
+    public String getSqlComment() {
+        if (sqlCommentBody != null && !sqlCommentBody.isEmpty()) {
+            return "/*" + StringEscape.escapeRawString(sqlCommentBody) + "*/";
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/Wrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/Wrapper.java
@@ -49,6 +49,10 @@ public abstract class Wrapper<T> implements ISqlSegment {
         return null;
     }
 
+    public String getSqlComment() {
+        return null;
+    }
+
     /**
      * 获取 MergeSegments
      */

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/QueryWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/QueryWrapper.java
@@ -100,7 +100,7 @@ public class QueryWrapper<T> extends AbstractWrapper<T, String, QueryWrapper<T>>
      * 返回一个支持 lambda 函数写法的 wrapper
      */
     public LambdaQueryWrapper<T> lambda() {
-        return new LambdaQueryWrapper<>(entity, entityClass, sqlSelect, paramNameSeq, paramNameValuePairs, expression);
+        return new LambdaQueryWrapper<>(entity, entityClass, sqlSelect, paramNameSeq, paramNameValuePairs, expression).setSqlCommentBody(getSqlCommentBody());
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/UpdateWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/UpdateWrapper.java
@@ -89,7 +89,7 @@ public class UpdateWrapper<T> extends AbstractWrapper<T, String, UpdateWrapper<T
      * 返回一个支持 lambda 函数写法的 wrapper
      */
     public LambdaUpdateWrapper<T> lambda() {
-        return new LambdaUpdateWrapper<>(entity, sqlSet, paramNameSeq, paramNameValuePairs, expression);
+        return new LambdaUpdateWrapper<>(entity, sqlSet, paramNameSeq, paramNameValuePairs, expression).setSqlCommentBody(getSqlCommentBody());
     }
 
     @Override

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
@@ -32,7 +32,7 @@ public enum SqlMethod {
      */
     DELETE_BY_ID("deleteById", "根据ID 删除一条数据", "<script>\nDELETE FROM %s WHERE %s=#{%s}\n</script>"),
     DELETE_BY_MAP("deleteByMap", "根据columnMap 条件删除记录", "<script>\nDELETE FROM %s %s\n</script>"),
-    DELETE("delete", "根据 entity 条件删除记录", "<script>\nDELETE FROM %s %s\n</script>"),
+    DELETE("delete", "根据 entity 条件删除记录", "<script>\nDELETE FROM %s %s %s\n</script>"),
     DELETE_BATCH_BY_IDS("deleteBatchIds", "根据ID集合，批量删除数据", "<script>\nDELETE FROM %s WHERE %s IN (%s)\n</script>"),
 
     /**
@@ -40,7 +40,7 @@ public enum SqlMethod {
      */
     LOGIC_DELETE_BY_ID("deleteById", "根据ID 逻辑删除一条数据", "<script>\nUPDATE %s %s WHERE %s=#{%s} %s\n</script>"),
     LOGIC_DELETE_BY_MAP("deleteByMap", "根据columnMap 条件逻辑删除记录", "<script>\nUPDATE %s %s %s\n</script>"),
-    LOGIC_DELETE("delete", "根据 entity 条件逻辑删除记录", "<script>\nUPDATE %s %s %s\n</script>"),
+    LOGIC_DELETE("delete", "根据 entity 条件逻辑删除记录", "<script>\nUPDATE %s %s %s %s\n</script>"),
     LOGIC_DELETE_BATCH_BY_IDS("deleteBatchIds", "根据ID集合，批量逻辑删除数据", "<script>\nUPDATE %s %s WHERE %s IN (%s) %s\n</script>"),
 
     /**
@@ -48,7 +48,7 @@ public enum SqlMethod {
      */
     UPDATE_BY_ID("updateById", "根据ID 选择修改数据", "<script>\nUPDATE %s %s WHERE %s=#{%s} %s\n</script>"),
     UPDATE_ALL_COLUMN_BY_ID("updateAllColumnById", "根据ID 选择修改数据", "<script>\nUPDATE %s SET %s WHERE %s=#{%s} %s\n</script>"),
-    UPDATE("update", "根据 whereEntity 条件，更新记录", "<script>\nUPDATE %s %s %s\n</script>"),
+    UPDATE("update", "根据 whereEntity 条件，更新记录", "<script>\nUPDATE %s %s %s %s\n</script>"),
 
     /**
      * 逻辑删除 -> 修改
@@ -61,13 +61,13 @@ public enum SqlMethod {
     SELECT_BY_ID("selectById", "根据ID 查询一条数据", "SELECT %s FROM %s WHERE %s=#{%s}"),
     SELECT_BY_MAP("selectByMap", "根据columnMap 查询一条数据", "<script>\nSELECT %s FROM %s %s\n</script>"),
     SELECT_BATCH_BY_IDS("selectBatchIds", "根据ID集合，批量查询数据", "<script>\nSELECT %s FROM %s WHERE %s IN (%s)\n</script>"),
-    SELECT_ONE("selectOne", "查询满足条件一条数据", "<script>\nSELECT %s FROM %s %s\n</script>"),
-    SELECT_COUNT("selectCount", "查询满足条件总记录数", "<script>\nSELECT COUNT(%s) FROM %s %s\n</script>"),
-    SELECT_LIST("selectList", "查询满足条件所有数据", "<script>\nSELECT %s FROM %s %s\n</script>"),
-    SELECT_PAGE("selectPage", "查询满足条件所有数据（并翻页）", "<script>\nSELECT %s FROM %s %s\n</script>"),
-    SELECT_MAPS("selectMaps", "查询满足条件所有数据", "<script>\nSELECT %s FROM %s %s\n</script>"),
-    SELECT_MAPS_PAGE("selectMapsPage", "查询满足条件所有数据（并翻页）", "<script>\nSELECT %s FROM %s %s\n</script>"),
-    SELECT_OBJS("selectObjs", "查询满足条件所有数据", "<script>\nSELECT %s FROM %s %s\n</script>"),
+    SELECT_ONE("selectOne", "查询满足条件一条数据", "<script>\nSELECT %s FROM %s %s %s\n</script>"),
+    SELECT_COUNT("selectCount", "查询满足条件总记录数", "<script>\nSELECT COUNT(%s) FROM %s %s %s\n</script>"),
+    SELECT_LIST("selectList", "查询满足条件所有数据", "<script>\nSELECT %s FROM %s %s %s\n</script>"),
+    SELECT_PAGE("selectPage", "查询满足条件所有数据（并翻页）", "<script>\nSELECT %s FROM %s %s %s\n</script>"),
+    SELECT_MAPS("selectMaps", "查询满足条件所有数据", "<script>\nSELECT %s FROM %s %s %s\n</script>"),
+    SELECT_MAPS_PAGE("selectMapsPage", "查询满足条件所有数据（并翻页）", "<script>\nSELECT %s FROM %s %s %s\n</script>"),
+    SELECT_OBJS("selectObjs", "查询满足条件所有数据", "<script>\nSELECT %s FROM %s %s %s\n</script>"),
 
     /**
      * 逻辑删除 -> 查询

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
@@ -108,6 +108,16 @@ public abstract class AbstractMethod implements Constants {
     }
 
     /**
+     * SQL 注释
+     *
+     * @return sql
+     */
+    protected String sqlComment() {
+        return SqlScriptUtils.convertChoose(String.format("%s != null and %s != null", WRAPPER, Q_WRAPPER_SQL_COMMENT),
+            SqlScriptUtils.unSafeParam(Q_WRAPPER_SQL_COMMENT), EMPTY);
+    }
+
+    /**
      * SQL 查询所有表字段
      *
      * @param table        表信息

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/Delete.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/Delete.java
@@ -35,13 +35,15 @@ public class Delete extends AbstractMethod {
         SqlMethod sqlMethod = SqlMethod.LOGIC_DELETE;
         if (tableInfo.isLogicDelete()) {
             sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(), sqlLogicSet(tableInfo),
-                sqlWhereEntityWrapper(true, tableInfo));
+                sqlWhereEntityWrapper(true, tableInfo),
+                sqlComment());
             SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
             return addUpdateMappedStatement(mapperClass, modelClass, sqlMethod.getMethod(), sqlSource);
         } else {
             sqlMethod = SqlMethod.DELETE;
             sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(),
-                sqlWhereEntityWrapper(true, tableInfo));
+                sqlWhereEntityWrapper(true, tableInfo),
+                sqlComment());
             SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
             return this.addDeleteMappedStatement(mapperClass, sqlMethod.getMethod(), sqlSource);
         }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectCount.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectCount.java
@@ -32,7 +32,7 @@ public class SelectCount extends AbstractMethod {
     @Override
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_COUNT;
-        String sql = String.format(sqlMethod.getSql(), this.sqlCount(), tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo));
+        String sql = String.format(sqlMethod.getSql(), this.sqlCount(), tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo), sqlComment());
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
         return this.addSelectMappedStatementForOther(mapperClass, sqlMethod.getMethod(), sqlSource, Integer.class);
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectList.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectList.java
@@ -33,7 +33,8 @@ public class SelectList extends AbstractMethod {
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_LIST;
         String sql = String.format(sqlMethod.getSql(), sqlSelectColumns(tableInfo, true),
-            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo));
+            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo),
+            sqlComment());
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
         return this.addSelectMappedStatementForTable(mapperClass, sqlMethod.getMethod(), sqlSource, tableInfo);
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectMaps.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectMaps.java
@@ -35,7 +35,8 @@ public class SelectMaps extends AbstractMethod {
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_MAPS;
         String sql = String.format(sqlMethod.getSql(), sqlSelectColumns(tableInfo, true),
-            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo));
+            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo),
+            sqlComment());
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
         return this.addSelectMappedStatementForOther(mapperClass, sqlMethod.getMethod(), sqlSource, Map.class);
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectMapsPage.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectMapsPage.java
@@ -35,7 +35,8 @@ public class SelectMapsPage extends AbstractMethod {
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_MAPS_PAGE;
         String sql = String.format(sqlMethod.getSql(), sqlSelectColumns(tableInfo, true),
-            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo));
+            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo),
+            sqlComment());
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
         return this.addSelectMappedStatementForOther(mapperClass, sqlMethod.getMethod(), sqlSource, Map.class);
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectObjs.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectObjs.java
@@ -33,7 +33,8 @@ public class SelectObjs extends AbstractMethod {
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_OBJS;
         String sql = String.format(sqlMethod.getSql(), sqlSelectObjsColumns(tableInfo),
-            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo));
+            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo),
+            sqlComment());
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
         return this.addSelectMappedStatementForOther(mapperClass, sqlMethod.getMethod(), sqlSource, Object.class);
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectOne.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectOne.java
@@ -34,7 +34,8 @@ public class SelectOne extends AbstractMethod {
         SqlMethod sqlMethod = SqlMethod.SELECT_ONE;
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, String.format(sqlMethod.getSql(),
             this.sqlSelectColumns(tableInfo, true), tableInfo.getTableName(),
-            this.sqlWhereEntityWrapper(true, tableInfo)), modelClass);
+            this.sqlWhereEntityWrapper(true, tableInfo), sqlComment()),
+            modelClass);
         return this.addSelectMappedStatementForTable(mapperClass, sqlMethod.getMethod(), sqlSource, tableInfo);
     }
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectPage.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectPage.java
@@ -33,7 +33,8 @@ public class SelectPage extends AbstractMethod {
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_PAGE;
         String sql = String.format(sqlMethod.getSql(), sqlSelectColumns(tableInfo, true),
-            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo));
+            tableInfo.getTableName(), sqlWhereEntityWrapper(true, tableInfo),
+            sqlComment());
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
         return this.addSelectMappedStatementForTable(mapperClass, sqlMethod.getMethod(), sqlSource, tableInfo);
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/Update.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/Update.java
@@ -34,7 +34,8 @@ public class Update extends AbstractMethod {
         SqlMethod sqlMethod = SqlMethod.UPDATE;
         String sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(),
             sqlSet(true, true, tableInfo, true, ENTITY, ENTITY_DOT),
-            sqlWhereEntityWrapper(true, tableInfo));
+            sqlWhereEntityWrapper(true, tableInfo),
+            sqlComment());
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, modelClass);
         return this.addUpdateMappedStatement(mapperClass, modelClass, sqlMethod.getMethod(), sqlSource);
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Constants.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Constants.java
@@ -89,6 +89,10 @@ public interface Constants extends StringPool {
      */
     String Q_WRAPPER_SQL_SELECT = WRAPPER_DOT + "sqlSelect";
     /**
+     * wrapper 类的属性 sqlComment
+     */
+    String Q_WRAPPER_SQL_COMMENT = WRAPPER_DOT + "sqlComment";
+    /**
      * columnMap
      */
     String COLUMN_MAP = "cm";

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/StringEscape.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/StringEscape.java
@@ -72,16 +72,12 @@ public class StringEscape {
     }
 
     /**
-     * 转义字符串
+     * 转义字符串。纯转义，不添加单引号。
      *
      * @param escapeStr 被转义的字符串
      * @return 转义后的字符串
      */
-    public static String escapeString(String escapeStr) {
-        if (escapeStr.matches("\'(.+)\'")) {
-            escapeStr = escapeStr.substring(1, escapeStr.length() - 1);
-        }
-        String parameterAsString = escapeStr;
+    public static String escapeRawString(String escapeStr) {
         int stringLength = escapeStr.length();
         if (isEscapeNeededForString(escapeStr, stringLength)) {
             StringBuilder buf = new StringBuilder((int) (escapeStr.length() * 1.1));
@@ -138,9 +134,23 @@ public class StringEscape {
                         buf.append(c);
                 }
             }
-            parameterAsString = buf.toString();
+            return buf.toString();
+        } else {
+            return escapeStr;
         }
-        return "\'" + parameterAsString + "\'";
+    }
+
+    /**
+     * 转义字符串
+     *
+     * @param escapeStr 被转义的字符串
+     * @return 转义后的字符串
+     */
+    public static String escapeString(String escapeStr) {
+        if (escapeStr.matches("\'(.+)\'")) {
+            escapeStr = escapeStr.substring(1, escapeStr.length() - 1);
+        }
+        return "\'" + escapeRawString(escapeStr) + "\'";
     }
 
 }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/ActiveRecordTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/ActiveRecordTest.java
@@ -15,6 +15,7 @@
  */
 package com.baomidou.mybatisplus.test.h2;
 
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.exceptions.MybatisPlusException;
 import com.baomidou.mybatisplus.core.metadata.IPage;
@@ -151,4 +152,30 @@ class ActiveRecordTest {
         Assertions.assertTrue(student.deleteById(12L));
         Assertions.assertTrue(student.delete(new QueryWrapper<H2Student>().gt("id", 10)));
     }
+
+    @Test
+    @Order(Integer.MAX_VALUE)
+    void sqlCommentTest() {
+        String name = "name1", nameNew = "name1New";
+        H2Student student = new H2Student().setName(name).setAge(2);
+        student.delete(new QueryWrapper<H2Student>().setSqlCommentBody("deleteAllStu"));
+        Assertions.assertTrue(student.insert());
+        boolean updated = new H2Student().setName(nameNew).update(new QueryWrapper<H2Student>().setSqlCommentBody("updateStuName1").lambda()
+            .eq(H2Student::getName, name)
+        );
+        Assertions.assertTrue(updated);
+        H2Student h2Student = student.selectOne(
+            new QueryWrapper<H2Student>().lambda().setSqlCommentBody("getStuByUniqueName")
+                .eq(H2Student::getName, nameNew)
+        );
+        Assertions.assertNotNull(h2Student);
+        LambdaQueryWrapper<H2Student> queryWrapper = new QueryWrapper<H2Student>().lambda().ge(H2Student::getAge, 1);
+        int userCount = student.selectCount(queryWrapper.setSqlCommentBody("getStuCount"));
+        Assertions.assertEquals(1, userCount);
+        List<H2Student> h2StudentList = student.selectList(queryWrapper.setSqlCommentBody("getStuList"));
+        Assertions.assertEquals(1, h2StudentList.size());
+        IPage<H2Student> h2StudentIPage = student.selectPage(new Page<>(1, 10), queryWrapper.setSqlCommentBody("getStuPage"));
+        Assertions.assertEquals(1, h2StudentIPage.getRecords().size());
+    }
+
 }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserMapperTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserMapperTest.java
@@ -25,22 +25,16 @@ import com.baomidou.mybatisplus.test.h2.entity.H2User;
 import com.baomidou.mybatisplus.test.h2.entity.SuperEntity;
 import com.baomidou.mybatisplus.test.h2.enums.AgeEnum;
 import com.baomidou.mybatisplus.test.h2.mapper.H2UserMapper;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import javax.annotation.Resource;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.annotation.Resource;
 
 import static java.util.stream.Collectors.toList;
 
@@ -174,4 +168,38 @@ class H2UserMapperTest extends BaseTest {
         userMapper.delete(new QueryWrapper<>(new H2User().setAge(AgeEnum.TWO))
             .eq("name", "Tony"));
     }
+
+    @Test
+    @Order(Integer.MAX_VALUE)
+    void sqlCommentTest() {
+        userMapper.delete(new QueryWrapper<H2User>().setSqlCommentBody("deleteAllUsers"));
+        String name = "name1", nameNew = "name1New";
+        int insertCount = userMapper.insert(new H2User().setName(name).setAge(AgeEnum.ONE));
+        Assertions.assertEquals(1, insertCount);
+        int updateCount = userMapper.update(new H2User(),
+            new UpdateWrapper<H2User>().setSqlCommentBody("updateUserName1").lambda()
+                .set(H2User::getName, nameNew)
+                .eq(H2User::getName, name)
+        );
+        Assertions.assertEquals(1, updateCount);
+        H2User h2User = userMapper.selectOne(
+            new QueryWrapper<H2User>().lambda().setSqlCommentBody("getUserByUniqueName")
+                .eq(H2User::getName, nameNew)
+        );
+        Assertions.assertNotNull(h2User);
+        LambdaQueryWrapper<H2User> queryWrapper = new QueryWrapper<H2User>().lambda().ge(H2User::getAge, 1);
+        int userCount = userMapper.selectCount(queryWrapper.setSqlCommentBody("getUserCount"));
+        Assertions.assertEquals(1, userCount);
+        List<H2User> h2UserList = userMapper.selectList(queryWrapper.setSqlCommentBody("getUserList"));
+        Assertions.assertEquals(1, h2UserList.size());
+        IPage<H2User> h2UserIPage = userMapper.selectPage(new Page<>(1, 10), queryWrapper.setSqlCommentBody("getUserPage"));
+        Assertions.assertEquals(1, h2UserIPage.getRecords().size());
+        List<Map<String, Object>> selectMaps = userMapper.selectMaps(queryWrapper.setSqlCommentBody("getUserMaps"));
+        Assertions.assertEquals(1, selectMaps.size());
+        IPage<Map<String, Object>> selectMapsPage = userMapper.selectMapsPage(new Page<>(1, 10), queryWrapper.setSqlCommentBody("getUserMapsPage"));
+        Assertions.assertEquals(1, selectMapsPage.getRecords().size());
+        List<Object> selectObjs = userMapper.selectObjs(queryWrapper.setSqlCommentBody("getUserObjs"));
+        Assertions.assertEquals(1, selectObjs.size());
+    }
+
 }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/entity/H2Student.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/entity/H2Student.java
@@ -26,6 +26,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * 学生实体
@@ -33,6 +34,7 @@ import lombok.NoArgsConstructor;
  * @author nieqiurong 2018/7/27.
  */
 @Data
+@Accessors(chain = true)
 @TableName("h2student")
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
增加新功能：带wrapper参数的CRUD操作允许加SQL注释。
这样可以给SQL加上唯一标识，希望达到以下效果：1）拿到慢查询SQL之后，根据SQL注释里的唯一标识搜索到对应的代码，定位SQL的调用场景；2）方便排查数据库操作流程；


### 测试用例
H2UserMapperTest.sqlCommentTest()
ActiveRecordTest.sqlCommentTest()


### 修复效果的截屏
无

