### PR TITLE
PostgreSqlQuery添加大写表名字段读取支持

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/PostgreSqlQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/PostgreSqlQuery.java
@@ -33,7 +33,7 @@ public class PostgreSqlQuery extends AbstractDbQuery {
     public String tableFieldsSql() {
         return "SELECT A.attname AS name,format_type (A.atttypid,A.atttypmod) AS type,col_description (A.attrelid,A.attnum) AS comment,\n" +
             "(CASE WHEN (SELECT COUNT (*) FROM pg_constraint AS PC WHERE A.attnum = PC.conkey[1] AND PC.contype = 'p') > 0 THEN 'PRI' ELSE '' END) AS key \n" +
-            "FROM pg_class AS C,pg_attribute AS A WHERE A.attrelid='%s'::regclass AND A.attrelid= C.oid AND A.attnum> 0 AND NOT A.attisdropped ORDER  BY A.attnum";
+            "FROM pg_class AS C,pg_attribute AS A WHERE A.attrelid='\"%s\"'::regclass AND A.attrelid= C.oid AND A.attnum> 0 AND NOT A.attisdropped ORDER  BY A.attnum";
     }
 
 


### PR DESCRIPTION
### 该Pull Request关联的Issue
无

### 修改描述
PostgreSql表名对大小写敏感，添加双引号支持大写表名字段读取。不添加引号语句中表名默认变成小写找不到相应资源。

### 测试用例
任意大写表名可进行测试，现有代码无法读取其中字段。

### 修复效果的截屏
TableName中为大写表名，生成的Entity中已经读取到相应字段

![Xnip2020-11-28_17-00-59](https://user-images.githubusercontent.com/3069117/100515423-1372d100-31b7-11eb-88b2-51a9840304ce.jpg)
