### PR TITLE
优化KeyGenerator执行语句获取方式，支撑多数据源

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/KeySequence.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/KeySequence.java
@@ -15,7 +15,12 @@
  */
 package com.baomidou.mybatisplus.annotation;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * 序列主键策略
@@ -36,7 +41,13 @@ public @interface KeySequence {
     String value() default "";
 
     /**
+     * 数据库类型
+     */
+    DbType type() default DbType.OTHER;
+
+    /**
      * id的类型
+     *
      * @deprecated 3.1.2 自动匹配,无需指定
      */
     @Deprecated

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/incrementer/KeyGeneratorExecuteSqlRegistry.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/incrementer/KeyGeneratorExecuteSqlRegistry.java
@@ -1,0 +1,49 @@
+package com.baomidou.mybatisplus.core.incrementer;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import com.baomidou.mybatisplus.annotation.DbType;
+
+/**
+ * 数据库序列SQL模板注册
+ *
+ * @author micuncang
+ * @date 2021/1/9
+ */
+public class KeyGeneratorExecuteSqlRegistry {
+
+    private static final Map<DbType, String> KEY_GENERATOR_SQL_MAP = new EnumMap<>(DbType.class);
+
+    static {
+        // postgresql and children
+        KEY_GENERATOR_SQL_MAP.put(DbType.POSTGRE_SQL, "select nextval('%s')");
+        KEY_GENERATOR_SQL_MAP.put(DbType.H2, "select %s.nextval");
+        KEY_GENERATOR_SQL_MAP.put(DbType.KINGBASE_ES, "select nextval('%s')");
+        // oracle and children
+        KEY_GENERATOR_SQL_MAP.put(DbType.ORACLE, "SELECT %s.NEXTVAL FROM DUAL");
+        // other
+        KEY_GENERATOR_SQL_MAP.put(DbType.DB2, "values nextval for %s");
+    }
+
+    /**
+     * 按需注册数据库对应的序列SQL模板
+     *
+     * @param dbType     数据库类型
+     * @param executeSql 数据库序列SQL模板
+     */
+    public static void regist(DbType dbType, String executeSql) {
+        KEY_GENERATOR_SQL_MAP.put(dbType, executeSql);
+    }
+
+    /**
+     * 根据数据库类型获取序列SQL模板
+     *
+     * @param dbType 数据库类型
+     * @return 序列SQL模板
+     */
+    public static String getExecuteSql(DbType dbType) {
+        return KEY_GENERATOR_SQL_MAP.get(dbType);
+    }
+
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue
#3225

### 修改描述
添加KeyGeneratorExecuteSqlRegistry支持按照DbType动态获取默认sequence执行语句，用于支撑多类型数据源。


### 测试用例


### 修复效果的截屏


