### PR TITLE
测试用例优化，使用StringUtils.guessGetterName()方法代替被弃用的ReflectionKit.getMethod…

### DIFF
--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKitTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKitTest.java
@@ -81,13 +81,13 @@ class ReflectionKitTest {
     @Test
     void testGetMethodCapitalize() throws NoSuchFieldException {
         Field field = C.class.getDeclaredField("sex");
-        String getMethod = ReflectionKit.getMethodCapitalize(field, "sex");
+        String getMethod = StringUtils.guessGetterName("sex",field.getType());
         Assertions.assertEquals("getSex", getMethod);
         field = A.class.getDeclaredField("testWrap");
-        getMethod = ReflectionKit.getMethodCapitalize(field, "testWrap");
+        getMethod = StringUtils.guessGetterName("testWrap",field.getType());
         Assertions.assertEquals("getTestWrap", getMethod);
         field = A.class.getDeclaredField("testSimple");
-        getMethod = ReflectionKit.getMethodCapitalize(field, "testSimple");
+        getMethod = StringUtils.guessGetterName("testSimple",field.getType());
         Assertions.assertEquals("isTestSimple", getMethod);
     }
 


### PR DESCRIPTION
使用原来的方法在项目编译时会显示警告。