### PR TITLE
fixed: columnMap 空指针的问题

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
@@ -74,7 +74,9 @@ public abstract class AbstractLambdaWrapper<T, Children extends AbstractLambdaWr
     protected ColumnCache getColumnCache(SFunction<T, ?> column) {
         LambdaMeta lambda = LambdaUtils.extract(column);
         String fileName = PropertyNamer.methodToProperty(lambda.getImplMethodName());
-        return getColumnCache(fileName, lambda.getInstantiatedClass());
+        Class<?> instantiatedClass = lambda.getInstantiatedClass();
+        tryInitCache(instantiatedClass);
+        return getColumnCache(fileName, instantiatedClass);
     }
 
     private void tryInitCache(Class<?> lambdaClass) {


### PR DESCRIPTION
### 该Pull Request关联的Issue
无

### 修改描述
看代码时，发现单元测试跑不过，随手修改，原因是因为`columnMap`没有被初始化


### 测试用例
```
@Test
    void testPluralLambda() {
        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), Entity.class);
        QueryWrapper<Entity> queryWrapper = new QueryWrapper<>();
        queryWrapper.lambda().eq(Entity::getName, "sss");
        queryWrapper.lambda().eq(Entity::getName, "sss2");
        logSqlWhere("测试 PluralLambda", queryWrapper, "(username = ? AND username = ?)");
        logParams(queryWrapper);
    }
```


### 修复效果的截屏


