### PR TITLE
fix: 完善ServiceImpl泛型查找逻辑

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
@@ -80,11 +80,11 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
     }
 
     protected Class<T> currentMapperClass() {
-        return (Class<T>) ReflectionKit.getSuperClassGenericType(getClass(), 0);
+        return (Class<T>) ReflectionKit.getTargetSuperClassGenericType(getClass(), ServiceImpl.class, 0);
     }
 
     protected Class<T> currentModelClass() {
-        return (Class<T>) ReflectionKit.getSuperClassGenericType(getClass(), 1);
+        return (Class<T>) ReflectionKit.getTargetSuperClassGenericType(getClass(), ServiceImpl.class, 1);
     }
 
     /**

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/service/ServiceImplTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/service/ServiceImplTest.java
@@ -1,0 +1,50 @@
+package com.baomidou.mybatisplus.extension.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.toolkit.ReflectionKit;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+
+/**
+ * @author liuzhongbo
+ * date 2020/11/30
+ */
+public class ServiceImplTest {
+
+    private static class Entity {
+
+    }
+
+    private interface EntityMapper extends BaseMapper<Entity> {
+
+    }
+
+    private static class EntityService extends ServiceImpl<EntityMapper, Entity> implements IService<Entity> {
+
+    }
+
+    private static class ParameterizedSubEntityService<M, T> extends EntityService {
+
+    }
+
+    private static class SubParameterizedSubEntityService extends ParameterizedSubEntityService<Object, Integer> {
+
+    }
+
+    private static class SubEntityService extends EntityService {
+
+    }
+
+    @Test
+    void testGetTargetSuperClassGenericType() {
+        Assertions.assertSame(ReflectionKit.getTargetSuperClassGenericType(SubEntityService.class, ServiceImpl.class, 0), EntityMapper.class);
+        Assertions.assertSame(ReflectionKit.getTargetSuperClassGenericType(SubEntityService.class, ServiceImpl.class, 1), Entity.class);
+        Assertions.assertSame(ReflectionKit.getTargetSuperClassGenericType(EntityService.class, ServiceImpl.class, 0), EntityMapper.class);
+        Assertions.assertSame(ReflectionKit.getTargetSuperClassGenericType(EntityService.class, ServiceImpl.class, 1), Entity.class);
+        Assertions.assertSame(ReflectionKit.getTargetSuperClassGenericType(SubParameterizedSubEntityService.class, ServiceImpl.class, 0), EntityMapper.class);
+        Assertions.assertSame(ReflectionKit.getTargetSuperClassGenericType(SubParameterizedSubEntityService.class, ServiceImpl.class, 1), Entity.class);
+    }
+
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue
#1749 我不确定这个ISSUE是否是这个原因导致的，但是我自己使用的时候遇到了这个问题。
当实际Service不是直接从ServiceImpl继承而来时，就会找不到正确的泛型，进而找不到TableInfo

### 修改描述
原先ServiceImpl中获取mapperClass和entityClass是直接通过Class#getGenericSuperclass()方法，但实际上如果从实际使用的Service不是直接继承自ServiceImpl，就无法找到对应的泛型；
修改为：先找到目标类（ServiceImpl.class），对其子类调用getGenericSuperclass()方法，以保证获取到的泛型是ServiceImpl的泛型


### 测试用例
已添加测试用例ServiceImplTest.java

对于非直接继承自ServiceImpl的Service能够正确获取mapperClass和entityClass




