### PR TITLE
修复复合主键生成时，查询表字段SQL的bug

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/DMQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/DMQuery.java
@@ -38,18 +38,19 @@ public class DMQuery  extends AbstractDbQuery{
     @Override
     public String tableFieldsSql() {
         return
-            "SELECT T2.COLUMN_NAME,T1.COMMENTS,T2.DATA_TYPE," +
-            "CASE WHEN CONSTRAINT_TYPE='P' THEN 'PRI' END AS KEY " +
-            "FROM  USER_COL_COMMENTS T1,USER_TAB_COLUMNS T2," +
-              "( SELECT T4.TABLE_NAME ,T4.COLUMN_NAME,T5.CONSTRAINT_TYPE " +
-               " FROM USER_CONS_COLUMNS T4,USER_CONSTRAINTS T5 " +
-               "WHERE T4.CONSTRAINT_NAME = T5.CONSTRAINT_NAME AND T5.CONSTRAINT_TYPE = 'P') T3 " +
-            "WHERE T1.TABLE_NAME = T2.TABLE_NAME AND "+
-            "T1.COLUMN_NAME=T2.COLUMN_NAME AND "+
-            "T1.COLUMN_NAME=T2.COLUMN_NAME AND "+
-            "T1.TABLE_NAME=T3.TABLE_NAME AND "+
-            "T1.COLUMN_NAME=T3.COLUMN_NAME AND "+
-             "T1.TABLE_NAME = '%s'";
+            "SELECT T2.COLUMN_NAME,T1.COMMENTS,T2.DATA_TYPE ," +
+                "CASE WHEN CONSTRAINT_TYPE='P' THEN 'PRI' END AS KEY " +
+                "FROM USER_COL_COMMENTS T1, USER_TAB_COLUMNS T2, " +
+                "(SELECT T4.TABLE_NAME, T4.COLUMN_NAME ,T5.CONSTRAINT_TYPE " +
+                "FROM USER_CONS_COLUMNS T4, USER_CONSTRAINTS T5 " +
+                "WHERE T4.CONSTRAINT_NAME = T5.CONSTRAINT_NAME " +
+                "AND T5.CONSTRAINT_TYPE = 'P')T3 " +
+                "WHERE T1.TABLE_NAME = T2.TABLE_NAME AND " +
+                "T1.COLUMN_NAME=T2.COLUMN_NAME AND " +
+                "T1.TABLE_NAME = T3.TABLE_NAME(+) AND " +
+                "T1.COLUMN_NAME=T3.COLUMN_NAME(+)   AND " +
+                "T1.TABLE_NAME = '%s' " +
+                "ORDER BY T2.TABLE_NAME,T2.COLUMN_ID";
     }
 
     @Override


### PR DESCRIPTION
### 该Pull Request关联的Issue

无

### 修改描述
之前的提交未测试到复合主键的生成
本次提交修复多主键查询表字段SQL的Bug
但是还是存在多个主键生成代码时候只有一个主键字段被标注为`@TableId`其它的还是`@TableField`
我在代码中看到`ConfigBuilder`有这么一句注释
``` 
line 584:   // 避免多重主键设置，目前只取第一个找到ID，并放到list中的索引为0的位置
```
所以我暂时也没有做处理，想确认一下

### 测试用例



### 修复效果的截屏


