### PR TITLE
Model中的log改为懒加载，降低大量创建Model时的资源消耗

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/activerecord/Model.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/activerecord/Model.java
@@ -47,7 +47,7 @@ public abstract class Model<T extends Model<?>> implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final transient Log log = LogFactory.getLog(getClass());
+    private transient Log log = null;
 
     /**
      * 插入（字段选择插入）
@@ -196,7 +196,7 @@ public abstract class Model<T extends Model<?>> implements Serializable {
      * @param queryWrapper 实体对象封装操作类（可以为 null）
      */
     public T selectOne(Wrapper<T> queryWrapper) {
-        return SqlHelper.getObject(log, selectList(queryWrapper));
+        return SqlHelper.getObject(getLog(), selectList(queryWrapper));
     }
 
     /**
@@ -281,5 +281,18 @@ public abstract class Model<T extends Model<?>> implements Serializable {
      */
     protected void closeSqlSession(SqlSession sqlSession) {
         SqlSessionUtils.closeSqlSession(sqlSession, GlobalConfigUtils.currentSessionFactory(getClass()));
+    }
+
+    /**
+     * 获取Log
+     *
+     * @return log对象
+     */
+    private Log getLog() {
+        if (log == null) {
+            log = LogFactory.getLog(getClass());
+        }
+
+        return log;
     }
 }


### PR DESCRIPTION
### 该Pull Request关联的Issue
#3262 



### 修改描述
Model中的log默认为空，在使用到log的地方通过调用`getLog()`方法获取log的实例，在`getLog()`方法中对log懒加载。

懒加载这里我没有进行严格的加锁、双重判空等防止重复创建的操作，因为这里即使重复创建log对象，带来的也只是极个别的对象浪费，影响不大，而且这里逻辑比较少，对业务代码的性能影响也少。

### 测试用例
依然使用 Issue #3262  中的Demo，把pom.xml中的Mybatis Plus版本改为修改后的最新版本，重新执行测试。期望是测试结果中创建对象的各种测试用例的性能相比之前有很大提升。


### 修复效果的截屏
![image](https://user-images.githubusercontent.com/8757243/104847701-b7a60800-591c-11eb-8cac-209f4285676c.png)


