### PR TITLE
新增 ORACLE_NEW 分页方言,优化 ORACLE 分页 SQL（原有 ORACLE 分页需要嵌套3层SQL效率低）

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -41,7 +41,12 @@ public enum DbType {
     /**
      * ORACLE
      */
+
     ORACLE("oracle", "Oracle数据库", "com.baomidou.mybatisplus.extension.plugins.pagination.dialects.OracleDialect"),
+
+
+    ORACLE_NEW("oracleNew", "Oracle新版数据库","com.baomidou.mybatisplus.extension.plugins.pagination.dialects.OracleNewDialect"),
+
     /**
      * DB2
      */

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/OracleNewDialect.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/OracleNewDialect.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2020, baomidou (jobob@qq.com).
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.baomidou.mybatisplus.extension.plugins.pagination.dialects;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.DialectModel;
+
+/**
+ * ORACLE 新版数据库分页语句组装实现
+ *
+ * @author 廖仑辉
+ * @since 2019-11-29
+ */
+public class OracleNewDialect implements IDialect {
+
+    @Override
+    public DialectModel buildPaginationSql(String originalSql, long offset, long limit) {
+        limit = (offset >= 1) ? (offset + limit) : limit;
+        String sql = originalSql + " OFFSET " + FIRST_MARK + " ROWS FETCH NEXT " + SECOND_MARK + " ROWS ONLY ";
+        return new DialectModel(sql, offset, limit).setConsumerChain();
+    }
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/DbTypeTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/DbTypeTest.java
@@ -37,6 +37,7 @@ class DbTypeTest {
         DIALECT_MAP.put(DbType.MYSQL, MySqlDialect.class);
         DIALECT_MAP.put(DbType.MARIADB, MariaDBDialect.class);
         DIALECT_MAP.put(DbType.ORACLE, OracleDialect.class);
+        DIALECT_MAP.put(DbType.ORACLE_NEW, OracleNewDialect.class);
         DIALECT_MAP.put(DbType.POSTGRE_SQL, PostgreDialect.class);
         DIALECT_MAP.put(DbType.SQL_SERVER, SQLServerDialect.class);
         DIALECT_MAP.put(DbType.SQL_SERVER2005, SQLServer2005Dialect.class);


### PR DESCRIPTION
### 该Pull Request关联的Issue

https://github.com/baomidou/mybatis-plus/issues/1180

### 修改描述

新增 ORACLE_NEW 分页方言,优化 ORACLE 分页 SQL（原有 ORACLE 分页需要嵌套3层SQL效率低）

### 测试用例


com/baomidou/mybatisplus/test/DbTypeTest.java:40

@Configuration
public class MybatisPlusConfig {
    @Bean
    public PaginationInterceptor paginationInterceptor() {
        PaginationInterceptor page = new PaginationInterceptor();
        page.setDialectType(DbType.ORACLE_NEW.getDb());
        return page;
    }
}


### 修复效果的截屏

![image](https://user-images.githubusercontent.com/13741751/69873019-1f9d2780-12f2-11ea-8b80-d72a19192643.png)

