### PR TITLE
加入对seata分布式事务代理数据源支持

### DIFF
--- a/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
+++ b/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
@@ -70,6 +70,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import java.lang.reflect.Constructor;
 
 /**
  * {@link EnableAutoConfiguration Auto-Configuration} for Mybatis. Contributes a
@@ -157,6 +158,11 @@ public class MybatisPlusAutoConfiguration implements InitializingBean {
     public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
         // TODO 使用 MybatisSqlSessionFactoryBean 而不是 SqlSessionFactoryBean
         MybatisSqlSessionFactoryBean factory = new MybatisSqlSessionFactoryBean();
+        try {
+            Constructor dataSourceProxy = Class.forName("io.seata.rm.datasource.DataSourceProxy").getConstructor(DataSource.class);
+            dataSource = (DataSource)dataSourceProxy.newInstance(dataSource);
+        } catch (Exception e) {
+        }
         factory.setDataSource(dataSource);
         factory.setVfs(SpringBootVFS.class);
         if (StringUtils.hasText(this.properties.getConfigLocation())) {


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述

利用反射判断是否存在seata代理数据源的依赖,存在即进行代理该数据源(理论上等同判断druid是否存在,存在进行druid的配置)

### 测试用例



### 修复效果的截屏


