### PR TITLE
* 增加tableinfo 和tableFieldInfo 序列化支持，用于扩展时候可以clone

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Constants.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Constants.java
@@ -15,13 +15,15 @@
  */
 package com.baomidou.mybatisplus.core.toolkit;
 
+import java.io.Serializable;
+
 /**
  * mybatis_plus 自用常量集中管理
  *
  * @author miemie
  * @since 2018-07-22
  */
-public interface Constants extends StringPool {
+public interface Constants extends StringPool, Serializable {
 
     /**
      * project name


### PR DESCRIPTION
### 该Pull Request关联的Issue

不是bug，功能性增强

### 修改描述

在扩展的时候，发现TableInfo和TableFieldInfo的对象复制很麻烦，如果继承Serializable，则调用对象clone方法很容易

### 测试用例

很简答的修改，没有错误哦

### 修复效果的截屏


