### PR TITLE
mybatis-plus-generator生成controller文件superControllerClassPacket为空

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
@@ -227,11 +227,14 @@ public abstract class AbstractTemplateEngine {
         objectMap.put("superServiceClass", getSuperClassName(config.getSuperServiceClass()));
         objectMap.put("superServiceImplClassPackage", config.getSuperServiceImplClass());
         objectMap.put("superServiceImplClass", getSuperClassName(config.getSuperServiceImplClass()));
-        objectMap.put("superControllerClassPackage", config.getSuperControllerClass());
+        objectMap.put("superControllerClassPackage", verifyClassPacket(config.getSuperControllerClass()));
         objectMap.put("superControllerClass", getSuperClassName(config.getSuperControllerClass()));
         return Objects.isNull(config.getInjectionConfig()) ? objectMap : config.getInjectionConfig().prepareObjectMap(objectMap);
     }
 
+    private String verifyClassPacket(String classPacket) {
+        return StringUtils.isEmpty(classPacket) ? null : classPacket;
+    }
 
     /**
      * 获取类名

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
@@ -232,6 +232,12 @@ public abstract class AbstractTemplateEngine {
         return Objects.isNull(config.getInjectionConfig()) ? objectMap : config.getInjectionConfig().prepareObjectMap(objectMap);
     }
 
+    /**
+     * 用于渲染对象MAP信息 {@link #getObjectMap(TableInfo)} 时的superClassPacket非空校验
+     *
+     * @param classPacket ignore
+     * @return ignore
+     */
     private String verifyClassPacket(String classPacket) {
         return StringUtils.isEmpty(classPacket) ? null : classPacket;
     }


### PR DESCRIPTION
我在使用mybatis-plus-generator时，把用户个性化的设置抽取到配置文件中，例如包名这些。偶然间发现superControllerClass设置为空字符串时，生成的controller会报错，原因是文件中有
`import ;`字样，并没有对superControllerClass做非空校验。

示例项目：https://github.com/fuyitaoqqq/ack
所用mybatis-plus-generator版本：3.2.0