### PR TITLE
修复批量操作之前的空指针异常,可能由于mp或者调用方执行mybatis操作之前引起

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
@@ -34,6 +34,7 @@ import org.mybatis.spring.MyBatisExceptionTranslator;
 import org.mybatis.spring.SqlSessionHolder;
 import org.mybatis.spring.SqlSessionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -229,7 +230,10 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
             if (unwrapped instanceof RuntimeException) {
                 MyBatisExceptionTranslator myBatisExceptionTranslator
                     = new MyBatisExceptionTranslator(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(), true);
-                throw Objects.requireNonNull(myBatisExceptionTranslator.translateExceptionIfPossible((RuntimeException) unwrapped));
+                DataAccessException dataAccessException = myBatisExceptionTranslator.translateExceptionIfPossible((RuntimeException) unwrapped);
+                if (dataAccessException != null) {
+                    throw dataAccessException;
+                }
             }
             throw ExceptionUtils.mpe(unwrapped);
         } finally {


### PR DESCRIPTION
### 该Pull Request关联的Issue
#3464


### 修改描述
修复批量操作之前的空指针异常,可能由于mp或者调用方执行mybatis操作之前引起


### 测试用例

 @Test
    @Order(23)
    void testSaveOrUpdateBatch() {
        Assertions.assertTrue(userService.saveOrUpdateBatch(Arrays.asList(new H2User(1010L, "batch1010"),
            new H2User("batch1011"), new H2User(1010L, "batch1010"), new H2User("batch1015"))));
    }


@Data
@Accessors(chain = true)
// 比如通过删除@TableName触发此异常
// @TableName("h2user")
@EqualsAndHashCode(callSuper = true)
public class H2User extends SuperEntity {
//.. 省略属性
}

### 修复效果的截屏
抛出具体的异常，而不是空指针异常

![image](https://user-images.githubusercontent.com/6361319/118426387-b2579f00-b6fd-11eb-8456-f8bbb8f25705.png)
