### PR TITLE
left join 是子查询，并且子查询中带有入参，这个时候分页就不要移除这个join 不然预编译设置参数会报错

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -306,6 +306,11 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
                         str = Optional.ofNullable(table.getAlias()).map(Alias::getName).orElse(table.getName()) + StringPool.DOT;
                     } else if (rightItem instanceof SubSelect) {
                         SubSelect subSelect = (SubSelect) rightItem;
+                        /* 如果 left join 是子查询，并且子查询里包含 ?(代表有入参) 或者 where 条件里包含使用 join 的表的字段作条件,就不移除 join */
+                        if (subSelect.toString().contains(StringPool.QUESTION_MARK)) {
+                            canRemoveJoin = false;
+                            break;
+                        }
                         str = subSelect.getAlias().getName() + StringPool.DOT;
                     }
                     // 不区分大小写


### PR DESCRIPTION
left join 是子查询，并且子查询中带有入参，这个时候分页就不要移除这个join 不然预编译设置参数会报错

### 该Pull Request关联的Issue



### 修改描述
left join 是子查询，并且子查询中带有入参，这个时候分页就不要移除这个join 不然预编译设置参数会报错


### 测试用例



### 修复效果的截屏


