### PR TITLE
feat(auto-config): MybatisPlusAutoConfiguration 配置 Interceptor时支持对插件排序

### DIFF
--- a/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
+++ b/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
@@ -58,6 +58,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
@@ -168,6 +169,7 @@ public class MybatisPlusAutoConfiguration implements InitializingBean {
             factory.setConfigurationProperties(this.properties.getConfigurationProperties());
         }
         if (!ObjectUtils.isEmpty(this.interceptors)) {
+            AnnotationAwareOrderComparator.sort(this.interceptors);
             factory.setPlugins(this.interceptors);
         }
         if (this.databaseIdProvider != null) {


### PR DESCRIPTION
### 修改描述

自动装配`Interceptor`时未遵循Spring 排序”姿势“（使用`@Order`或实现`Ordered`接口），有些场景会依赖`Interceptor`的执行顺序，如期望在`PaginationInterceptor`执行后获取重写完成色`SQL`和参数


