### PR TITLE
DML操作记录数预言拦截器

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
@@ -25,6 +25,7 @@ import com.baomidou.mybatisplus.core.enums.SqlLike;
 import com.baomidou.mybatisplus.core.toolkit.*;
 import com.baomidou.mybatisplus.core.toolkit.sql.SqlUtils;
 import com.baomidou.mybatisplus.core.toolkit.sql.StringEscape;
+import com.baomidou.mybatisplus.core.toolkit.support.Range;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -62,6 +63,10 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
      * SQL注释
      */
     protected SharedString sqlComment;
+    /**
+     * 预期的DML操作记录数
+     */
+    protected Range<Integer> expectedDmlRowCount;
     /**
      * 数据库表映射实体类
      */
@@ -445,6 +450,16 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
             return "/*" + StringEscape.escapeRawString(sqlComment.getStringValue()) + "*/";
         }
         return null;
+    }
+
+    @Override
+    public Range<Integer> getExpectedDmlRowCount() {
+        return expectedDmlRowCount;
+    }
+
+    public Children setExpectedDmlRowCount(Range<Integer> expectedDmlRowCount) {
+        this.expectedDmlRowCount = expectedDmlRowCount;
+        return typedThis;
     }
 
     @Override

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/Wrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/Wrapper.java
@@ -21,6 +21,7 @@ import com.baomidou.mybatisplus.core.metadata.TableFieldInfo;
 import com.baomidou.mybatisplus.core.metadata.TableInfo;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.core.toolkit.*;
+import com.baomidou.mybatisplus.core.toolkit.support.Range;
 
 import java.util.Objects;
 
@@ -49,6 +50,18 @@ public abstract class Wrapper<T> implements ISqlSegment {
     }
 
     public String getSqlComment() {
+        return null;
+    }
+
+    /**
+     * 返回 预期的DML操作记录数。
+     * 可用于预言判断、自动回滚不符合预期的事务。
+     * 拦截器可参考{@code DmlRowCountPredictionInterceptor}。
+     * 相关配置可参考{@link com.baomidou.mybatisplus.core.config.GlobalConfig.DmlRowCountPredictionConfig}.
+     *
+     * @return range or null
+     */
+    public Range<Integer> getExpectedDmlRowCount() {
         return null;
     }
 

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/QueryWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/QueryWrapper.java
@@ -104,7 +104,8 @@ public class QueryWrapper<T> extends AbstractWrapper<T, String, QueryWrapper<T>>
      */
     public LambdaQueryWrapper<T> lambda() {
         return new LambdaQueryWrapper<>(entity, entityClass, sqlSelect, paramNameSeq, paramNameValuePairs, expression,
-            lastSql, sqlComment);
+            lastSql, sqlComment)
+            .setExpectedDmlRowCount(expectedDmlRowCount);
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/UpdateWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/UpdateWrapper.java
@@ -93,7 +93,8 @@ public class UpdateWrapper<T> extends AbstractWrapper<T, String, UpdateWrapper<T
      * 返回一个支持 lambda 函数写法的 wrapper
      */
     public LambdaUpdateWrapper<T> lambda() {
-        return new LambdaUpdateWrapper<>(entity, sqlSet, paramNameSeq, paramNameValuePairs, expression, lastSql, sqlComment);
+        return new LambdaUpdateWrapper<>(entity, sqlSet, paramNameSeq, paramNameValuePairs, expression, lastSql, sqlComment)
+            .setExpectedDmlRowCount(expectedDmlRowCount);
     }
 
     @Override

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
@@ -21,10 +21,13 @@ import com.baomidou.mybatisplus.core.handlers.MetaObjectHandler;
 import com.baomidou.mybatisplus.core.incrementer.IKeyGenerator;
 import com.baomidou.mybatisplus.core.injector.ISqlInjector;
 import com.baomidou.mybatisplus.core.mapper.Mapper;
+import com.baomidou.mybatisplus.core.toolkit.support.Range;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+
 import org.apache.ibatis.session.SqlSessionFactory;
 
 import java.io.Serializable;
@@ -90,6 +93,11 @@ public class GlobalConfig implements Serializable {
     public void signGlobalConfig(SqlSessionFactory sqlSessionFactory) {
         this.sqlSessionFactory = sqlSessionFactory;
     }
+
+    /**
+     * DML操作记录数预言 配置
+     */
+    private DmlRowCountPredictionConfig dmlRowCountPredictionConfig = new DmlRowCountPredictionConfig();
 
     @Data
     public static class DbConfig {
@@ -157,5 +165,29 @@ public class GlobalConfig implements Serializable {
          * @since 3.1.2
          */
         private FieldStrategy selectStrategy = FieldStrategy.NOT_NULL;
+    }
+
+    /**
+     * DML操作记录数预言 配置类。
+     */
+    @Data
+    public static class DmlRowCountPredictionConfig {
+
+        /**
+         * DML操作记录数预言 是否开启。
+         * 默认开启。只有给SQL操作设置了期望值才会做预言匹配。
+         */
+        private boolean predictionEnabled = true;
+        /**
+         * DML操作记录数默认期望值 是否开启。
+         * 默认不开启。
+         * 大部分DML操作记录数都是1，开启全局配置之后可以减少相关代码量。
+         */
+        private boolean defaultExpectedDmlRowCountEnabled = false;
+        /**
+         * DML操作记录数默认期望值。
+         * 默认值为1。
+         */
+        private Range<Integer> defaultExpectedDmlRowCount = Range.is(1);
     }
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/support/Range.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/support/Range.java
@@ -1,0 +1,508 @@
+/*
+ * Copyright (c) 2011-2020, baomidou (jobob@qq.com).
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.baomidou.mybatisplus.core.toolkit.support;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//package org.apache.commons.lang3;
+// copy from commons-lang3:3.9, modification:
+// 1) org.apache.commons.lang3.Validate replaced
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * <p>An immutable range of objects from a minimum to maximum point inclusive.</p>
+ *
+ * <p>The objects need to either be implementations of {@code Comparable}
+ * or you need to supply a {@code Comparator}. </p>
+ *
+ * <p>#ThreadSafe# if the objects and comparator are thread-safe</p>
+ *
+ * @since 3.0
+ */
+public final class Range<T> implements Serializable {
+
+    /**
+     * Serialization version.
+     *
+     * @see java.io.Serializable
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The ordering scheme used in this range.
+     */
+    private final Comparator<T> comparator;
+    /**
+     * The minimum value in this range (inclusive).
+     */
+    private final T minimum;
+    /**
+     * The maximum value in this range (inclusive).
+     */
+    private final T maximum;
+    /**
+     * Cached output hashCode (class is immutable).
+     */
+    private transient int hashCode;
+    /**
+     * Cached output toString (class is immutable).
+     */
+    private transient String toString;
+
+    /**
+     * <p>Obtains a range using the specified element as both the minimum
+     * and maximum in this range.</p>
+     *
+     * <p>The range uses the natural ordering of the elements to determine where
+     * values lie in the range.</p>
+     *
+     * @param <T>     the type of the elements in this range
+     * @param element the value to use for this range, not null
+     * @return the range object, not null
+     * @throws IllegalArgumentException if the element is null
+     * @throws ClassCastException       if the element is not {@code Comparable}
+     */
+    public static <T extends Comparable<T>> Range<T> is(final T element) {
+        return between(element, element, null);
+    }
+
+    /**
+     * <p>Obtains a range using the specified element as both the minimum
+     * and maximum in this range.</p>
+     *
+     * <p>The range uses the specified {@code Comparator} to determine where
+     * values lie in the range.</p>
+     *
+     * @param <T>        the type of the elements in this range
+     * @param element    the value to use for this range, must not be {@code null}
+     * @param comparator the comparator to be used, null for natural ordering
+     * @return the range object, not null
+     * @throws IllegalArgumentException if the element is null
+     * @throws ClassCastException       if using natural ordering and the elements are not {@code Comparable}
+     */
+    public static <T> Range<T> is(final T element, final Comparator<T> comparator) {
+        return between(element, element, comparator);
+    }
+
+    /**
+     * <p>Obtains a range with the specified minimum and maximum values (both inclusive).</p>
+     *
+     * <p>The range uses the natural ordering of the elements to determine where
+     * values lie in the range.</p>
+     *
+     * <p>The arguments may be passed in the order (min,max) or (max,min).
+     * The getMinimum and getMaximum methods will return the correct values.</p>
+     *
+     * @param <T>           the type of the elements in this range
+     * @param fromInclusive the first value that defines the edge of the range, inclusive
+     * @param toInclusive   the second value that defines the edge of the range, inclusive
+     * @return the range object, not null
+     * @throws IllegalArgumentException if either element is null
+     * @throws ClassCastException       if the elements are not {@code Comparable}
+     */
+    public static <T extends Comparable<T>> Range<T> between(final T fromInclusive, final T toInclusive) {
+        return between(fromInclusive, toInclusive, null);
+    }
+
+    /**
+     * <p>Obtains a range with the specified minimum and maximum values (both inclusive).</p>
+     *
+     * <p>The range uses the specified {@code Comparator} to determine where
+     * values lie in the range.</p>
+     *
+     * <p>The arguments may be passed in the order (min,max) or (max,min).
+     * The getMinimum and getMaximum methods will return the correct values.</p>
+     *
+     * @param <T>           the type of the elements in this range
+     * @param fromInclusive the first value that defines the edge of the range, inclusive
+     * @param toInclusive   the second value that defines the edge of the range, inclusive
+     * @param comparator    the comparator to be used, null for natural ordering
+     * @return the range object, not null
+     * @throws IllegalArgumentException if either element is null
+     * @throws ClassCastException       if using natural ordering and the elements are not {@code Comparable}
+     */
+    public static <T> Range<T> between(final T fromInclusive, final T toInclusive, final Comparator<T> comparator) {
+        return new Range<>(fromInclusive, toInclusive, comparator);
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param element1 the first element, not null
+     * @param element2 the second element, not null
+     * @param comp     the comparator to be used, null for natural ordering
+     */
+    @SuppressWarnings("unchecked")
+    private Range(final T element1, final T element2, final Comparator<T> comp) {
+        if (element1 == null || element2 == null) {
+            throw new IllegalArgumentException("Elements in a range must not be null: element1=" +
+                element1 + ", element2=" + element2);
+        }
+        if (comp == null) {
+            this.comparator = Range.ComparableComparator.INSTANCE;
+        } else {
+            this.comparator = comp;
+        }
+        if (this.comparator.compare(element1, element2) < 1) {
+            this.minimum = element1;
+            this.maximum = element2;
+        } else {
+            this.minimum = element2;
+            this.maximum = element1;
+        }
+    }
+
+    // Accessors
+    //--------------------------------------------------------------------
+
+    /**
+     * <p>Gets the minimum value in this range.</p>
+     *
+     * @return the minimum value in this range, not null
+     */
+    public T getMinimum() {
+        return minimum;
+    }
+
+    /**
+     * <p>Gets the maximum value in this range.</p>
+     *
+     * @return the maximum value in this range, not null
+     */
+    public T getMaximum() {
+        return maximum;
+    }
+
+    /**
+     * <p>Gets the comparator being used to determine if objects are within the range.</p>
+     *
+     * <p>Natural ordering uses an internal comparator implementation, thus this
+     * method never returns null. See {@link #isNaturalOrdering()}.</p>
+     *
+     * @return the comparator being used, not null
+     */
+    public Comparator<T> getComparator() {
+        return comparator;
+    }
+
+    /**
+     * <p>Whether or not the Range is using the natural ordering of the elements.</p>
+     *
+     * <p>Natural ordering uses an internal comparator implementation, thus this
+     * method is the only way to check if a null comparator was specified.</p>
+     *
+     * @return true if using natural ordering
+     */
+    public boolean isNaturalOrdering() {
+        return comparator == Range.ComparableComparator.INSTANCE;
+    }
+
+    // Element tests
+    //--------------------------------------------------------------------
+
+    /**
+     * <p>Checks whether the specified element occurs within this range.</p>
+     *
+     * @param element the element to check for, null returns false
+     * @return true if the specified element occurs within this range
+     */
+    public boolean contains(final T element) {
+        if (element == null) {
+            return false;
+        }
+        return comparator.compare(element, minimum) > -1 && comparator.compare(element, maximum) < 1;
+    }
+
+    /**
+     * <p>Checks whether this range is after the specified element.</p>
+     *
+     * @param element the element to check for, null returns false
+     * @return true if this range is entirely after the specified element
+     */
+    public boolean isAfter(final T element) {
+        if (element == null) {
+            return false;
+        }
+        return comparator.compare(element, minimum) < 0;
+    }
+
+    /**
+     * <p>Checks whether this range starts with the specified element.</p>
+     *
+     * @param element the element to check for, null returns false
+     * @return true if the specified element occurs within this range
+     */
+    public boolean isStartedBy(final T element) {
+        if (element == null) {
+            return false;
+        }
+        return comparator.compare(element, minimum) == 0;
+    }
+
+    /**
+     * <p>Checks whether this range ends with the specified element.</p>
+     *
+     * @param element the element to check for, null returns false
+     * @return true if the specified element occurs within this range
+     */
+    public boolean isEndedBy(final T element) {
+        if (element == null) {
+            return false;
+        }
+        return comparator.compare(element, maximum) == 0;
+    }
+
+    /**
+     * <p>Checks whether this range is before the specified element.</p>
+     *
+     * @param element the element to check for, null returns false
+     * @return true if this range is entirely before the specified element
+     */
+    public boolean isBefore(final T element) {
+        if (element == null) {
+            return false;
+        }
+        return comparator.compare(element, maximum) > 0;
+    }
+
+    /**
+     * <p>Checks where the specified element occurs relative to this range.</p>
+     *
+     * <p>The API is reminiscent of the Comparable interface returning {@code -1} if
+     * the element is before the range, {@code 0} if contained within the range and
+     * {@code 1} if the element is after the range. </p>
+     *
+     * @param element the element to check for, not null
+     * @return -1, 0 or +1 depending on the element's location relative to the range
+     */
+    public int elementCompareTo(final T element) {
+        // Comparable API says throw NPE on null
+        if (element == null) {
+            throw new NullPointerException("Element is null");
+        }
+        if (isAfter(element)) {
+            return -1;
+        } else if (isBefore(element)) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    // Range tests
+    //--------------------------------------------------------------------
+
+    /**
+     * <p>Checks whether this range contains all the elements of the specified range.</p>
+     *
+     * <p>This method may fail if the ranges have two different comparators or element types.</p>
+     *
+     * @param otherRange the range to check, null returns false
+     * @return true if this range contains the specified range
+     * @throws RuntimeException if ranges cannot be compared
+     */
+    public boolean containsRange(final Range<T> otherRange) {
+        if (otherRange == null) {
+            return false;
+        }
+        return contains(otherRange.minimum)
+            && contains(otherRange.maximum);
+    }
+
+    /**
+     * <p>Checks whether this range is completely after the specified range.</p>
+     *
+     * <p>This method may fail if the ranges have two different comparators or element types.</p>
+     *
+     * @param otherRange the range to check, null returns false
+     * @return true if this range is completely after the specified range
+     * @throws RuntimeException if ranges cannot be compared
+     */
+    public boolean isAfterRange(final Range<T> otherRange) {
+        if (otherRange == null) {
+            return false;
+        }
+        return isAfter(otherRange.maximum);
+    }
+
+    /**
+     * <p>Checks whether this range is overlapped by the specified range.</p>
+     *
+     * <p>Two ranges overlap if there is at least one element in common.</p>
+     *
+     * <p>This method may fail if the ranges have two different comparators or element types.</p>
+     *
+     * @param otherRange the range to test, null returns false
+     * @return true if the specified range overlaps with this
+     * range; otherwise, {@code false}
+     * @throws RuntimeException if ranges cannot be compared
+     */
+    public boolean isOverlappedBy(final Range<T> otherRange) {
+        if (otherRange == null) {
+            return false;
+        }
+        return otherRange.contains(minimum)
+            || otherRange.contains(maximum)
+            || contains(otherRange.minimum);
+    }
+
+    /**
+     * <p>Checks whether this range is completely before the specified range.</p>
+     *
+     * <p>This method may fail if the ranges have two different comparators or element types.</p>
+     *
+     * @param otherRange the range to check, null returns false
+     * @return true if this range is completely before the specified range
+     * @throws RuntimeException if ranges cannot be compared
+     */
+    public boolean isBeforeRange(final Range<T> otherRange) {
+        if (otherRange == null) {
+            return false;
+        }
+        return isBefore(otherRange.minimum);
+    }
+
+    /**
+     * Calculate the intersection of {@code this} and an overlapping Range.
+     *
+     * @param other overlapping Range
+     * @return range representing the intersection of {@code this} and {@code other} ({@code this} if equal)
+     * @throws IllegalArgumentException if {@code other} does not overlap {@code this}
+     * @since 3.0.1
+     */
+    public Range<T> intersectionWith(final Range<T> other) {
+        if (!this.isOverlappedBy(other)) {
+            throw new IllegalArgumentException(String.format(
+                "Cannot calculate intersection with non-overlapping range %s", other));
+        }
+        if (this.equals(other)) {
+            return this;
+        }
+        final T min = getComparator().compare(minimum, other.minimum) < 0 ? other.minimum : minimum;
+        final T max = getComparator().compare(maximum, other.maximum) < 0 ? maximum : other.maximum;
+        return between(min, max, getComparator());
+    }
+
+    // Basics
+    //--------------------------------------------------------------------
+
+    /**
+     * <p>Compares this range to another object to test if they are equal.</p>.
+     *
+     * <p>To be equal, the minimum and maximum values must be equal, which
+     * ignores any differences in the comparator.</p>
+     *
+     * @param obj the reference object with which to compare
+     * @return true if this object is equal
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (obj == null || obj.getClass() != getClass()) {
+            return false;
+        } else {
+            @SuppressWarnings("unchecked") // OK because we checked the class above
+            final Range<T> range = (Range<T>) obj;
+            return minimum.equals(range.minimum) &&
+                maximum.equals(range.maximum);
+        }
+    }
+
+    /**
+     * <p>Gets a suitable hash code for the range.</p>
+     *
+     * @return a hash code value for this object
+     */
+    @Override
+    public int hashCode() {
+        int result = hashCode;
+        if (hashCode == 0) {
+            result = 17;
+            result = 37 * result + getClass().hashCode();
+            result = 37 * result + minimum.hashCode();
+            result = 37 * result + maximum.hashCode();
+            hashCode = result;
+        }
+        return result;
+    }
+
+    /**
+     * <p>Gets the range as a {@code String}.</p>
+     *
+     * <p>The format of the String is '[<i>min</i>..<i>max</i>]'.</p>
+     *
+     * @return the {@code String} representation of this range
+     */
+    @Override
+    public String toString() {
+        if (toString == null) {
+            toString = "[" + minimum + ".." + maximum + "]";
+        }
+        return toString;
+    }
+
+    /**
+     * <p>Formats the receiver using the given format.</p>
+     *
+     * <p>This uses {@link java.util.Formattable} to perform the formatting. Three variables may
+     * be used to embed the minimum, maximum and comparator.
+     * Use {@code %1$s} for the minimum element, {@code %2$s} for the maximum element
+     * and {@code %3$s} for the comparator.
+     * The default format used by {@code toString()} is {@code [%1$s..%2$s]}.</p>
+     *
+     * @param format the format string, optionally containing {@code %1$s}, {@code %2$s} and  {@code %3$s}, not null
+     * @return the formatted string, not null
+     */
+    public String toString(final String format) {
+        return String.format(format, minimum, maximum, comparator);
+    }
+
+    //-----------------------------------------------------------------------
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private enum ComparableComparator implements Comparator {
+        INSTANCE;
+
+        /**
+         * Comparable based compare implementation.
+         *
+         * @param obj1 left hand side of comparison
+         * @param obj2 right hand side of comparison
+         * @return negative, 0, positive comparison value
+         */
+        @Override
+        public int compare(final Object obj1, final Object obj2) {
+            return ((Comparable) obj1).compareTo(obj2);
+        }
+    }
+
+}

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/DmlRowCountPredictionInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/DmlRowCountPredictionInterceptor.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2011-2020, baomidou (jobob@qq.com).
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.baomidou.mybatisplus.extension.plugins;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.plugin.Intercepts;
+import org.apache.ibatis.plugin.Invocation;
+import org.apache.ibatis.plugin.Signature;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.transaction.Transaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.conditions.AbstractWrapper;
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.config.GlobalConfig;
+import com.baomidou.mybatisplus.core.exceptions.MybatisPlusException;
+import com.baomidou.mybatisplus.core.executor.MybatisBatchExecutor;
+import com.baomidou.mybatisplus.core.toolkit.Constants;
+import com.baomidou.mybatisplus.core.toolkit.support.Range;
+
+/**
+ * DML操作记录数预言拦截器。
+ * <p>
+ * 功能：
+ * 检查 UPDATE / DELETE 语句影响的记录数是否符合预期，如果不符合预期，那就回滚事务、抛出运行时异常（大致逻辑），处理方式在不同情况下略有区别：<ul>
+ * <li>如果是托管事务（数据库连接已经是手动提交），抛出运行时异常，让事务管理器接管异常，处理事务回滚之类的事情。</li>
+ * <li>如果数据库连接是自动提交的，该拦截器会在开始的时候调整为手动提交，结果不符合预期的时候回滚事务、并抛出运行时异常，中断调用流程。</li>
+ * </ul>
+ * <p>
+ * 设计动机：
+ * 在操作记录数这一维度，保护数据不被意外情况破坏。
+ * 数据被意外破坏的隐患一直存在，基于如下观察到的情况：<ul>
+ *     <li>正确的做法就有限的几种，出错的可能性多种多样。再加上可能项目时间紧迫、人员不足等情况，出错可能性更大。</li>
+ *     <li>事务代码写起来比较繁琐，包括：JDBC原生事务、Spring注解事务、Spring手动事务。对于单条SQL，大家不太使用事务的方式来写，如果多操作了数据，最多报个错，数据是不会回滚的。</li>
+ *     <li>使用Spring事务容易踩坑，特别是在使用不熟练的情况下。</li>
+ * </ul>
+ * <p>
+ * 支持范围：
+ * <ol>
+ *     <li>支持：Mybatis Plus Mapper 模式。使用{@link AbstractWrapper#setExpectedDmlRowCount(Range)}方法指定预期。</li>
+ *     <li>支持：Mybatis Plus ActiveRecord 模式。使用{@link AbstractWrapper#setExpectedDmlRowCount(Range)}方法指定预期。</li>
+ *     <li>暂不支持：Mybatis 原生 Mapper 模式（实际用到的场景较少）</li>
+ * </ol>
+ * <p>
+ * Mybatis Plus Mapper 模式，写法示例：
+ * <pre>{@code
+ * userMapper.update(new H2User(),
+ * 	new UpdateWrapper<H2User>().lambda().setExpectedDmlRowCount(Range.is(1))
+ * 		.eq(H2User::getName, name)
+ * 		.set(H2User::getName, nameNew)
+ * );
+ * ...
+ * userMapper.delete(new QueryWrapper<H2User>().lambda().setExpectedDmlRowCount(Range.is(1))
+ * 	.eq(H2User::getName, "")
+ * );
+ * ...
+ * userMapper.delete(new QueryWrapper<H2User>().setExpectedDmlRowCount(Range.between(2, 10)));
+ * }</pre>
+ * <p>
+ * Mybatis Plus ActiveRecord 模式，写法示例：
+ * <pre>{@code
+ * student.setName(nameNew).update(
+ * 	new UpdateWrapper<H2Student>().lambda().setExpectedDmlRowCount(Range.is(1))
+ * 		.eq(H2Student::getName, name)
+ * );
+ * ...
+ * student.delete(new QueryWrapper<H2Student>().lambda().setExpectedDmlRowCount(Range.is(1))
+ * 	.eq(H2Student::getName, "")
+ * );
+ * ...
+ * student.delete(new QueryWrapper<H2Student>().setExpectedDmlRowCount(Range.between(2, 10)));
+ * }</pre>
+ * <p>
+ * 配置示例：
+ * <pre>{@code
+ * MybatisConfiguration configuration = new MybatisConfiguration();
+ * ...
+ * configuration.setGlobalConfig(globalConfig);
+ * mybatisSqlSessionFactoryBean.setConfiguration(configuration);
+ * GlobalConfig.DmlRowCountPredictionConfig dmlRowCountPredictionConfig = globalConfig.getDmlRowCountPredictionConfig();
+ * dmlRowCountPredictionConfig.setPredictionEnabled(true).setDefaultExpectedDmlRowCountEnabled(false)
+ * 	.setDefaultExpectedDmlRowCount(Range.between(1, 1));
+ * configuration.addInterceptor(new DmlRowCountPredictionInterceptor());
+ * }</pre>
+ *
+ * @author sandynz
+ */
+@Intercepts({@Signature(type = Executor.class, method = "update", args = {MappedStatement.class, Object.class})})
+public class DmlRowCountPredictionInterceptor implements Interceptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(DmlRowCountPredictionInterceptor.class);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object intercept(Invocation invocation) throws Throwable {
+        Object[] args = invocation.getArgs();
+        MappedStatement mappedStatement = (MappedStatement) args[0];
+        switch (mappedStatement.getSqlCommandType()) {
+            case UPDATE:
+            case DELETE:
+                break;
+            default:
+                return invocation.proceed();
+        }
+
+        Configuration configuration = mappedStatement.getConfiguration();
+        if (!(configuration instanceof MybatisConfiguration)) {
+            return invocation.proceed();
+        }
+        MybatisConfiguration mybatisConfiguration = (MybatisConfiguration) configuration;
+        GlobalConfig.DmlRowCountPredictionConfig dmlRowCountPredictionConfig = mybatisConfiguration.getGlobalConfig().getDmlRowCountPredictionConfig();
+        if (!dmlRowCountPredictionConfig.isPredictionEnabled()) {
+            // 预言没开启
+            return invocation.proceed();
+        }
+
+        if (!(args[1] instanceof Map)) {
+            return invocation.proceed();
+        }
+        Map<String, Object> updateParamMap = (Map) args[1];
+        Object wrapper = updateParamMap.getOrDefault(Constants.WRAPPER, null);
+        if (!(wrapper instanceof Wrapper)) {
+            return invocation.proceed();
+        }
+
+        Executor executor = (Executor) invocation.getTarget();
+        if (executor instanceof MybatisBatchExecutor) {
+            // BatchExecutor.update无法返回实际更新的记录数（返回的是一个负数），这种情况需要忽略；
+            // 由于无法从Executor获取ExecutorType来判断，所以用类型来判断。
+            return invocation.proceed();
+        }
+        Transaction transaction = executor.getTransaction();
+        Connection connection = transaction.getConnection();
+
+        final boolean isOriginAutoCommit = connection.getAutoCommit();
+        if (isOriginAutoCommit) {
+            // 如果原始连接没有开启手动事务，那自动开启
+            try {
+                connection.setAutoCommit(false);
+            } catch (SQLException e) {
+                logger.warn("setAutoCommit to false failed, connection={}", connection, e);
+                // 开启失败，忽略本拦截器功能
+                return invocation.proceed();
+            }
+        }
+
+        Object result;
+        try {
+            result = invocation.proceed();
+        } catch (Throwable e) {
+            if (isOriginAutoCommit) {
+                rollbackForConn(connection, "invocationProceedFailed");
+            }
+            throw e;
+        }
+
+        // verify conn
+        {
+            Connection postConn = transaction.getConnection();
+            if (postConn != connection) {
+                // 理论上这两个连接是同一个，假如出现了意外情况：1）打印详细日志，2）提交之前开启的手动事务
+                logger.warn("postConn != connection, postConn={}, connection={}", postConn, connection, new Exception("DEBUG_POSTCONN_NE_CONN"));
+                if (isOriginAutoCommit) {
+                    commitForConn(connection, "postConnNeConn");
+                }
+                return result;
+            }
+        }
+
+        if (result instanceof Integer) {
+            Wrapper ew = (Wrapper) wrapper;
+            Range<Integer> expectedDmlRowCount = ew.getExpectedDmlRowCount();
+            if (expectedDmlRowCount == null) {
+                if (dmlRowCountPredictionConfig.isDefaultExpectedDmlRowCountEnabled()) {
+                    expectedDmlRowCount = dmlRowCountPredictionConfig.getDefaultExpectedDmlRowCount();
+                }
+            }
+            if (expectedDmlRowCount == null) {
+                commitForConn(connection, "expectedDmlRowCountNull");
+                return result;
+            }
+
+            int dmlRowCount = (Integer) result;
+            if (expectedDmlRowCount.contains(dmlRowCount)) {
+                if (isOriginAutoCommit) {
+                    // 如果是前面开启的手动事务，手动提交
+                    commitForConn(connection, "dmlRowCountMatched");
+                }
+            } else {
+                logger.info("not match, dmlRowCount={}, expectedDmlRowCount={}", dmlRowCount, expectedDmlRowCount);
+                if (isOriginAutoCommit) {
+                    // 如果是前面开启的手动事务，手动回滚。然后抛出异常
+                    rollbackForConn(connection, "dmlRowCountNotMatched");
+                }
+                //else, 抛出异常，让负责管理连接的组件来回滚事务（比如：Spring注解事务、Spring手动事务）
+                throw new MybatisPlusException(String.format("实际操作记录数%d不在期望范围：%s", dmlRowCount, expectedDmlRowCount.toString()));
+            }
+        } else {
+            if (isOriginAutoCommit) {
+                commitForConn(connection, "resultNotInteger");
+            }
+        }
+
+        return result;
+    }
+
+    private void commitForConn(Connection connection, String callFrom) {
+        try {
+            connection.commit();
+        } catch (SQLException e) {
+            logger.warn("commit failed, ignore, callFrom={}, connection={}", callFrom, connection, e);
+        }
+    }
+
+    private void rollbackForConn(Connection connection, String callFrom) {
+        try {
+            connection.rollback();
+        } catch (SQLException e) {
+            logger.warn("rollback failed, ignore, callFrom={}, connection={}", callFrom, connection, e);
+        }
+    }
+
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/ActiveRecordTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/ActiveRecordTest.java
@@ -211,18 +211,23 @@ class ActiveRecordTest {
         count = student.selectCount(new QueryWrapper<>());
         Assertions.assertEquals(1, count);
 
-        student.setName(nameNew).update(
+        boolean updated = student.setName(nameNew).update(
             new UpdateWrapper<H2Student>().lambda().setExpectedDmlRowCount(Range.is(1))
                 .eq(H2Student::getName, name)
         );
+        Assertions.assertTrue(updated);
+        Assertions.assertEquals(1, student.selectCount(
+                new QueryWrapper<H2Student>().lambda().eq(H2Student::getName, nameNew)));
 
         count = student.selectCount(new QueryWrapper<H2Student>().lambda()
             .eq(H2Student::getName, nameNew)
         );
         Assertions.assertEquals(1, count);
 
-        boolean updated = student.clone().setName(name).updateById();
+        updated = student.clone().setName(name).updateById();
         Assertions.assertTrue(updated);
+        Assertions.assertEquals(1, student.selectCount(
+                new QueryWrapper<H2Student>().lambda().eq(H2Student::getName, name)));
 
         try {
             student.delete(new QueryWrapper<H2Student>().lambda().setExpectedDmlRowCount(Range.is(1))

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserMapperTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserMapperTest.java
@@ -236,19 +236,24 @@ class H2UserMapperTest extends BaseTest {
         count = userMapper.selectCount(new QueryWrapper<>());
         Assertions.assertEquals(1, count);
 
-        userMapper.update(new H2User(),
+        int updateCount = userMapper.update(new H2User(),
             new UpdateWrapper<H2User>().lambda().setExpectedDmlRowCount(Range.is(1))
                 .eq(H2User::getName, name)
                 .set(H2User::getName, nameNew)
         );
+        Assertions.assertEquals(1, updateCount);
+        Assertions.assertEquals(1, userMapper.selectCount(
+                new QueryWrapper<H2User>().lambda().eq(H2User::getName, nameNew)));
 
         count = userMapper.selectCount(new QueryWrapper<H2User>().lambda()
             .eq(H2User::getName, nameNew)
         );
         Assertions.assertEquals(1, count);
 
-        int updateCount = userMapper.updateById(u1.clone().setName(name));
+        updateCount = userMapper.updateById(u1.clone().setName(name));
         Assertions.assertEquals(1, updateCount);
+        Assertions.assertEquals(1, userMapper.selectCount(
+                new QueryWrapper<H2User>().lambda().eq(H2User::getName, name)));
 
         try {
             userMapper.delete(new QueryWrapper<H2User>().lambda().setExpectedDmlRowCount(Range.is(1))

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
@@ -28,6 +28,7 @@ import org.apache.ibatis.exceptions.PersistenceException;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -353,6 +354,17 @@ class H2UserTest extends BaseTest {
             ));
         } catch (Exception e) {
             Assertions.assertTrue(e instanceof PersistenceException);
+        }
+    }
+
+    @Test
+    @Order(29)
+    void testPredictionTransactional() {
+        try {
+            userService.testPredictionTransactional();
+        } catch (DataAccessException e) {
+            List<H2User> list = userService.list(new QueryWrapper<H2User>().like("name", "prediction"));
+            Assertions.assertTrue(CollectionUtils.isEmpty(list));
         }
     }
 

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/config/DBConfig.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/config/DBConfig.java
@@ -29,7 +29,9 @@ import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.DatabasePopulator;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * H2 Memory Database config
@@ -54,6 +56,11 @@ public class DBConfig {
     @Bean
     public DataSourceTransactionManager transactionManager(DataSource ds) {
         return new DataSourceTransactionManager(ds);
+    }
+
+    @Bean
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+        return new TransactionTemplate(transactionManager);
     }
 
     @Bean

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/config/MybatisPlusConfig.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/config/MybatisPlusConfig.java
@@ -23,12 +23,14 @@ import com.baomidou.mybatisplus.core.injector.AbstractMethod;
 import com.baomidou.mybatisplus.core.injector.DefaultSqlInjector;
 import com.baomidou.mybatisplus.core.parser.AbstractJsqlParser;
 import com.baomidou.mybatisplus.core.parser.ISqlParser;
+import com.baomidou.mybatisplus.core.toolkit.support.Range;
 import com.baomidou.mybatisplus.extension.injector.methods.additional.AlwaysUpdateSomeColumnById;
 import com.baomidou.mybatisplus.extension.injector.methods.additional.InsertBatchSomeColumn;
 import com.baomidou.mybatisplus.extension.injector.methods.additional.LogicDeleteByIdWithFill;
 import com.baomidou.mybatisplus.extension.plugins.OptimisticLockerInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.PaginationInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.SqlExplainInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.DmlRowCountPredictionInterceptor;
 import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
 import com.baomidou.mybatisplus.test.h2.H2MetaObjectHandler;
 import net.sf.jsqlparser.statement.delete.Delete;
@@ -75,7 +77,12 @@ public class MybatisPlusConfig {
         configuration.setMapUnderscoreToCamelCase(true);
         configuration.setDefaultExecutorType(ExecutorType.REUSE);
         configuration.setDefaultEnumTypeHandler(EnumOrdinalTypeHandler.class);  //默认枚举处理
+        configuration.setGlobalConfig(globalConfig);
         sqlSessionFactory.setConfiguration(configuration);
+        GlobalConfig.DmlRowCountPredictionConfig dmlRowCountPredictionConfig = globalConfig.getDmlRowCountPredictionConfig();
+        dmlRowCountPredictionConfig.setPredictionEnabled(true).setDefaultExpectedDmlRowCountEnabled(false)
+            .setDefaultExpectedDmlRowCount(Range.between(1, 1));
+        configuration.addInterceptor(new DmlRowCountPredictionInterceptor());
         PaginationInterceptor pagination = new PaginationInterceptor();
         SqlExplainInterceptor sqlExplainInterceptor = new SqlExplainInterceptor();
         List<ISqlParser> sqlParserList = new ArrayList<>();

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/entity/H2Student.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/entity/H2Student.java
@@ -39,13 +39,22 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class H2Student extends Model<H2Student> {
+public class H2Student extends Model<H2Student> implements Cloneable {
 
 
     /**
 	 * serialVersionUID
 	 */
 	private static final long serialVersionUID = 1290051894415073936L;
+
+	@Override
+    public H2Student clone() {
+        try {
+            return (H2Student) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new InternalError(e);
+        }
+    }
 
 	public H2Student(Long id, String name, Integer age) {
         this.id = id;

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/entity/H2User.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/entity/H2User.java
@@ -34,12 +34,21 @@ import java.util.Date;
 @Accessors(chain = true)
 @TableName("h2user")
 @EqualsAndHashCode(callSuper = true)
-public class H2User extends SuperEntity {
+public class H2User extends SuperEntity implements Cloneable {
 
     /**
 	 * serialVersionUID
 	 */
 	private static final long serialVersionUID = 2043176352335589747L;
+
+    @Override
+    public H2User clone() {
+        try {
+            return (H2User) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new InternalError(e);
+        }
+    }
 
 	/* 测试忽略验证 */
     private String name;

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/service/IH2UserService.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/service/IH2UserService.java
@@ -53,4 +53,6 @@ public interface IH2UserService extends IService<H2User> {
     void testSaveOrUpdateBatchTransactional();
 
     void testSimpleAndBatchTransactional();
+
+    void testPredictionTransactional();
 }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/service/impl/H2UserServiceImpl.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/service/impl/H2UserServiceImpl.java
@@ -22,9 +22,11 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import com.baomidou.mybatisplus.core.exceptions.MybatisPlusException;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.metadata.OrderItem;
+import com.baomidou.mybatisplus.core.toolkit.support.Range;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.baomidou.mybatisplus.test.h2.entity.H2User;
@@ -122,5 +124,16 @@ public class H2UserServiceImpl extends ServiceImpl<H2UserMapper, H2User> impleme
         saveBatch(Arrays.asList(new H2User("simpleAndBatchTx2", 0), new H2User("simpleAndBatchTx3", 0), new H2User("simpleAndBatchTx4", 0)), 1);
         saveOrUpdateBatch(Arrays.asList(new H2User("simpleAndBatchTx5", 0), new H2User("simpleAndBatchTx6", 0), new H2User("simpleAndBatchTx7", 0)), 1);
         throw new MybatisPlusException("测试事务回滚");
+    }
+
+    @Override
+    @Transactional(rollbackFor = RuntimeException.class)
+    public void testPredictionTransactional() {
+        save(new H2User("prediction1", 0));
+        update(new H2User(),
+            new UpdateWrapper<H2User>().lambda().setExpectedDmlRowCount(Range.is(100))
+                .eq(H2User::getName, "prediction1")
+                .set(H2User::getName, "prediction2")
+        );
     }
 }


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
功能：
检查 UPDATE / DELETE 语句影响的记录数是否符合预期，如果不符合预期，那就回滚事务、抛出运行时异常（大致逻辑），处理方式在不同情况下略有区别。

设计动机：
在操作记录数这一维度，保护数据不被意外情况破坏。
数据被意外破坏的隐患一直存在，基于如下观察到的情况：
1）正确的做法就有限的几种，出错的可能性多种多样。再加上可能项目时间紧迫、人员不足等情况，出错可能性更大。
2）事务代码写起来比较繁琐，包括：JDBC原生事务、Spring注解事务、Spring手动事务。对于单条SQL，大家不太使用事务的方式来写，如果多操作了数据，最多报个错，数据是不会回滚的。
3）使用Spring事务容易踩坑，特别是在使用不熟练的情况下。

代码修改范围：
1）增加一个拦截器 DmlRowCountPredictionInterceptor。
2）为了传递DML操作记录数期望值，在Wrapper及其子类增加相关设置方法、获取方法、字段。从commons-lang3拷贝Range类到项目中，用于表示DML操作记录数期望值范围。
3）为了方便使用者，在GlobalConfig里增加了一个新的配置类DmlRowCountPredictionConfig。预设两个用途：a）提供可配置的DML操作记录数默认期望值，减少使用过程中的代码量，特别是集成到已有项目中的时候，b）全局禁用该拦截器功能，方便测试的时候调整。


### 测试用例
1）H2UserMapperTest . expectedDmlRowCountTest。测试 Mapper 模式、Spring手动事务集成情况。
2）ActiveRecordTest . expectedDmlRowCountTest。测试 ActiveRecord 模式。
3）H2UserTest . testPredictionTransactional。测试Spring注解事务集成情况。


### 修复效果的截屏


