### PR TITLE
分页排序优化

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -402,6 +402,9 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
     }
 
     protected List<OrderByElement> addOrderByElements(List<OrderItem> orderList, List<OrderByElement> orderByElements) {
+        if (CollectionUtils.isEmpty(orderList)) {
+            return orderByElements;
+        }
         List<OrderByElement> additionalOrderBy = orderList.stream()
             .filter(item -> StringUtils.isNotBlank(item.getColumn()))
             .map(item -> {
@@ -414,8 +417,9 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
         if (CollectionUtils.isEmpty(orderByElements)) {
             return additionalOrderBy;
         }
-        orderByElements.addAll(additionalOrderBy);
-        return orderByElements;
+        // 建议前端传了排序字段，优先使用前端的排序，比如：默认按id排序，前端传了name排序，建议先按name排序，再按id排序
+        additionalOrderBy.addAll(orderByElements);
+        return additionalOrderBy;
     }
 
     /**


### PR DESCRIPTION
### 该Pull Request关联的Issue

无

### 修改描述
分页插件建议先按前端传的排序字段进行排序，再使用默认的排序字段排序。
比如：默认排序字段为： id
前端传了name来动态排序，建议改为 order by name, id 而不是id,name

### 测试用例



### 修复效果的截屏


