### PR TITLE
自定义SQL使用customSqlSegment时，where条件支持指定表的别名

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
@@ -16,6 +16,7 @@
 package com.baomidou.mybatisplus.core.conditions;
 
 import com.baomidou.mybatisplus.core.toolkit.Assert;
+import com.baomidou.mybatisplus.core.toolkit.Constants;
 import com.baomidou.mybatisplus.core.toolkit.LambdaUtils;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import com.baomidou.mybatisplus.core.toolkit.support.ColumnCache;
@@ -60,7 +61,8 @@ public abstract class AbstractLambdaWrapper<T, Children extends AbstractLambdaWr
 
     protected String columnToString(SFunction<T, ?> column, boolean onlyColumn) {
         ColumnCache cache = getColumnCache(column);
-        return onlyColumn ? cache.getColumn() : cache.getColumnSelect();
+        String columnStr = onlyColumn ? cache.getColumn() : cache.getColumnSelect();
+        return alias != null ? alias + Constants.DOT + columnStr : columnStr;
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/Wrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/Wrapper.java
@@ -33,6 +33,8 @@ import java.util.Objects;
 @SuppressWarnings("all")
 public abstract class Wrapper<T> implements ISqlSegment {
 
+    protected String alias;
+
     /**
      * 实体对象（子类实现）
      *
@@ -87,6 +89,21 @@ public abstract class Wrapper<T> implements ISqlSegment {
         }
         return StringPool.EMPTY;
     }
+
+    /**
+     * 获取以wrapper中定义的where条件所等价的SQL片段
+     * （与getCustomSqlSegment方法作用相同，唯一的区别是可以指定where语句中条件的表别名）
+     * <p>
+     * 使用方法: `select xxx from table_a as a left join table_b as b on b.a_id = a.id` + ${ew.customSqlSegment("a")}
+     * <p>
+     */
+    public String customSqlSegment(String alias) {
+        this.alias = alias;
+        String sqlSegment = getCustomSqlSegment();
+        this.alias = null;
+        return sqlSegment;
+    }
+
 
     /**
      * 查询条件为空(包含entity)


### PR DESCRIPTION
### 该Pull Request关联的Issue
#3007 


### 修改描述

使用示例：
select a.name,b.name
from table_a as a
left join table_b as b on b.a_id = a.id 
${ew.customSqlSegment("a")}


### 测试用例
### 修复效果的截屏