### PR TITLE
automatically removes invalid in/notIn sql segments

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
@@ -268,22 +268,23 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
 
     @Override
     public Children in(boolean condition, R column, Collection<?> coll) {
-        return doIt(condition, () -> columnToString(column), IN, inExpression(coll));
+        return doIt(condition && CollectionUtils.isNotEmpty(coll), () -> columnToString(column), IN, inExpression(coll));
     }
 
     @Override
     public Children notIn(boolean condition, R column, Collection<?> coll) {
-        return not(condition).in(condition, column, coll);
+        return not(condition && CollectionUtils.isNotEmpty(coll)).in(condition, column, coll);
     }
 
     @Override
     public Children inSql(boolean condition, R column, String inValue) {
-        return doIt(condition, () -> columnToString(column), IN, () -> String.format("(%s)", inValue));
+        return doIt(condition && StringUtils.isNotBlank(inValue),
+            () -> columnToString(column), IN, () -> String.format("(%s)", inValue));
     }
 
     @Override
     public Children notInSql(boolean condition, R column, String inValue) {
-        return not(condition).inSql(condition, column, inValue);
+        return not(condition && StringUtils.isNotBlank(inValue)).inSql(condition, column, inValue);
     }
 
     @Override

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/test/WrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/test/WrapperTest.java
@@ -214,10 +214,16 @@ class WrapperTest {
 
     @Test
     void testInEmptyColl() {
-        QueryWrapper<User> queryWrapper = new QueryWrapper<User>().in("xxx", Collections.emptyList());
-        logSqlSegment("测试 empty 的 coll", queryWrapper, "(xxx IN ())");
+        // 当用户输入在 in/notIn 的条件过滤中输入了一个空list，会导致sql查询为空，这不太符合用户预期，我们应该直接将空list这个条件去掉
+        QueryWrapper<User> queryWrapper = new QueryWrapper<User>().in("xxx", Collections.emptyList())
+            .notIn("ttt",Collections.emptyList());
+        logSqlSegment("测试 empty 的 coll", queryWrapper, "");
+        QueryWrapper<User> queryWrapper1 = new QueryWrapper<User>().inSql("xxx", "")
+            .notInSql("ttt","");
+        logSqlSegment("测试 blank string sql", queryWrapper, "");
     }
 
+    @Test
     private List<Object> getList() {
         List<Object> list = new ArrayList<>();
         for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
…the SQL to behave abnormally

### 该Pull Request关联的Issue
Fixes #3478 

### 修改描述
当用户在 in(), notIn() 中输入了空list , inSql(), notInSql()中输入了空串，直接忽略这条filter 


### 测试用例



### 修复效果的截屏
![image](https://user-images.githubusercontent.com/42334988/117823792-70af9a00-b2a0-11eb-9d8c-6505211e2a7d.png)


