### PR TITLE
FIX : #2684 IPage.Convert对象转换比较耗时，处理比较慢

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/IPage.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/IPage.java
@@ -196,4 +196,17 @@ public interface IPage<T> extends Serializable {
         List<R> collect = this.getRecords().stream().map(mapper).collect(toList());
         return ((IPage<R>) this).setRecords(collect);
     }
+    
+    /**
+     * IPage 的泛型转换 
+     *
+     * @param mapper 转换函数
+     * @param <R>    转换后的泛型
+     * @return 转换泛型后的 IPage
+     */
+    @SuppressWarnings("unchecked")
+    default <R> IPage<R> parallelConvert(Function<? super T, ? extends R> mapper) {
+        List<R> collect = this.getRecords().parallelStream().map(mapper).collect(toList());
+        return ((IPage<R>) this).setRecords(collect);
+    }
 }


### PR DESCRIPTION
IPage转换时，新增parallel特性

### 该Pull Request关联的Issue

 #2684 IPage.Convert对象转换比较耗时，处理比较慢

### 修改描述

在对象转换时，采用并行处理

### 测试用例

JAVA 1.8以上的特性

### 修复效果的截屏

无
