### PR TITLE
减少分页的count 查询

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptor.java
@@ -15,23 +15,34 @@
  */
 package com.baomidou.mybatisplus.extension.plugins;
 
-import com.baomidou.mybatisplus.core.toolkit.ClassUtils;
-import com.baomidou.mybatisplus.core.toolkit.StringPool;
-import com.baomidou.mybatisplus.extension.plugins.inner.InnerInterceptor;
-import com.baomidou.mybatisplus.extension.toolkit.PropertyMapper;
-import lombok.Setter;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.statement.StatementHandler;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.mapping.SqlCommandType;
-import org.apache.ibatis.plugin.*;
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.plugin.Intercepts;
+import org.apache.ibatis.plugin.Invocation;
+import org.apache.ibatis.plugin.Plugin;
+import org.apache.ibatis.plugin.Signature;
 import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
 
-import java.sql.Connection;
-import java.util.*;
+import com.baomidou.mybatisplus.core.toolkit.ClassUtils;
+import com.baomidou.mybatisplus.core.toolkit.StringPool;
+import com.baomidou.mybatisplus.extension.plugins.inner.InnerInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.inner.InnerPostProcessor;
+import com.baomidou.mybatisplus.extension.toolkit.PropertyMapper;
+
+import lombok.Setter;
 
 /**
  * @author miemie
@@ -51,6 +62,9 @@ public class MybatisPlusInterceptor implements Interceptor {
 
     @Setter
     private List<InnerInterceptor> interceptors = new ArrayList<>();
+
+    @Setter
+    private List<InnerPostProcessor> postProcessors = new ArrayList<>();
 
     @Override
     public Object intercept(Invocation invocation) throws Throwable {
@@ -114,12 +128,22 @@ public class MybatisPlusInterceptor implements Interceptor {
         return target;
     }
 
-    public void addInnerInterceptor(InnerInterceptor innerInterceptor) {
+    public MybatisPlusInterceptor addInnerInterceptor(InnerInterceptor innerInterceptor) {
         this.interceptors.add(innerInterceptor);
+        return this;
+    }
+
+    public MybatisPlusInterceptor addInnerPostProcessor(InnerPostProcessor innerPostProcessor) {
+        this.postProcessors.add(innerPostProcessor);
+        return this;
     }
 
     public List<InnerInterceptor> getInterceptors() {
         return Collections.unmodifiableList(interceptors);
+    }
+
+    public List<InnerPostProcessor> getPostProcessor() {
+        return Collections.unmodifiableList(postProcessors);
     }
 
     /**

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/InnerPostProcessor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/InnerPostProcessor.java
@@ -1,0 +1,24 @@
+package com.baomidou.mybatisplus.extension.plugins.inner;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+
+/**
+ * 后置处理器，可以扩展手机号，身份证 脱敏
+ * @author liyabin
+ * @date 2021/3/10
+ */
+public interface InnerPostProcessor {
+
+    <E> boolean postProcessorBefore(List<E> dataList, Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, CacheKey cacheKey, BoundSql boundSql);
+
+    <E> List<E> postProcessorAfter(List<E> dataList, Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, CacheKey cacheKey, BoundSql boundSql) throws SQLException;
+
+}

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerExtInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerExtInterceptor.java
@@ -1,0 +1,99 @@
+package com.baomidou.mybatisplus.extension.plugins.inner;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+
+import com.baomidou.mybatisplus.annotation.DbType;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.toolkit.ParameterUtils;
+import com.baomidou.mybatisplus.extension.plugins.pagination.dialects.IDialect;
+
+/**
+ * @author liyabin
+ * @date 2021/3/10
+ */
+public class PaginationInnerExtInterceptor extends PaginationInnerInterceptor implements InnerPostProcessor {
+
+    private boolean directSelect;
+
+    public PaginationInnerExtInterceptor(DbType dbType) {
+        super(dbType);
+    }
+
+    public PaginationInnerExtInterceptor(IDialect dialect) {
+        super(dialect);
+    }
+
+    public PaginationInnerExtInterceptor(IDialect dialect, boolean directSelect) {
+        super(dialect);
+        this.directSelect = directSelect;
+    }
+
+    public PaginationInnerExtInterceptor(DbType dbType, boolean directSelect) {
+        super(dbType);
+        this.directSelect = directSelect;
+    }
+
+    /**
+     * 如果directSelect 为true 那么直接使用父类方法
+     */
+    @Override
+    public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+        return !directSelect || super.willDoQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
+    }
+
+    @Override
+    public <E> boolean postProcessorBefore(List<E> dataList, Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, CacheKey cacheKey, BoundSql boundSql) {
+        return !directSelect;
+    }
+
+    @Override
+    public <E> List<E> postProcessorAfter(List<E> dataList, Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, CacheKey cacheKey, BoundSql boundSql) throws SQLException {
+        IPage<?> page = ParameterUtils.findPage(parameter).orElse(null);
+        if (page == null || page.getSize() < 0 || !page.isSearchCount()) {
+            return dataList;
+        }
+        long dataSize = Optional.ofNullable(dataList).map(List::size).orElse(0);
+        long total;
+        // 如果查询出来的数据集小于 pageSize ,这个时候total 可以利用数学方法计算得出
+        if (dataSize < page.getSize() && dataSize > 0) {
+            total = (page.getCurrent() - 1) * page.getSize() + dataSize;
+        } else if (dataSize == 0 && page.getCurrent() == 1) {
+            // 这表示这条SQL结果就是空
+            total = 0;
+        } else {
+            // 这个时候才应该查DB库
+            total = getTotal(page, executor, ms, parameter, rowBounds, resultHandler, boundSql);
+            // 只是最坏的情况，溢出总数而且配置溢出默认查第一页的情况
+            if (dataSize == 0 && continuePage(page)) {
+                dataList = executor.query(ms, parameter, rowBounds, resultHandler, cacheKey, boundSql);
+            }
+        }
+        page.setTotal(total);
+
+        return dataList;
+    }
+
+    /**
+     * count 查询之后,是否继续执行分页
+     *
+     * @param page 分页对象
+     * @return 是否
+     */
+    @Override
+    protected boolean continuePage(IPage<?> page) {
+        if (!overflow || page.getCurrent() <= page.getPages()) {
+            return false;
+        }
+        handlerOverflow(page);
+        return true;
+    }
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述

【最后一页不需要count】
1、发现分页组件中原本可以不需要执行count 的sql语句执行了count。这在大表中表现是令人沮丧。把语句执行时间拉长了一倍。通常大表查询业务人员通常会通过加查询条件实现，尽可能的一览无遗而这个时候就会这个等式时常能适用。
如果查询的结果集  dataSize < pageSize。此时的应有数学公式total = (currentPage-1)*pageSize + dataSize;
【拓展列表查询后对返回数据的拓展】
2、现在公司对信息安全要求越来越高。通常要求列表页面手机号，身份证等敏感信息脱敏，通过详情页查看明细是得到具体的数据，因此对分页插件进行拓展。由于1是建立在二的基础上所以对MybatisPlusInterceptor 执行流程做出局部调整。

### 测试用例
修改之前
![image](https://user-images.githubusercontent.com/22710200/110639657-ee94ed80-81ea-11eb-8793-13f0ec4196be.png)
修改之后
![image](https://user-images.githubusercontent.com/22710200/110639625-e8067600-81ea-11eb-86d9-32f47666d6c5.png)

### 修复效果的截屏
