### PR TITLE
实现指定数据库继承父类，避免多继承字段不存在问题

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableSuperClass.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableSuperClass.java
@@ -1,0 +1,15 @@
+package com.baomidou.mybatisplus.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * @author by keray
+ * date:2019/8/9 23:15
+ * 标识该类的字段属性是被子类继承
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface TableSuperClass {
+
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
@@ -93,6 +93,12 @@ public class GlobalConfig implements Serializable {
     private MetaObjectHandler metaObjectHandler;
 
     /**
+     * 是否开启多继承指定数据库字段基础超类
+     * 默认不开启
+     */
+    private Boolean enableSuperClass = false;
+
+    /**
      * 标记全局设置 (统一所有入口)
      */
     public void signGlobalConfig(SqlSessionFactory sqlSessionFactory) {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
@@ -244,6 +244,14 @@ public class TableInfoHelper {
         /* 数据库全局配置 */
         GlobalConfig.DbConfig dbConfig = globalConfig.getDbConfig();
         List<Field> list = getAllFields(clazz);
+        if (globalConfig.getEnableSuperClass()) {
+            list = list
+                .stream()
+                .filter(field ->
+                    field.getDeclaringClass().getName().equals(clazz.getName()) ||
+                        field.getDeclaringClass().getAnnotation(TableSuperClass.class) != null)
+                .collect(toList());
+        }
         // 标记是否读取到主键
         boolean isReadPK = false;
         // 是否存在 @TableId 注解

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/SampleTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/SampleTest.java
@@ -21,6 +21,7 @@ import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.test.base.entity.CommonData;
 import com.baomidou.mybatisplus.test.base.entity.CommonLogicData;
+import com.baomidou.mybatisplus.test.base.entity.WeixinUserEntity;
 import org.apache.ibatis.reflection.DefaultReflectorFactory;
 import org.apache.ibatis.reflection.MetaClass;
 import org.junit.jupiter.api.Test;
@@ -64,5 +65,12 @@ class SampleTest {
     @Test
     void testPrefixOrder() {
         System.out.println(Wrappers.query().eq("order_id", 1).getSqlSegment());
+    }
+
+    @Test
+    void testSuperClass() {
+        TableInfo info = TableInfoHelper.initTableInfo(null, WeixinUserEntity.class);
+        info.getFieldList().forEach(f -> System.out.println(f.getColumn()));
+        System.out.println(info.getAllSqlSelect());
     }
 }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/base/entity/BaseEntity.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/base/entity/BaseEntity.java
@@ -1,0 +1,42 @@
+package com.baomidou.mybatisplus.test.base.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableSuperClass;
+import com.baomidou.mybatisplus.extension.activerecord.Model;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * @author by keray
+ * date:2019/7/25 15:33
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+@TableSuperClass
+public class BaseEntity extends Model<BaseEntity> {
+    @TableId(type = IdType.INPUT)
+    private String id;
+
+    private LocalDateTime createTime;
+
+    private LocalDateTime modifyTime;
+
+    @TableLogic(delval = "1", value = "0")
+    private Boolean deleted = false;
+
+    private LocalDateTime deleteTime;
+
+    private String createBy;
+
+    private String updateBy;
+
+    @Override
+    protected Serializable pkVal() {
+        return this.id;
+    }
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/base/entity/BaseUserEntity.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/base/entity/BaseUserEntity.java
@@ -1,0 +1,15 @@
+package com.baomidou.mybatisplus.test.base.entity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * @author by keray
+ * date:2019/8/9 23:27
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class BaseUserEntity extends BaseEntity {
+    private String username;
+    private String password;
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/base/entity/WeixinUserEntity.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/base/entity/WeixinUserEntity.java
@@ -1,0 +1,16 @@
+package com.baomidou.mybatisplus.test.base.entity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * @author by keray
+ * date:2019/8/9 23:29
+ */
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class WeixinUserEntity extends BaseUserEntity{
+    private String openId;
+    private String unionid;
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/base/mapper/commons/WeixinUserMapper.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/base/mapper/commons/WeixinUserMapper.java
@@ -1,0 +1,11 @@
+package com.baomidou.mybatisplus.test.base.mapper.commons;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.test.base.entity.WeixinUserEntity;
+
+/**
+ * @author by keray
+ * date:2019/8/9 23:35
+ */
+public interface WeixinUserMapper extends BaseMapper<WeixinUserEntity> {
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/mysql/SelectCountDistinctTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/mysql/SelectCountDistinctTest.java
@@ -21,15 +21,19 @@ import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.test.base.entity.CommonData;
 import com.baomidou.mybatisplus.test.base.entity.CommonLogicData;
+import com.baomidou.mybatisplus.test.base.entity.WeixinUserEntity;
 import com.baomidou.mybatisplus.test.base.mapper.commons.CommonDataMapper;
 import com.baomidou.mybatisplus.test.base.mapper.commons.CommonLogicDataMapper;
+import com.baomidou.mybatisplus.test.base.mapper.commons.WeixinUserMapper;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.annotation.Resource;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @DirtiesContext
@@ -42,6 +46,9 @@ class SelectCountDistinctTest {
     private CommonLogicDataMapper commonLogicMapper;
     @Resource
     private CommonDataMapper commonDataMapper;
+
+    @Resource
+    private WeixinUserMapper weixinUserMapper;
 
     @Test
     @Order(1)
@@ -141,4 +148,14 @@ class SelectCountDistinctTest {
         Assertions.assertNotNull(page.getRecords().get(0));
     }
 
+    @Test
+    void testSuperClassInsert() {
+        WeixinUserEntity entity = new WeixinUserEntity();
+        entity.setOpenId("openId");
+        entity.setUsername("username");
+        entity.setId("1");
+        entity.setCreateTime(LocalDateTime.now());
+        /* 理想状态不应该insert username字段 */
+        weixinUserMapper.insert(entity);
+    }
 }


### PR DESCRIPTION
### 该Pull Request关联的Issue

#1481

### 修改描述

添加@TableSuperClass注解，标识类的字段会被初始化到子类的List<TableFieldInfo>中，否者不会创建该类的字段。解决了在C->B->A，A共有字段，C实体定义基础B，数据库字段不继承B insert，select 报table不存在的B字段异常。
com.baomidou.mybatisplus.core.config.GlobalConfig#enableSuperClass配置是否开启指定数据库父类基础，默认不开启

### 测试用例
com.baomidou.mybatisplus.test.SampleTest#testSuperClass：测试生成tableInfo的字段信息
com.baomidou.mybatisplus.test.mysql.SelectCountDistinctTest#testSuperClassInsert：测试insert时是否添加B类字段

### 修复效果的截屏

开启改功能实体生成的List<TableFieldInfo>：
![image](https://user-images.githubusercontent.com/24504763/62822469-aea4f900-bbb6-11e9-9cb6-217322d8e489.png)
 
关闭功能生成的List<TableFieldInfo>：username,passwordwei为B类的字段，实际table不存在
![image](https://user-images.githubusercontent.com/24504763/62822537-8964ba80-bbb7-11e9-9354-62c2f9a0be84.png)


开启改功能实体insert的sql：
![image](https://user-images.githubusercontent.com/24504763/62822512-40146b00-bbb7-11e9-8500-696bb3789c18.png)

关闭该功能实体insert的sql：多余了B的username
![image](https://user-images.githubusercontent.com/24504763/62822524-6508de00-bbb7-11e9-9a6c-626081071bbe.png)
