### PR TITLE
TableFieldInfo支持传入泛型类型参数来构造TypeHandler

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://downloads.gradle-dn.com/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/handlers/FastjsonTypeHandler.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/handlers/FastjsonTypeHandler.java
@@ -23,6 +23,8 @@ import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.MappedJdbcTypes;
 import org.apache.ibatis.type.MappedTypes;
 
+import java.lang.reflect.Type;
+
 /**
  * Fastjson 实现 JSON 字段类型处理器
  *
@@ -33,11 +35,19 @@ import org.apache.ibatis.type.MappedTypes;
 @MappedTypes({Object.class})
 @MappedJdbcTypes(JdbcType.VARCHAR)
 public class FastjsonTypeHandler extends AbstractJsonTypeHandler<Object> {
-    private Class<Object> type;
+    private Type type;
+
+    public FastjsonTypeHandler(Type type) {
+        if (log.isTraceEnabled()) {
+            log.trace("FastjsonTypeHandler({})", type);
+        }
+        Assert.notNull(type, "Type argument cannot be null");
+        this.type = type;
+    }
 
     public FastjsonTypeHandler(Class<Object> type) {
         if (log.isTraceEnabled()) {
-            log.trace("FastjsonTypeHandler(" + type + ")");
+            log.trace("FastjsonTypeHandler({})", type);
         }
         Assert.notNull(type, "Type argument cannot be null");
         this.type = type;

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/handlers/TableInfoHelperTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/handlers/TableInfoHelperTest.java
@@ -1,0 +1,94 @@
+package com.baomidou.mybatisplus.extension.handlers;
+
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.metadata.TableInfo;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+class TableInfoHelperTest {
+
+    @Data
+    private static class BaseModel {
+
+        private Long id;
+
+        private String test;
+    }
+
+
+    @Data
+    private static class ModelOne {
+
+        @TableId
+        private Long id;
+
+        private String name;
+    }
+
+    @Data
+    private static class ModelTwo {
+
+        private Long id;
+
+        private String name;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @TableName(excludeProperty = "test")
+    private static class ModelThree extends BaseModel {
+
+        private String sex;
+
+        private String name;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @TableName(excludeProperty = {"test", "id"}, autoResultMap = true)
+    private static class ModelFour extends BaseModel {
+
+        private String sex;
+        @TableField(typeHandler = JacksonTypeHandler.class)
+        private String name;
+
+        @TableField(typeHandler = FastjsonTypeHandler.class)
+        private List<URL> urls;
+        @TableField(typeHandler = FastjsonTypeHandler.class)
+        private URL url;
+    }
+
+    @Test
+    void testIsExistTableId() {
+        Assertions.assertTrue(TableInfoHelper.isExistTableId(Arrays.asList(ModelOne.class.getDeclaredFields())));
+        Assertions.assertFalse(TableInfoHelper.isExistTableId(Arrays.asList(ModelTwo.class.getDeclaredFields())));
+    }
+
+    @Test
+    void testExcludeProperty() {
+        TableInfo tableInfo = TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), ModelThree.class);
+        Assertions.assertEquals(tableInfo.getFieldList().size(), 2);
+        tableInfo.getFieldList().forEach(field -> Assertions.assertNotEquals("test", field.getProperty()));
+        tableInfo = TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), ModelFour.class);
+        Assertions.assertEquals(tableInfo.getFieldList().size(), 2);
+        tableInfo.getFieldList().forEach(field -> Assertions.assertNotEquals("test", field.getProperty()));
+    }
+
+    @Test
+    void testJsonHandler() {
+        MybatisConfiguration configuration = new MybatisConfiguration();
+        TableInfo tableInfo = TableInfoHelper.initTableInfo(new MapperBuilderAssistant(configuration, ""), ModelFour.class);
+        System.out.println("1 = " + 1);
+    }
+}


### PR DESCRIPTION
FastjsonTypeHandler支持泛型

### 该Pull Request关联的Issue
#2098


### 修改描述
在3.3.1的基础上扩展，构造TypeHandler时传入泛型参数，FastjsonTypeHandler保存好泛型参数即可


### 测试用例
简单的打断点测试
copy了core中的TableInfoHelperTest到extension中，扩展了模块4
![image](https://user-images.githubusercontent.com/38414302/72954546-af7fbf00-3dd3-11ea-885d-9d37a7cb89d1.png)
![image](https://user-images.githubusercontent.com/38414302/72954558-bad2ea80-3dd3-11ea-8b8e-ffdcb0d10f37.png)
![image](https://user-images.githubusercontent.com/38414302/72954561-bc041780-3dd3-11ea-83ed-d4a06068e183.png)


### 修复效果的截屏
![image](https://user-images.githubusercontent.com/38414302/72954567-bd354480-3dd3-11ea-8cef-434915cf3128.png)
