### PR TITLE
PaginationInnerInterceptor: join 条件判断应不区分大小写

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -295,6 +295,8 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
             if (CollectionUtils.isNotEmpty(joins)) {
                 boolean canRemoveJoin = true;
                 String whereS = Optional.ofNullable(plainSelect.getWhere()).map(Expression::toString).orElse(StringPool.EMPTY);
+                // 不区分大小写
+                whereS = whereS.toLowerCase();
                 for (Join join : joins) {
                     if (!join.isLeft()) {
                         canRemoveJoin = false;
@@ -302,6 +304,8 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
                     }
                     Table table = (Table) join.getRightItem();
                     String str = Optional.ofNullable(table.getAlias()).map(Alias::getName).orElse(table.getName()) + StringPool.DOT;
+                    // 不区分大小写
+                    str = str.toLowerCase();
                     String onExpressionS = join.getOnExpression().toString();
                     /* 如果 join 里包含 ?(代表有入参) 或者 where 条件里包含使用 join 的表的字段作条件,就不移除 join */
                     if (onExpressionS.contains(StringPool.QUESTION_MARK) || whereS.contains(str)) {

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/optimize/JsqlParserCountOptimize.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/optimize/JsqlParserCountOptimize.java
@@ -98,6 +98,8 @@ public class JsqlParserCountOptimize implements ISqlParser {
             if (optimizeJoin && CollectionUtils.isNotEmpty(joins)) {
                 boolean canRemoveJoin = true;
                 String whereS = Optional.ofNullable(plainSelect.getWhere()).map(Expression::toString).orElse(StringPool.EMPTY);
+                // 不区分大小写
+                whereS = whereS.toLowerCase();
                 for (Join join : joins) {
                     if (!join.isLeft()) {
                         canRemoveJoin = false;
@@ -105,6 +107,8 @@ public class JsqlParserCountOptimize implements ISqlParser {
                     }
                     Table table = (Table) join.getRightItem();
                     String str = Optional.ofNullable(table.getAlias()).map(Alias::getName).orElse(table.getName()) + StringPool.DOT;
+                    // 不区分大小写
+                    str = str.toLowerCase();
                     String onExpressionS = join.getOnExpression().toString();
                     /* 如果 join 里包含 ?(代表有入参) 或者 where 条件里包含使用 join 的表的字段作条件,就不移除 join */
                     if (onExpressionS.contains(StringPool.QUESTION_MARK) || whereS.contains(str)) {

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptorTest.java
@@ -37,6 +37,10 @@ class PaginationInnerInterceptorTest {
         assertsCountSql("select * from user u LEFT JOIN role r ON r.id = u.role_id AND r.name = ? where u.xx = ?",
             "SELECT COUNT(1) FROM user u LEFT JOIN role r ON r.id = u.role_id AND r.name = ? WHERE u.xx = ?");
 
+        /* join 表与 where 条件大小写不同的情况 */
+        assertsCountSql("select * from user u LEFT JOIN role r ON r.id = u.role_id where R.NAME = ?",
+            "SELECT COUNT(1) FROM user u LEFT JOIN role r ON r.id = u.role_id WHERE R.NAME = ?");
+
         assertsCountSql("select * from user u LEFT JOIN role r ON r.id = u.role_id WHERE u.xax = ? AND r.cc = ? AND r.qq = ?",
             "SELECT COUNT(1) FROM user u LEFT JOIN role r ON r.id = u.role_id WHERE u.xax = ? AND r.cc = ? AND r.qq = ?");
     }

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/plugins/pagination/optimize/JsqlParserCountOptimizeTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/plugins/pagination/optimize/JsqlParserCountOptimizeTest.java
@@ -30,6 +30,10 @@ class JsqlParserCountOptimizeTest {
         assertThat(parser.parser(metaObject, "select * from user u LEFT JOIN role r ON r.id = u.role_id AND r.name = ? where u.xx = ?").getSql())
             .isEqualTo("SELECT COUNT(1) FROM user u LEFT JOIN role r ON r.id = u.role_id AND r.name = ? WHERE u.xx = ?");
 
+        /* join 表与 where 条件大小写不同的情况 */
+        assertThat(parser.parser(metaObject, "select * from user u LEFT JOIN role r ON r.id = u.role_id where R.NAME = ?").getSql())
+            .isEqualTo("SELECT COUNT(1) FROM user u LEFT JOIN role r ON r.id = u.role_id WHERE R.NAME = ?");
+
         assertThat(parser.parser(metaObject, "select * from user u LEFT JOIN role r ON r.id = u.role_id WHERE u.xax = ? AND r.cc = ? AND r.qq = ?").getSql())
             .isEqualTo("SELECT COUNT(1) FROM user u LEFT JOIN role r ON r.id = u.role_id WHERE u.xax = ? AND r.cc = ? AND r.qq = ?");
 


### PR DESCRIPTION
### 该Pull Request关联的Issue
暂无


### 修改描述
autoCountSql 中使用了 where 条件与 join 的表的字段进行比较，但字符串比较默认是区分大小写的，而 sql 查询多数情况下不区分大小写。



### 测试用例
```sql
select u.* from user u left join group g on u.group_id = g.group_id where G.GROUP_TYPE = 2
```
使用分页后join被优化掉。


### 修复效果的截屏
暂无

