### PR TITLE
add catalog schema，解决sql 1142的问题

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/IllegalSQLInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/IllegalSQLInterceptor.java
@@ -267,7 +267,9 @@ public class IllegalSQLInterceptor implements Interceptor {
             ResultSet rs;
             try {
                 DatabaseMetaData metadata = conn.getMetaData();
-                rs = metadata.getIndexInfo(dbName, dbName, tableName, false, true);
+                String catalog = StringUtils.isEmpty(dbName)? conn.getCatalog():dbName;
+                String schema = StringUtils.isEmpty(dbName)? conn.getSchema():dbName;
+                rs = metadata.getIndexInfo(catalog, schema, tableName, false, true);
                 indexInfos = new ArrayList<>();
                 while (rs.next()) {
                     //索引中的列序列号等于1，才有效


### PR DESCRIPTION

### 该Pull Request关联的Issue

无

### 修改描述

IllegalSQLInterceptor 176行 - 空指针异常
-----------------------------------------
源码 160行validUseIndex 方法里
private static void validUseIndex(Table table, String columnName, Connection connection) {
      .....
}

table 对象 ：只有一个name非空属性为表名称 channel

源码270行 

rs = metadata.getIndexInfo(dbName, dbName, tableName, false, true);

dbName 为空，及String catalog, String schema 这两类型都为空
以mysql为例 驱动版本 mysql-connector-java-8.0.18.jar

第一种情况：
DatabaseMetaData.class
3341行 getCatalogIterator(catalog) mysql会获取当前用户所有的库，会在每个库执行
SHOW INDEX FROM 表 FROM 库
排序后，如果该表名称（channel） 在别的库（库2）也存在，获取的索引信息无法保证是正确的，有可能是 表 在 库2 的索引信息。

第二种情况：
当前登录用户没有权限在mysql库执行 SHOW INDEX FROM channel（表名称） FROM mysql
IllegalSQLInterceptor 该类的getIndexInfos方法 会返回一个null对象
后面紧跟着空指针异常，导致程序无法正常运行


如何避免这两种情况？
metadata.getIndexInfo方法中，传入String catalog, String schema 属性
在不同的数据库中 两个参数的含义不同，我们无需改变，从Connection对象获取即可

修改代码如下：
rs = metadata.getIndexInfo(dbName, dbName, tableName, false, true);
String catalog = StringUtils.isEmpty(dbName)? conn.getCatalog():dbName;
String schema = StringUtils.isEmpty(dbName)? conn.getSchema():dbName;
rs = metadata.getIndexInfo(catalog, schema, tableName, false, true);


### 测试用例

第一种情况：在当前登录用户能访问的数据库中，建立同名称的表 即可重现
第二种情况：是数据库权限


### 修复效果的截屏


