### PR TITLE
修复代码生成器模板文件路径为空时模板引擎报错的问题

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/BeetlTemplateEngine.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/BeetlTemplateEngine.java
@@ -15,6 +15,7 @@
  */
 package com.baomidou.mybatisplus.generator.engine;
 
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.generator.config.builder.ConfigBuilder;
 import org.beetl.core.Configuration;
 import org.beetl.core.GroupTemplate;
@@ -49,6 +50,9 @@ public class BeetlTemplateEngine extends AbstractTemplateEngine {
 
     @Override
     public void writer(Map<String, Object> objectMap, String templatePath, String outputFile) throws Exception {
+        if (StringUtils.isBlank(templatePath)) {
+            return;
+        }
         Template template = groupTemplate.getTemplate(templatePath);
         try (FileOutputStream fileOutputStream = new FileOutputStream(outputFile)) {
             template.binding(objectMap);

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/FreemarkerTemplateEngine.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/FreemarkerTemplateEngine.java
@@ -16,6 +16,7 @@
 package com.baomidou.mybatisplus.generator.engine;
 
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.generator.config.ConstVal;
 import com.baomidou.mybatisplus.generator.config.builder.ConfigBuilder;
 import freemarker.template.Configuration;
@@ -47,6 +48,9 @@ public class FreemarkerTemplateEngine extends AbstractTemplateEngine {
 
     @Override
     public void writer(Map<String, Object> objectMap, String templatePath, String outputFile) throws Exception {
+        if (StringUtils.isBlank(templatePath)) {
+            return;
+        }
         Template template = configuration.getTemplate(templatePath);
         try (FileOutputStream fileOutputStream = new FileOutputStream(outputFile)) {
             template.process(objectMap, new OutputStreamWriter(fileOutputStream, ConstVal.UTF8));


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
VelocityTemplateEngine 在写入时对模板文件路径进行了判空操作，但 FreemarkerTemplateEngine 和 BeetlTemplateEngine 未进行判空操作，导致模板文件路径为空时控制台会打印错误信息。

该 PR 对此文件进行修复，修复后控制台不再打印错误信息


### 测试用例
无

### 修复效果的截屏
无

