### PR TITLE
自定前端页面生成的时候，需要通过表名，获取到相关数据库配置前端设置

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/InjectionConfig.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/InjectionConfig.java
@@ -57,10 +57,15 @@ public abstract class InjectionConfig {
     private IFileCreate fileCreate;
 
     /**
-     * 根据表相关数据 注入自定义Map对象
+     * 注入自定义 Map 对象
+     */
+    public abstract void initMap();
+
+    /**
+     * 依据表相关信息， 从三方获取到需要元数据，处理方法环境里面
      * @param tableInfo
      */
-    public abstract void initMap(TableInfo tableInfo);
+    public abstract void initTableMap(TableInfo tableInfo);
 
     /**
      * 模板待渲染 Object Map 预处理<br>

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/InjectionConfig.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/InjectionConfig.java
@@ -22,6 +22,7 @@ import com.baomidou.mybatisplus.generator.config.FileOutConfig;
 import com.baomidou.mybatisplus.generator.config.IFileCreate;
 import com.baomidou.mybatisplus.generator.config.builder.ConfigBuilder;
 
+import com.baomidou.mybatisplus.generator.config.po.TableInfo;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -56,9 +57,10 @@ public abstract class InjectionConfig {
     private IFileCreate fileCreate;
 
     /**
-     * 注入自定义 Map 对象
+     * 根据表相关数据 注入自定义Map对象
+     * @param tableInfo
      */
-    public abstract void initMap();
+    public abstract void initMap(TableInfo tableInfo);
 
     /**
      * 模板待渲染 Object Map 预处理<br>

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
@@ -72,7 +72,7 @@ public abstract class AbstractTemplateEngine {
                 // 自定义内容
                 InjectionConfig injectionConfig = getConfigBuilder().getInjectionConfig();
                 if (null != injectionConfig) {
-                    injectionConfig.initMap();
+                    injectionConfig.initMap(tableInfo);
                     objectMap.put("cfg", injectionConfig.getMap());
                     List<FileOutConfig> focList = injectionConfig.getFileOutConfigList();
                     if (CollectionUtils.isNotEmpty(focList)) {

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
@@ -72,7 +72,7 @@ public abstract class AbstractTemplateEngine {
                 // 自定义内容
                 InjectionConfig injectionConfig = getConfigBuilder().getInjectionConfig();
                 if (null != injectionConfig) {
-                    injectionConfig.initMap(tableInfo);
+                    injectionConfig.initTableMap(tableInfo);
                     objectMap.put("cfg", injectionConfig.getMap());
                     List<FileOutConfig> focList = injectionConfig.getFileOutConfigList();
                     if (CollectionUtils.isNotEmpty(focList)) {


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
自定前端页面生成的时候，需要通过表名，获取到相关数据库配置前端设置，而自定义initMap()方法，并不能获取到表相关的数据，导致我只能把所有的都处理一遍，不太友好


### 测试用例



### 修复效果的截屏


