### PR TITLE
fixed: columnMap 空指针的问题

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
@@ -74,7 +74,9 @@ public abstract class AbstractLambdaWrapper<T, Children extends AbstractLambdaWr
     protected ColumnCache getColumnCache(SFunction<T, ?> column) {
         LambdaMeta lambda = LambdaUtils.extract(column);
         String fileName = PropertyNamer.methodToProperty(lambda.getImplMethodName());
-        return getColumnCache(fileName, lambda.getInstantiatedClass());
+        Class<?> instantiatedClass = lambda.getInstantiatedClass();
+        tryInitCache(instantiatedClass);
+        return getColumnCache(fileName, instantiatedClass);
     }
 
     private void tryInitCache(Class<?> lambdaClass) {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
@@ -42,11 +42,6 @@ public abstract class AbstractLambdaWrapper<T, Children extends AbstractLambdaWr
     private Map<String, ColumnCache> columnMap = null;
     private boolean initColumnMap = false;
 
-    @SuppressWarnings("unchecked")
-    @Override
-    protected String columnsToString(SFunction<T, ?>... columns) {
-        return columnsToString(true, columns);
-    }
 
     @SuppressWarnings("unchecked")
     protected String columnsToString(boolean onlyColumn, SFunction<T, ?>... columns) {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
@@ -140,64 +140,64 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
     }
 
     @Override
-    public Children eq(boolean condition, R column, Object val) {
-        return addCondition(condition, column, EQ, val);
+    public Children eq(boolean condition, String alias, R column, Object val) {
+        return addCondition(condition, alias, column, EQ, val);
     }
 
     @Override
-    public Children ne(boolean condition, R column, Object val) {
-        return addCondition(condition, column, NE, val);
+    public Children ne(boolean condition, String alias, R column, Object val) {
+        return addCondition(condition, alias, column, NE, val);
     }
 
     @Override
-    public Children gt(boolean condition, R column, Object val) {
-        return addCondition(condition, column, GT, val);
+    public Children gt(boolean condition, String alias, R column, Object val) {
+        return addCondition(condition, alias, column, GT, val);
     }
 
     @Override
-    public Children ge(boolean condition, R column, Object val) {
-        return addCondition(condition, column, GE, val);
+    public Children ge(boolean condition, String alias, R column, Object val) {
+        return addCondition(condition, alias, column, GE, val);
     }
 
     @Override
-    public Children lt(boolean condition, R column, Object val) {
-        return addCondition(condition, column, LT, val);
+    public Children lt(boolean condition, String alias, R column, Object val) {
+        return addCondition(condition, alias, column, LT, val);
     }
 
     @Override
-    public Children le(boolean condition, R column, Object val) {
-        return addCondition(condition, column, LE, val);
+    public Children le(boolean condition, String alias, R column, Object val) {
+        return addCondition(condition, alias, column, LE, val);
     }
 
     @Override
-    public Children like(boolean condition, R column, Object val) {
-        return likeValue(condition, LIKE, column, val, SqlLike.DEFAULT);
+    public Children like(boolean condition, String alias, R column, Object val) {
+        return likeValue(condition, LIKE, alias, column, val, SqlLike.DEFAULT);
     }
 
     @Override
-    public Children notLike(boolean condition, R column, Object val) {
-        return likeValue(condition, NOT_LIKE, column, val, SqlLike.DEFAULT);
+    public Children notLike(boolean condition, String alias, R column, Object val) {
+        return likeValue(condition, NOT_LIKE, alias, column, val, SqlLike.DEFAULT);
     }
 
     @Override
-    public Children likeLeft(boolean condition, R column, Object val) {
-        return likeValue(condition, LIKE, column, val, SqlLike.LEFT);
+    public Children likeLeft(boolean condition, String alias, R column, Object val) {
+        return likeValue(condition, LIKE, alias, column, val, SqlLike.LEFT);
     }
 
     @Override
-    public Children likeRight(boolean condition, R column, Object val) {
-        return likeValue(condition, LIKE, column, val, SqlLike.RIGHT);
+    public Children likeRight(boolean condition, String alias, R column, Object val) {
+        return likeValue(condition, LIKE, alias, column, val, SqlLike.RIGHT);
     }
 
     @Override
-    public Children between(boolean condition, R column, Object val1, Object val2) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), BETWEEN,
+    public Children between(boolean condition, String alias, R column, Object val1, Object val2) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), BETWEEN,
             () -> formatParam(null, val1), AND, () -> formatParam(null, val2)));
     }
 
     @Override
-    public Children notBetween(boolean condition, R column, Object val1, Object val2) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), NOT_BETWEEN,
+    public Children notBetween(boolean condition, String alias, R column, Object val1, Object val2) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), NOT_BETWEEN,
             () -> formatParam(null, val1), AND, () -> formatParam(null, val2)));
     }
 
@@ -268,53 +268,53 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
     }
 
     @Override
-    public Children isNull(boolean condition, R column) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), IS_NULL));
+    public Children isNull(boolean condition, String alias, R column) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), IS_NULL));
     }
 
     @Override
-    public Children isNotNull(boolean condition, R column) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), IS_NOT_NULL));
+    public Children isNotNull(boolean condition, String alias, R column) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), IS_NOT_NULL));
     }
 
     @Override
-    public Children in(boolean condition, R column, Collection<?> coll) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), IN, inExpression(coll)));
+    public Children in(boolean condition, String alias, R column, Collection<?> coll) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), IN, inExpression(coll)));
     }
 
     @Override
-    public Children in(boolean condition, R column, Object... values) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), IN, inExpression(values)));
+    public Children in(boolean condition, String alias, R column, Object... values) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), IN, inExpression(values)));
     }
 
     @Override
-    public Children notIn(boolean condition, R column, Collection<?> coll) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), NOT_IN, inExpression(coll)));
+    public Children notIn(boolean condition, String alias, R column, Collection<?> coll) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), NOT_IN, inExpression(coll)));
     }
 
     @Override
-    public Children notIn(boolean condition, R column, Object... values) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), NOT_IN, inExpression(values)));
+    public Children notIn(boolean condition, String alias, R column, Object... values) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), NOT_IN, inExpression(values)));
     }
 
     @Override
-    public Children inSql(boolean condition, R column, String inValue) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), IN,
+    public Children inSql(boolean condition, String alias, R column, String inValue) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), IN,
             () -> String.format("(%s)", inValue)));
     }
 
     @Override
-    public Children notInSql(boolean condition, R column, String inValue) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), NOT_IN,
+    public Children notInSql(boolean condition, String alias, R column, String inValue) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), NOT_IN,
             () -> String.format("(%s)", inValue)));
     }
 
     @Override
-    public Children groupBy(boolean condition, R column, R... columns) {
+    public Children groupBy(boolean condition, String alias, R column, R... columns) {
         return maybeDo(condition, () -> {
-            String one = columnToString(column);
+            String one = columnToSqlSegment(alias, column).getSqlSegment();
             if (ArrayUtils.isNotEmpty(columns)) {
-                one += (StringPool.COMMA + columnsToString(columns));
+                one += (StringPool.COMMA + columnsToString(alias, columns));
             }
             final String finalOne = one;
             appendSqlSegments(GROUP_BY, () -> finalOne);
@@ -322,13 +322,13 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
     }
 
     @Override
-    public Children orderBy(boolean condition, boolean isAsc, R column, R... columns) {
+    public Children orderBy(boolean condition, boolean isAsc, String alias, R column, R... columns) {
         return maybeDo(condition, () -> {
             final SqlKeyword mode = isAsc ? ASC : DESC;
-            appendSqlSegments(ORDER_BY, columnToSqlSegment(column), mode);
+            appendSqlSegments(ORDER_BY, columnToSqlSegment(alias, column), mode);
             if (ArrayUtils.isNotEmpty(columns)) {
                 Arrays.stream(columns).forEach(c -> appendSqlSegments(ORDER_BY,
-                    columnToSqlSegment(columnSqlInjectFilter(c)), mode));
+                    columnToSqlSegment(alias, columnSqlInjectFilter(c)), mode));
             }
         });
     }
@@ -374,8 +374,8 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
      * 内部自用
      * <p>拼接 LIKE 以及 值</p>
      */
-    protected Children likeValue(boolean condition, SqlKeyword keyword, R column, Object val, SqlLike sqlLike) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), keyword,
+    protected Children likeValue(boolean condition, SqlKeyword keyword, String alias, R column, Object val, SqlLike sqlLike) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), keyword,
             () -> formatParam(null, SqlUtils.concatLike(val, sqlLike))));
     }
 
@@ -387,9 +387,8 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
      * @param sqlKeyword SQL 关键词
      * @param val        条件值
      */
-    protected Children addCondition(boolean condition, R column, SqlKeyword sqlKeyword, Object val) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), sqlKeyword,
-            () -> formatParam(null, val)));
+    protected Children addCondition(boolean condition, String alias, R column, SqlKeyword sqlKeyword, Object val) {
+        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(alias, column), sqlKeyword, () -> formatParam(null, val)));
     }
 
     /**
@@ -570,9 +569,20 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
 
     /**
      * 获取 columnName
+     *
+     * @param alias 别名
+     * @param column 列
+     *
+     * @return columnName
      */
-    protected final ISqlSegment columnToSqlSegment(R column) {
-        return () -> columnToString(column);
+    protected final ISqlSegment columnToSqlSegment(String alias, R column) {
+        return () ->{
+            String columnName = columnToString(column);
+            if(!StringUtils.isBlank(alias)){
+                return alias +  StringPool.DOT +  columnName;
+            }
+            return columnName;
+        };
     }
 
     /**
@@ -585,10 +595,11 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
     /**
      * 多字段转换为逗号 "," 分割字符串
      *
+     * @param alias 别名
      * @param columns 多字段
      */
-    protected String columnsToString(R... columns) {
-        return Arrays.stream(columns).map(this::columnToString).collect(joining(StringPool.COMMA));
+    private String columnsToString(String alias, R... columns) {
+        return Arrays.stream(columns).map(column->columnToSqlSegment(alias, column).getSqlSegment()).collect(joining(StringPool.COMMA));
     }
 
     @Override

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
@@ -81,196 +81,292 @@ public interface Compare<Children, R> extends Serializable {
      * ignore
      */
     default Children eq(R column, Object val) {
-        return eq(true, column, val);
+        return eq(true, "", column, val);
+    }
+
+    /**
+     * ignore
+     */
+    default Children eq(String alias, R column, Object val) {
+        return eq(true, alias, column, val);
     }
 
     /**
      * 等于 =
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val       值
      * @return children
      */
-    Children eq(boolean condition, R column, Object val);
+    Children eq(boolean condition, String alias, R column, Object val);
 
     /**
      * ignore
      */
     default Children ne(R column, Object val) {
-        return ne(true, column, val);
+        return ne(true, "", column, val);
+    }
+
+    /**
+     * ignore
+     */
+    default Children ne(String alias, R column, Object val) {
+        return ne(true, alias, column, val);
     }
 
     /**
      * 不等于 &lt;&gt;
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val       值
      * @return children
      */
-    Children ne(boolean condition, R column, Object val);
+    Children ne(boolean condition, String alias, R column, Object val);
 
     /**
      * ignore
      */
     default Children gt(R column, Object val) {
-        return gt(true, column, val);
+        return gt(true, "", column, val);
+    }
+
+    /**
+     * ignore
+     */
+    default Children gt(String alias, R column, Object val) {
+        return gt(true, alias, column, val);
     }
 
     /**
      * 大于 &gt;
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val       值
      * @return children
      */
-    Children gt(boolean condition, R column, Object val);
+    Children gt(boolean condition, String alias, R column, Object val);
 
     /**
      * ignore
      */
     default Children ge(R column, Object val) {
-        return ge(true, column, val);
+        return ge(true, "", column, val);
+    }
+
+    /**
+     * ignore
+     */
+    default Children ge(String alias, R column, Object val) {
+        return ge(true, alias, column, val);
     }
 
     /**
      * 大于等于 &gt;=
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val       值
      * @return children
      */
-    Children ge(boolean condition, R column, Object val);
+    Children ge(boolean condition, String alias, R column, Object val);
 
     /**
      * ignore
      */
     default Children lt(R column, Object val) {
-        return lt(true, column, val);
+        return lt(true, "", column, val);
+    }
+
+    /**
+     * ignore
+     */
+    default Children lt(String alias, R column, Object val) {
+        return lt(true, alias, column, val);
     }
 
     /**
      * 小于 &lt;
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val       值
      * @return children
      */
-    Children lt(boolean condition, R column, Object val);
+    Children lt(boolean condition, String alias, R column, Object val);
 
     /**
      * ignore
      */
     default Children le(R column, Object val) {
-        return le(true, column, val);
+        return le(true, "", column, val);
+    }
+
+    /**
+     * ignore
+     */
+    default Children le(String alias, R column, Object val) {
+        return le(true, alias, column, val);
     }
 
     /**
      * 小于等于 &lt;=
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val       值
      * @return children
      */
-    Children le(boolean condition, R column, Object val);
+    Children le(boolean condition, String alias, R column, Object val);
 
     /**
      * ignore
      */
     default Children between(R column, Object val1, Object val2) {
-        return between(true, column, val1, val2);
+        return between(true, "", column, val1, val2);
+    }
+
+    /**
+     * ignore
+     */
+    default Children between(String alias, R column, Object val1, Object val2) {
+        return between(true, alias, column, val1, val2);
     }
 
     /**
      * BETWEEN 值1 AND 值2
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val1      值1
      * @param val2      值2
      * @return children
      */
-    Children between(boolean condition, R column, Object val1, Object val2);
+    Children between(boolean condition, String alias, R column, Object val1, Object val2);
 
     /**
      * ignore
      */
     default Children notBetween(R column, Object val1, Object val2) {
-        return notBetween(true, column, val1, val2);
+        return notBetween(true, "", column, val1, val2);
+    }
+
+    /**
+     * ignore
+     */
+    default Children notBetween(String alias, R column, Object val1, Object val2) {
+        return notBetween(true, alias, column, val1, val2);
     }
 
     /**
      * NOT BETWEEN 值1 AND 值2
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val1      值1
      * @param val2      值2
      * @return children
      */
-    Children notBetween(boolean condition, R column, Object val1, Object val2);
+    Children notBetween(boolean condition, String alias, R column, Object val1, Object val2);
 
     /**
      * ignore
      */
     default Children like(R column, Object val) {
-        return like(true, column, val);
+        return like(true, "", column, val);
+    }
+
+    /**
+     * ignore
+     */
+    default Children like(String alias, R column, Object val) {
+        return like(true, alias, column, val);
     }
 
     /**
      * LIKE '%值%'
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val       值
      * @return children
      */
-    Children like(boolean condition, R column, Object val);
+    Children like(boolean condition, String alias, R column, Object val);
 
     /**
      * ignore
      */
     default Children notLike(R column, Object val) {
-        return notLike(true, column, val);
+        return notLike(true, "", column, val);
     }
+
+    /**
+     * ignore
+     */
+    default Children notLike(String alias, R column, Object val) {
+        return notLike(true, alias, column, val);
+    }
+
 
     /**
      * NOT LIKE '%值%'
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val       值
      * @return children
      */
-    Children notLike(boolean condition, R column, Object val);
+    Children notLike(boolean condition, String alias, R column, Object val);
 
     /**
      * ignore
      */
     default Children likeLeft(R column, Object val) {
-        return likeLeft(true, column, val);
+        return likeLeft(true, "", column, val);
+    }
+
+    /**
+     * ignore
+     */
+    default Children likeLeft(String alias, R column, Object val) {
+        return likeLeft(true, alias, column, val);
     }
 
     /**
      * LIKE '%值'
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param val       值
      * @return children
      */
-    Children likeLeft(boolean condition, R column, Object val);
+    Children likeLeft(boolean condition, String alias, R column, Object val);
 
     /**
      * ignore
      */
     default Children likeRight(R column, Object val) {
-        return likeRight(true, column, val);
+        return likeRight(true, "", column, val);
+    }
+
+    /**
+     * ignore
+     */
+    default Children likeRight(String alias, R column, Object val) {
+        return likeRight(true, alias, column, val);
     }
 
     /**
@@ -281,5 +377,5 @@ public interface Compare<Children, R> extends Serializable {
      * @param val       值
      * @return children
      */
-    Children likeRight(boolean condition, R column, Object val);
+    Children likeRight(boolean condition, String alias, R column, Object val);
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
@@ -32,7 +32,14 @@ public interface Func<Children, R> extends Serializable {
      * ignore
      */
     default Children isNull(R column) {
-        return isNull(true, column);
+        return isNull(true, "", column);
+    }
+
+    /**
+     * ignore
+     */
+    default Children isNull(String alias, R column) {
+        return isNull(true, alias, column);
     }
 
     /**
@@ -40,16 +47,24 @@ public interface Func<Children, R> extends Serializable {
      * <p>例: isNull("name")</p>
      *
      * @param condition 执行条件
+     * @param alias     别名
      * @param column    字段
      * @return children
      */
-    Children isNull(boolean condition, R column);
+    Children isNull(boolean condition, String alias, R column);
 
     /**
      * ignore
      */
     default Children isNotNull(R column) {
-        return isNotNull(true, column);
+        return isNotNull(true, "", column);
+    }
+
+    /**
+     * ignore
+     */
+    default Children isNotNull(String alias, R column) {
+        return isNotNull(true, alias, column);
     }
 
     /**
@@ -60,13 +75,20 @@ public interface Func<Children, R> extends Serializable {
      * @param column    字段
      * @return children
      */
-    Children isNotNull(boolean condition, R column);
+    Children isNotNull(boolean condition, String alias, R column);
 
     /**
      * ignore
      */
     default Children in(R column, Collection<?> coll) {
-        return in(true, column, coll);
+        return in(true, "", column, coll);
+    }
+
+    /**
+     * ignore
+     */
+    default Children in(String alias, R column, Collection<?> coll) {
+        return in(true, alias, column, coll);
     }
 
     /**
@@ -77,17 +99,25 @@ public interface Func<Children, R> extends Serializable {
      * <li> 如果集合为 empty 则不会进行 sql 拼接 </li>
      *
      * @param condition 执行条件
+     * @param alias     别名
      * @param column    字段
      * @param coll      数据集合
      * @return children
      */
-    Children in(boolean condition, R column, Collection<?> coll);
+    Children in(boolean condition, String alias, R column, Collection<?> coll);
 
     /**
      * ignore
      */
     default Children in(R column, Object... values) {
-        return in(true, column, values);
+        return in(true, "", column, values);
+    }
+
+    /**
+     * ignore
+     */
+    default Children in(String alias, R column, Object... values) {
+        return in(true, alias, column, values);
     }
 
     /**
@@ -98,17 +128,25 @@ public interface Func<Children, R> extends Serializable {
      * <li> 如果动态数组为 empty 则不会进行 sql 拼接 </li>
      *
      * @param condition 执行条件
+     * @param alias     别名
      * @param column    字段
      * @param values    数据数组
      * @return children
      */
-    Children in(boolean condition, R column, Object... values);
+    Children in(boolean condition, String alias, R column, Object... values);
 
     /**
      * ignore
      */
     default Children notIn(R column, Collection<?> coll) {
-        return notIn(true, column, coll);
+        return notIn(true, "", column, coll);
+    }
+
+    /**
+     * ignore
+     */
+    default Children notIn(String alias, R column, Collection<?> coll) {
+        return notIn(true, alias, column, coll);
     }
 
     /**
@@ -116,17 +154,25 @@ public interface Func<Children, R> extends Serializable {
      * <p>例: notIn("id", Arrays.asList(1, 2, 3, 4, 5))</p>
      *
      * @param condition 执行条件
+     * @param alias     别名
      * @param column    字段
      * @param coll      数据集合
      * @return children
      */
-    Children notIn(boolean condition, R column, Collection<?> coll);
+    Children notIn(boolean condition, String alias, R column, Collection<?> coll);
 
     /**
      * ignore
      */
     default Children notIn(R column, Object... value) {
-        return notIn(true, column, value);
+        return notIn(true, "", column, value);
+    }
+
+    /**
+     * ignore
+     */
+    default Children notIn(String alias, R column, Object... value) {
+        return notIn(true, alias, column, value);
     }
 
     /**
@@ -134,17 +180,25 @@ public interface Func<Children, R> extends Serializable {
      * <p>例: notIn("id", 1, 2, 3, 4, 5)</p>
      *
      * @param condition 执行条件
+     * @param alias     别名
      * @param column    字段
      * @param values    数据数组
      * @return children
      */
-    Children notIn(boolean condition, R column, Object... values);
+    Children notIn(boolean condition, String alias, R column, Object... values);
 
     /**
      * ignore
      */
     default Children inSql(R column, String inValue) {
-        return inSql(true, column, inValue);
+        return inSql(true, "", column, inValue);
+    }
+
+    /**
+     * ignore
+     */
+    default Children inSql(String alias, R column, String inValue) {
+        return inSql(true, alias, column, inValue);
     }
 
     /**
@@ -154,17 +208,25 @@ public interface Func<Children, R> extends Serializable {
      * <p>例2: inSql("id", "select id from table where id &lt; 3")</p>
      *
      * @param condition 执行条件
+     * @param alias     别名
      * @param column    字段
      * @param inValue   sql语句
      * @return children
      */
-    Children inSql(boolean condition, R column, String inValue);
+    Children inSql(boolean condition, String alias, R column, String inValue);
 
     /**
      * ignore
      */
     default Children notInSql(R column, String inValue) {
-        return notInSql(true, column, inValue);
+        return notInSql(true, "", column, inValue);
+    }
+
+    /**
+     * ignore
+     */
+    default Children notInSql(String alias, R column, String inValue) {
+        return notInSql(true, alias, column, inValue);
     }
 
     /**
@@ -174,17 +236,25 @@ public interface Func<Children, R> extends Serializable {
      * <p>例2: notInSql("id", "select id from table where id &lt; 3")</p>
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    字段
      * @param inValue   sql语句 ---&gt; 1,2,3,4,5,6 或者 select id from table where id &lt; 3
      * @return children
      */
-    Children notInSql(boolean condition, R column, String inValue);
+    Children notInSql(boolean condition, String alias, R column, String inValue);
 
     /**
      * ignore
      */
     default Children groupBy(R column, R... columns) {
-        return groupBy(true, column, columns);
+        return groupBy(true, "", column, columns);
+    }
+
+    /**
+     * ignore
+     */
+    default Children groupByWithAlias(String alias, R column, R... columns) {
+        return groupBy(true, alias, column, columns);
     }
 
     /**
@@ -192,17 +262,25 @@ public interface Func<Children, R> extends Serializable {
      * <p>例: groupBy("id", "name")</p>
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    单个字段
      * @param columns   字段数组
      * @return children
      */
-    Children groupBy(boolean condition, R column, R... columns);
+    Children groupBy(boolean condition, String alias, R column, R... columns);
 
     /**
      * ignore
      */
     default Children orderByAsc(R column, R... columns) {
-        return orderByAsc(true, column, columns);
+        return orderByAsc(true, "", column, columns);
+    }
+
+    /**
+     * ignore
+     */
+    default Children orderByAscWithAlias(String alias, R column, R... columns) {
+        return orderByAsc(true, alias, column, columns);
     }
 
     /**
@@ -210,19 +288,27 @@ public interface Func<Children, R> extends Serializable {
      * <p>例: orderByAsc("id", "name")</p>
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    单个字段
      * @param columns   字段数组
      * @return children
      */
-    default Children orderByAsc(boolean condition, R column, R... columns) {
-        return orderBy(condition, true, column, columns);
+    default Children orderByAsc(boolean condition, String alias, R column, R... columns) {
+        return orderBy(condition, true, alias, column, columns);
     }
 
     /**
      * ignore
      */
     default Children orderByDesc(R column, R... columns) {
-        return orderByDesc(true, column, columns);
+        return orderByDesc(true, "", column, columns);
+    }
+
+    /**
+     * ignore
+     */
+    default Children orderByDescWithAlias(String alias, R column, R... columns) {
+        return orderByDesc(true, alias, column, columns);
     }
 
     /**
@@ -230,12 +316,13 @@ public interface Func<Children, R> extends Serializable {
      * <p>例: orderByDesc("id", "name")</p>
      *
      * @param condition 执行条件
+     * @param alias 别名
      * @param column    单个字段
      * @param columns   字段数组
      * @return children
      */
-    default Children orderByDesc(boolean condition, R column, R... columns) {
-        return orderBy(condition, false, column, columns);
+    default Children orderByDesc(boolean condition, String alias, R column, R... columns) {
+        return orderBy(condition, false, alias, column, columns);
     }
 
     /**
@@ -244,11 +331,12 @@ public interface Func<Children, R> extends Serializable {
      *
      * @param condition 执行条件
      * @param isAsc     是否是 ASC 排序
+     * @param alias 别名
      * @param column    单个字段
      * @param columns   字段数组
      * @return children
      */
-    Children orderBy(boolean condition, boolean isAsc, R column, R... columns);
+    Children orderBy(boolean condition, boolean isAsc, String alias, R column, R... columns);
 
     /**
      * ignore
@@ -256,6 +344,7 @@ public interface Func<Children, R> extends Serializable {
     default Children having(String sqlHaving, Object... params) {
         return having(true, sqlHaving, params);
     }
+
 
     /**
      * HAVING ( sql语句 )

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Wrappers.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Wrappers.java
@@ -239,10 +239,6 @@ public final class Wrappers {
             return Collections.emptyMap();
         }
 
-        @Override
-        protected String columnsToString(String... columns) {
-            return null;
-        }
 
         @Override
         protected String columnToString(String column) {

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/QueryWrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/QueryWrapperTest.java
@@ -161,6 +161,33 @@ class QueryWrapperTest extends BaseWrapperTest {
         logParams(wrapper);
     }
 
+    @Test
+    void testSqlWithAlias() {
+        QueryWrapper<Entity> queryWrapper = new QueryWrapper<Entity>().eq("a", "id", "123")
+                                                                      .ne("b", "username", "456")
+                                                                      .le("c", "roleId", "22222")
+                                                                      .ge("d", "id", "444");
+        logSqlWhere("测试sql别名", queryWrapper,
+                    "(a.id = ? AND b.username <> ? AND c.roleId <= ? AND d.id >= ?)");
+    }
+
+    @Test
+    void testLambdaSqlWithAlias() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), Entity.class);
+        QueryWrapper<Entity> queryWrapper = new QueryWrapper<>();
+        queryWrapper.lambda().eq("a", Entity::getId, "sss2");
+        queryWrapper.lambda().eq("b", Entity::getName, "sss");
+        logSqlWhere("测试lambda生成的sql", queryWrapper, "(a.id = ? AND b.username = ?)");
+    }
+
+    @Test
+    void testGroupByAndOrderByWithAlias(){
+        logSqlWhere("order by 和 group by 增加别名测试", new QueryWrapper<Entity>()
+                        .orderByAscWithAlias("a", "id", "name", "sex")
+                        .groupByWithAlias("a", "id", "name", "sex"),
+                    "GROUP BY a.id,a.name,a.sex ORDER BY a.id ASC,a.name ASC,a.sex ASC");
+    }
+
     private List<Object> getList() {
         List<Object> list = new ArrayList<>();
         for (int i = 0; i < 2; i++) {

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/AbstractChainWrapper.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/AbstractChainWrapper.java
@@ -80,134 +80,134 @@ public abstract class AbstractChainWrapper<T, R, Children extends AbstractChainW
     }
 
     @Override
-    public Children eq(boolean condition, R column, Object val) {
-        getWrapper().eq(condition, column, val);
+    public Children eq(boolean condition, String alias, R column, Object val) {
+        getWrapper().eq(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children ne(boolean condition, R column, Object val) {
-        getWrapper().ne(condition, column, val);
+    public Children ne(boolean condition, String alias, R column, Object val) {
+        getWrapper().ne(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children gt(boolean condition, R column, Object val) {
-        getWrapper().gt(condition, column, val);
+    public Children gt(boolean condition, String alias, R column, Object val) {
+        getWrapper().gt(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children ge(boolean condition, R column, Object val) {
-        getWrapper().ge(condition, column, val);
+    public Children ge(boolean condition, String alias, R column, Object val) {
+        getWrapper().ge(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children lt(boolean condition, R column, Object val) {
-        getWrapper().lt(condition, column, val);
+    public Children lt(boolean condition, String alias, R column, Object val) {
+        getWrapper().lt(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children le(boolean condition, R column, Object val) {
-        getWrapper().le(condition, column, val);
+    public Children le(boolean condition, String alias, R column, Object val) {
+        getWrapper().le(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children between(boolean condition, R column, Object val1, Object val2) {
-        getWrapper().between(condition, column, val1, val2);
+    public Children between(boolean condition, String alias, R column, Object val1, Object val2) {
+        getWrapper().between(condition, alias, column, val1, val2);
         return typedThis;
     }
 
     @Override
-    public Children notBetween(boolean condition, R column, Object val1, Object val2) {
-        getWrapper().notBetween(condition, column, val1, val2);
+    public Children notBetween(boolean condition, String alias, R column, Object val1, Object val2) {
+        getWrapper().notBetween(condition, alias, column, val1, val2);
         return typedThis;
     }
 
     @Override
-    public Children like(boolean condition, R column, Object val) {
-        getWrapper().like(condition, column, val);
+    public Children like(boolean condition, String alias, R column, Object val) {
+        getWrapper().like(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children notLike(boolean condition, R column, Object val) {
-        getWrapper().notLike(condition, column, val);
+    public Children notLike(boolean condition, String alias, R column, Object val) {
+        getWrapper().notLike(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children likeLeft(boolean condition, R column, Object val) {
-        getWrapper().likeLeft(condition, column, val);
+    public Children likeLeft(boolean condition, String alias, R column, Object val) {
+        getWrapper().likeLeft(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children likeRight(boolean condition, R column, Object val) {
-        getWrapper().likeRight(condition, column, val);
+    public Children likeRight(boolean condition, String alias, R column, Object val) {
+        getWrapper().likeRight(condition, alias, column, val);
         return typedThis;
     }
 
     @Override
-    public Children isNull(boolean condition, R column) {
-        getWrapper().isNull(condition, column);
+    public Children isNull(boolean condition, String alias, R column) {
+        getWrapper().isNull(condition, alias, column);
         return typedThis;
     }
 
     @Override
-    public Children isNotNull(boolean condition, R column) {
-        getWrapper().isNotNull(condition, column);
+    public Children isNotNull(boolean condition, String alias, R column) {
+        getWrapper().isNotNull(condition, alias, column);
         return typedThis;
     }
 
     @Override
-    public Children in(boolean condition, R column, Collection<?> coll) {
-        getWrapper().in(condition, column, coll);
+    public Children in(boolean condition, String alias, R column, Collection<?> coll) {
+        getWrapper().in(condition, alias, column, coll);
         return typedThis;
     }
 
     @Override
-    public Children in(boolean condition, R column, Object... values) {
-        getWrapper().in(condition, column, values);
+    public Children in(boolean condition, String alias, R column, Object... values) {
+        getWrapper().in(condition, alias, column, values);
         return typedThis;
     }
 
     @Override
-    public Children notIn(boolean condition, R column, Collection<?> coll) {
-        getWrapper().notIn(condition, column, coll);
+    public Children notIn(boolean condition, String alias, R column, Collection<?> coll) {
+        getWrapper().notIn(condition, alias, column, coll);
         return typedThis;
     }
 
     @Override
-    public Children notIn(boolean condition, R column, Object... values) {
-        getWrapper().notIn(condition, column, values);
+    public Children notIn(boolean condition, String alias, R column, Object... values) {
+        getWrapper().notIn(condition, alias, column, values);
         return typedThis;
     }
 
     @Override
-    public Children inSql(boolean condition, R column, String inValue) {
-        getWrapper().inSql(condition, column, inValue);
+    public Children inSql(boolean condition, String alias, R column, String inValue) {
+        getWrapper().inSql(condition, alias, column, inValue);
         return typedThis;
     }
 
     @Override
-    public Children notInSql(boolean condition, R column, String inValue) {
-        getWrapper().notInSql(condition, column, inValue);
+    public Children notInSql(boolean condition, String alias, R column, String inValue) {
+        getWrapper().notInSql(condition, alias, column, inValue);
         return typedThis;
     }
 
     @Override
-    public Children groupBy(boolean condition, R column, R... columns) {
-        getWrapper().groupBy(condition, column, columns);
+    public Children groupBy(boolean condition, String alias, R column, R... columns) {
+        getWrapper().groupBy(condition, alias, column, columns);
         return typedThis;
     }
 
     @Override
-    public Children orderBy(boolean condition, boolean isAsc, R column, R... columns) {
-        getWrapper().orderBy(condition, isAsc, column, columns);
+    public Children orderBy(boolean condition, boolean isAsc, String alias, R column, R... columns) {
+        getWrapper().orderBy(condition, isAsc, alias, column, columns);
         return typedThis;
     }
 


### PR DESCRIPTION
### 该Pull Request关联的Issue
无
### 修改描述
单元测试报错，columnMap没有被初始化
### 测试用例

```
  @Test
  void testPluralLambda() {
      TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), Entity.class);
      QueryWrapper<Entity> queryWrapper = new QueryWrapper<>();
      queryWrapper.lambda().eq(Entity::getName, "sss");
      queryWrapper.lambda().eq(Entity::getName, "sss2");
      logSqlWhere("测试 PluralLambda", queryWrapper, "(username = ? AND username = ?)");
      logParams(queryWrapper);
  }
```


### 修复效果的截屏


