### PR TITLE
add preconnect property in globalconfig

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
@@ -189,5 +189,10 @@ public class GlobalConfig implements Serializable {
          * @since 3.1.2
          */
         private FieldStrategy selectStrategy;
+
+        /**
+         * 程序启动时是否自动进行数据库连接
+         */
+        private boolean preConnect = true;
     }
 }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
@@ -475,8 +475,8 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
         // TODO 初始化 id-work 以及 打印骚东西
         targetConfiguration.setGlobalConfig(this.globalConfig);
 
-        // TODO 设置元数据相关 如果用户没有配置 dbType 则自动获取
-        if (globalConfig.getDbConfig().getDbType() == DbType.OTHER && globalConfig.getDbConfig().getPreConnect()) {
+        // TODO 设置元数据相关 如果用户配置了 preConnect 则自动获取
+        if (globalConfig.getDbConfig().getPreConnect()) {
             try (Connection connection = AopUtils.getTargetObject(this.dataSource).getConnection()) {
                 globalConfig.getDbConfig().setDbType(JdbcUtils.getDbType(connection.getMetaData().getURL()));
             } catch (Exception e) {

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
@@ -476,7 +476,7 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
         targetConfiguration.setGlobalConfig(this.globalConfig);
 
         // TODO 设置元数据相关 如果用户没有配置 dbType 则自动获取
-        if (globalConfig.getDbConfig().getDbType() == DbType.OTHER) {
+        if (globalConfig.getDbConfig().getDbType() == DbType.OTHER && globalConfig.getDbConfig().getPreConnect()) {
             try (Connection connection = AopUtils.getTargetObject(this.dataSource).getConnection()) {
                 globalConfig.getDbConfig().setDbType(JdbcUtils.getDbType(connection.getMetaData().getURL()));
             } catch (Exception e) {


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
多模块项目中，多数据源，所有数据源实现在dao模块。工程中有多个mian模块，其中某些mian模块只需要用到部分数据源。相应的，如果只配了部分数据源则会报错（具体数据库连接配置是在main模块里各自配的），因为根据现在的实现，程序启动时会自动建立数据库连接，没配的那些没用到的就报错了。
希望能够增加个配置项供开发人员选择。

### 测试用例
无


### 修复效果的截屏
无

