### PR TITLE
获取type所实现的指定接口targetType的泛型类型信息

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractSqlInjector.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractSqlInjector.java
@@ -15,11 +15,14 @@
  */
 package com.baomidou.mybatisplus.core.injector;
 
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.mapper.Mapper;
 import com.baomidou.mybatisplus.core.metadata.TableInfo;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.core.toolkit.ArrayUtils;
 import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 import com.baomidou.mybatisplus.core.toolkit.GlobalConfigUtils;
+import com.baomidou.mybatisplus.core.toolkit.ReflectionKit;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
@@ -43,7 +46,7 @@ public abstract class AbstractSqlInjector implements ISqlInjector {
 
     @Override
     public void inspectInject(MapperBuilderAssistant builderAssistant, Class<?> mapperClass) {
-        Class<?> modelClass = extractModelClass(mapperClass);
+        Class<?> modelClass = ReflectionKit.getGenericInterfaces(mapperClass, Mapper.class, 0);
         if (modelClass != null) {
             String className = mapperClass.toString();
             Set<String> mapperRegistryCache = GlobalConfigUtils.getMapperRegistryCache(builderAssistant.getConfiguration());
@@ -78,6 +81,7 @@ public abstract class AbstractSqlInjector implements ISqlInjector {
      * @param mapperClass mapper 接口
      * @return mapper 泛型
      */
+    @Deprecated
     protected Class<?> extractModelClass(Class<?> mapperClass) {
         Type[] types = mapperClass.getGenericInterfaces();
         ParameterizedType target = null;

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKitTests.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKitTests.java
@@ -1,0 +1,21 @@
+package com.baomidou.mybatisplus.core.toolkit;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.mapper.Mapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author lichangfeng
+ * @since 2021-03-08
+ */
+public class ReflectionKitTests {
+    public static class MyEntity{}
+    public static interface Mapper1 extends BaseMapper<MyEntity>{}
+    public static interface Mapper2 extends Mapper1{}
+    @Test
+    void testGetGenericInterfaces() {
+        assertThat(ReflectionKit.getGenericInterfaces(Mapper2.class, Mapper.class, 0).equals(MyEntity.class));
+    }
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue

无

### 修改描述
AbstractSqlInjector中的extractModelClass方法只能获取当前类型继承/实现的第一个接口的第一个泛型类型。
 当自定义的mapper并不直接继承basemapper或mapper的时候（某些时候需要给不同的调用方不同的mapper等），
如：UserMapper1 extends UserMapper, UserMapper extends BaseMapper<User>,
现有的AbstractSqlInjector中的extractModelClass方法会有问题，所以重写一个更加通用的方法，并放到ReflectionKit下。



### 测试用例
```
public class ReflectionKitTests {
    public static class MyEntity{}
    public static interface Mapper1 extends BaseMapper<MyEntity>{}
    public static interface Mapper2 extends Mapper1{}
    @Test
    void testGetGenericInterfaces() {
        assertThat(ReflectionKit.getGenericInterfaces(Mapper2.class, Mapper.class, 0).equals(MyEntity.class));
    }
}
```


### 修复效果的截屏
无

