### PR TITLE
修复使用ServiceImpl批量处理发生异常时没有将Sql异常转换为DataAccessException类型的异常

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
@@ -28,10 +28,13 @@ import org.apache.ibatis.binding.MapperMethod;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
 import org.apache.ibatis.session.SqlSession;
+import org.mybatis.spring.MyBatisExceptionTranslator;
 import org.mybatis.spring.SqlSessionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.sql.DataSource;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
@@ -53,6 +56,9 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
 
     @Autowired
     protected M baseMapper;
+
+    @Autowired
+    protected DataSource dataSource;
 
     @Override
     public M getBaseMapper() {
@@ -108,7 +114,7 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
      * 批量插入
      *
      * @param entityList ignore
-     * @param batchSize ignore
+     * @param batchSize  ignore
      * @return ignore
      */
     @Transactional(rollbackFor = Exception.class)
@@ -126,6 +132,11 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
                 }
                 i++;
             }
+        } catch (RuntimeException ex) {
+//            new MyBatisExceptionTranslator(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(), true));
+            MyBatisExceptionTranslator myBatisExceptionTranslator = new MyBatisExceptionTranslator(dataSource, true);
+            DataAccessException dataAccessException = myBatisExceptionTranslator.translateExceptionIfPossible(ex);
+            throw dataAccessException;
         }
         return true;
     }
@@ -179,7 +190,13 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
                 }
                 i++;
             }
+        }catch (RuntimeException ex) {
+//            new MyBatisExceptionTranslator(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(), true));
+            MyBatisExceptionTranslator myBatisExceptionTranslator = new MyBatisExceptionTranslator(dataSource, true);
+            DataAccessException dataAccessException = myBatisExceptionTranslator.translateExceptionIfPossible(ex);
+            throw dataAccessException;
         }
+
         return true;
     }
 
@@ -232,6 +249,11 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
                 }
                 i++;
             }
+        }catch (RuntimeException ex) {
+//            new MyBatisExceptionTranslator(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(), true));
+            MyBatisExceptionTranslator myBatisExceptionTranslator = new MyBatisExceptionTranslator(dataSource, true);
+            DataAccessException dataAccessException = myBatisExceptionTranslator.translateExceptionIfPossible(ex);
+            throw dataAccessException;
         }
         return true;
     }
@@ -299,3 +321,4 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
         return SqlHelper.getObject(log, listObjs(queryWrapper, mapper));
     }
 }
+


### PR DESCRIPTION
### 该Pull Request关联的Issue

无

### 修改描述

当ServiceImpl的saveBatch方法、saveOrUpdateBatch方法、updateBatchById方法在进行批量提交的时候发生异常时，使用org.mybatis.spring.MyBatisExceptionTranslator转换器将SQL异常统一转换为org.springframework.dao.DataAccessException的异常，方便单次提交数据库处理异常与批量提交数据库处理异常能够统一。如下：

单次提交时有数据库主键重复的异常处理：
```java
        try {
            userDmoMapper.insert(userDmo);
        } catch (DuplicateKeyException ex) {
            throw new EntityExistedException("用户已经存在") {
            };
        }
```

修改前，批量提交无法处理主键重复的异常，修改后处理方式如下：

```java
        try {
            userDmoService.saveBatch(userDmoList);
        } catch (DuplicateKeyException ex) {
            throw new EntityExistedException("用户已经存在") {
            };
        }
```

### 测试用例



### 修复效果的截屏


