### PR TITLE
feat:查询一条，忽略 mybatis Expected one result (or null) to be returned by …

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/ChainQuery.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/ChainQuery.java
@@ -16,8 +16,10 @@
 package com.baomidou.mybatisplus.extension.conditions.query;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 import com.baomidou.mybatisplus.extension.conditions.ChainWrapper;
 import com.baomidou.mybatisplus.extension.toolkit.SqlHelper;
+import org.apache.ibatis.session.defaults.DefaultSqlSession;
 
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +48,20 @@ public interface ChainQuery<T> extends ChainWrapper<T> {
      */
     default T one() {
         return getBaseMapper().selectOne(getWrapper());
+    }
+
+    /**
+     * 查询一条，忽略 mybatis Expected one result (or null) to be returned by selectOne(), but found: .. ,默认获取第一条记录
+     *
+     * @return 单个
+     * @see DefaultSqlSession#selectOne(java.lang.String, java.lang.Object)  code:list.get(0)
+     */
+    default T first() {
+        List<T> list = this.list();
+        if (CollectionUtils.isEmpty(list)) {
+            return null;
+        }
+        return list.get(0);
     }
 
     /**

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/ChainQuery.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/ChainQuery.java
@@ -88,7 +88,7 @@ public interface ChainQuery<T> extends ChainWrapper<T> {
      *
      * @return true：存在
      */
-    default boolean isExists() {
+    default boolean exists() {
         int count = this.count();
         return count > 0;
     }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/ChainQuery.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/ChainQuery.java
@@ -84,6 +84,16 @@ public interface ChainQuery<T> extends ChainWrapper<T> {
     }
 
     /**
+     * 判断数据是否存在
+     *
+     * @return true：存在
+     */
+    default boolean isExists() {
+        int count = this.count();
+        return count > 0;
+    }
+
+    /**
      * 获取分页数据
      *
      * @param page 分页条件


### PR DESCRIPTION
…selectOne(), but found: .. ,默认获取第一条记录

### 该Pull Request关联的Issue
无，增加一些功能


### 修改描述
com.baomidou.mybatisplus.extension.conditions.query.ChainQuery增加first方法，类似mybatis源码中DefaultSqlSession#selectOne(java.lang.String, java.lang.Object)  code:list.get(0)的实现，不过不会出现  Expected one result (or null) to be returned by selectOne(), but found:.. 异常, 希望增加的这个功能可以通过，这样可以省下很多事情！
```java
    /**
     * 查询一条，忽略 mybatis Expected one result (or null) to be returned by selectOne(), but found: .. ,默认获取第一条记录
     *
     * @return 单个
     * @see DefaultSqlSession#selectOne(java.lang.String, java.lang.Object)  code:list.get(0)
     */
    default T first() {
        List<T> list = this.list();
        if (CollectionUtils.isEmpty(list)) {
            return null;
        }
        return list.get(0);
    }
```
增加isExists方法，方便开发使用。
update : 应群主要求，isExists方法名称改为exists
```java
    /**
     * 判断数据是否存在
     *
     * @return true：存在
     */
    default boolean exists() {
        int count = this.count();
        return count > 0;
    }
```

### 测试用例

无

### 修复效果的截屏

无

