### PR TITLE
add kotlin source code to task sourcesJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ subprojects {
     //noinspection GroovyAssignabilityCheck
     task sourcesJar(type: Jar) {
         archiveClassifier = 'sources'
-        from sourceSets.main.allJava
+        from sourceSets.main.allSource
     }
 
     javadoc {


### PR DESCRIPTION
`sourceSets.main.allJava` doesn't contains kotlin source code, change to `sourceSets.main.allSource` should fix it.

ref: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.SourceSet.html
