### PR TITLE
feat: 增加 PostInnerInterceptor 增加 after 处理回调, 增加 Mycat 注解支持

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptor.java
@@ -18,8 +18,11 @@ package com.baomidou.mybatisplus.extension.plugins;
 import com.baomidou.mybatisplus.core.toolkit.ClassUtils;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import com.baomidou.mybatisplus.extension.plugins.inner.InnerInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.inner.PostInnerInterceptor;
 import com.baomidou.mybatisplus.extension.toolkit.PropertyMapper;
+
 import lombok.Setter;
+
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.statement.StatementHandler;
@@ -56,50 +59,78 @@ public class MybatisPlusInterceptor implements Interceptor {
     public Object intercept(Invocation invocation) throws Throwable {
         Object target = invocation.getTarget();
         Object[] args = invocation.getArgs();
-        if (target instanceof Executor) {
-            final Executor executor = (Executor) target;
-            Object parameter = args[1];
-            boolean isUpdate = args.length == 2;
-            MappedStatement ms = (MappedStatement) args[0];
-            if (!isUpdate && ms.getSqlCommandType() == SqlCommandType.SELECT) {
-                RowBounds rowBounds = (RowBounds) args[2];
-                ResultHandler resultHandler = (ResultHandler) args[3];
-                BoundSql boundSql;
-                if (args.length == 4) {
-                    boundSql = ms.getBoundSql(parameter);
-                } else {
-                    // 几乎不可能走进这里面,除非使用Executor的代理对象调用query[args[6]]
-                    boundSql = (BoundSql) args[5];
-                }
-                for (InnerInterceptor query : interceptors) {
-                    if (!query.willDoQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql)) {
-                        return Collections.emptyList();
+        try {
+            if (target instanceof Executor) {
+                final Executor executor = (Executor) target;
+                Object parameter = args[1];
+                boolean isUpdate = args.length == 2;
+                MappedStatement ms = (MappedStatement) args[0];
+                if (!isUpdate && ms.getSqlCommandType() == SqlCommandType.SELECT) {
+                    RowBounds rowBounds = (RowBounds) args[2];
+                    ResultHandler resultHandler = (ResultHandler) args[3];
+                    BoundSql boundSql;
+                    if (args.length == 4) {
+                        boundSql = ms.getBoundSql(parameter);
+                    } else {
+                        // 几乎不可能走进这里面,除非使用Executor的代理对象调用query[args[6]]
+                        boundSql = (BoundSql) args[5];
                     }
-                    query.beforeQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
-                }
-                CacheKey cacheKey = executor.createCacheKey(ms, parameter, rowBounds, boundSql);
-                return executor.query(ms, parameter, rowBounds, resultHandler, cacheKey, boundSql);
-            } else if (isUpdate) {
-                for (InnerInterceptor update : interceptors) {
-                    if (!update.willDoUpdate(executor, ms, parameter)) {
-                        return -1;
+                    for (InnerInterceptor query : interceptors) {
+                        if (!query.willDoQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql)) {
+                            return Collections.emptyList();
+                        }
+                        query.beforeQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
                     }
-                    update.beforeUpdate(executor, ms, parameter);
-                }
-            }
-        } else {
-            // StatementHandler
-            final StatementHandler sh = (StatementHandler) target;
-            // 目前只有StatementHandler.getBoundSql方法args才为null
-            if (null == args) {
-                for (InnerInterceptor innerInterceptor : interceptors) {
-                    innerInterceptor.beforeGetBoundSql(sh);
+                    for (InnerInterceptor interceptor : interceptors) {
+                        if (interceptor instanceof PostInnerInterceptor) {
+                            ((PostInnerInterceptor) interceptor).afterQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
+                        }
+                    }
+                    CacheKey cacheKey = executor.createCacheKey(ms, parameter, rowBounds, boundSql);
+                    return executor.query(ms, parameter, rowBounds, resultHandler, cacheKey, boundSql);
+                } else if (isUpdate) {
+                    for (InnerInterceptor update : interceptors) {
+                        if (!update.willDoUpdate(executor, ms, parameter)) {
+                            return -1;
+                        }
+                        update.beforeUpdate(executor, ms, parameter);
+                    }
+                    for (InnerInterceptor interceptor : interceptors) {
+                        if (interceptor instanceof PostInnerInterceptor) {
+                            ((PostInnerInterceptor) interceptor).afterUpdate(executor, ms, parameter);
+                        }
+                    }
                 }
             } else {
-                Connection connections = (Connection) args[0];
-                Integer transactionTimeout = (Integer) args[1];
-                for (InnerInterceptor innerInterceptor : interceptors) {
-                    innerInterceptor.beforePrepare(sh, connections, transactionTimeout);
+                // StatementHandler
+                final StatementHandler sh = (StatementHandler) target;
+                // 目前只有StatementHandler.getBoundSql方法args才为null
+                if (null == args) {
+                    for (InnerInterceptor innerInterceptor : interceptors) {
+                        innerInterceptor.beforeGetBoundSql(sh);
+                    }
+                    for (InnerInterceptor interceptor : interceptors) {
+                        if (interceptor instanceof PostInnerInterceptor) {
+                            ((PostInnerInterceptor) interceptor).afterGetBoundSql(sh);
+                        }
+                    }
+                } else {
+                    Connection connections = (Connection) args[0];
+                    Integer transactionTimeout = (Integer) args[1];
+                    for (InnerInterceptor innerInterceptor : interceptors) {
+                        innerInterceptor.beforePrepare(sh, connections, transactionTimeout);
+                    }
+                    for (InnerInterceptor interceptor : interceptors) {
+                        if (interceptor instanceof PostInnerInterceptor) {
+                            ((PostInnerInterceptor) interceptor).afterPrepare(sh, connections, transactionTimeout);
+                        }
+                    }
+                }
+            }
+        } finally {
+            for (InnerInterceptor interceptor : interceptors) {
+                if (interceptor instanceof PostInnerInterceptor) {
+                    ((PostInnerInterceptor) interceptor).afterCompletion();
                 }
             }
         }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/MycatAnnotationInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/MycatAnnotationInterceptor.java
@@ -16,6 +16,7 @@ import com.baomidou.mybatisplus.core.toolkit.PluginUtils;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author <a href="mailto:xyz327@outlook.com">xizhou</a>
@@ -27,18 +28,22 @@ public class MycatAnnotationInterceptor implements PostInnerInterceptor {
 
     private static final String PROHIBITION_SYMBOL = "?";
 
-    private final Set<MyCatAnnotation> mycatAnnotation = new HashSet<>();
+    private final Set<MycatAnnotation> mycatAnnotations = new HashSet<>();
     private final ThreadLocal<String> threadLocal = new ThreadLocal<>();
 
     {
-        mycatAnnotation.add(MyCatAnnotation.of("/**mycat", "*/", true));
-        mycatAnnotation.add(MyCatAnnotation.of("/*balance", "*/", true));
+        mycatAnnotations.add(MycatAnnotation.of("/**mycat", "*/", true));
+        mycatAnnotations.add(MycatAnnotation.of("/*balance", "*/", true));
 
-        mycatAnnotation.add(MyCatAnnotation.of("/*!mycat", "*/", false));
-        mycatAnnotation.add(MyCatAnnotation.of("/*#mycat", "*/", false));
+        mycatAnnotations.add(MycatAnnotation.of("/*!mycat", "*/", false));
+        mycatAnnotations.add(MycatAnnotation.of("/*#mycat", "*/", false));
 
         // mycat2
-        mycatAnnotation.add(MyCatAnnotation.of("/*+ mycat", "*/", true));
+        mycatAnnotations.add(MycatAnnotation.of("/*+ mycat", "*/", true));
+    }
+
+    public void addMycatAnnotation(MycatAnnotation mycatAnnotation) {
+        mycatAnnotations.add(mycatAnnotation);
     }
 
     @Override
@@ -72,7 +77,7 @@ public class MycatAnnotationInterceptor implements PostInnerInterceptor {
     }
 
     private void parseSql(String originSql) {
-        MyCatAnnotation mycatAnno = findMycatAnno(originSql);
+        MycatAnnotation mycatAnno = findMycatAnno(originSql);
         if (mycatAnno == null) {
             return;
         }
@@ -89,8 +94,8 @@ public class MycatAnnotationInterceptor implements PostInnerInterceptor {
         threadLocal.set(mycatAnnotation);
     }
 
-    private MyCatAnnotation findMycatAnno(String originSql) {
-        for (MyCatAnnotation anno : mycatAnnotation) {
+    private MycatAnnotation findMycatAnno(String originSql) {
+        for (MycatAnnotation anno : mycatAnnotations) {
             if (originSql.contains(anno.prefix)) {
                 return anno;
             }
@@ -105,7 +110,8 @@ public class MycatAnnotationInterceptor implements PostInnerInterceptor {
 
 
     @Data(staticConstructor = "of")
-    public static class MyCatAnnotation {
+    @EqualsAndHashCode(of = {"prefix", "suffix"})
+    public static class MycatAnnotation {
 
         private final String prefix;
         private final String suffix;

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/MycatAnnotationInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/MycatAnnotationInterceptor.java
@@ -1,0 +1,115 @@
+package com.baomidou.mybatisplus.extension.plugins.inner;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.executor.statement.StatementHandler;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+
+import com.baomidou.mybatisplus.core.toolkit.PluginUtils;
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
+
+import lombok.Data;
+
+/**
+ * @author <a href="mailto:xyz327@outlook.com">xizhou</a>
+ * @see <a href="https://www.yuque.com/ccazhw/tuacvk/dqizp3">Mycat1 注解</a>
+ * @see <a href="https://www.yuque.com/books/share/6606b3b6-3365-4187-94c4-e51116894695/f9f24306bbd3992c1baff00cdb0956a4">Mycat2 注解</a>
+ * @since 2021/6/2 11:04 上午
+ */
+public class MycatAnnotationInterceptor implements PostInnerInterceptor {
+
+    private static final String PROHIBITION_SYMBOL = "?";
+
+    private final Set<MyCatAnnotation> mycatAnnotation = new HashSet<>();
+    private final ThreadLocal<String> threadLocal = new ThreadLocal<>();
+
+    {
+        mycatAnnotation.add(MyCatAnnotation.of("/**mycat", "*/", true));
+        mycatAnnotation.add(MyCatAnnotation.of("/*balance", "*/", true));
+
+        mycatAnnotation.add(MyCatAnnotation.of("/*!mycat", "*/", false));
+        mycatAnnotation.add(MyCatAnnotation.of("/*#mycat", "*/", false));
+
+        // mycat2
+        mycatAnnotation.add(MyCatAnnotation.of("/*+ mycat", "*/", true));
+    }
+
+    @Override
+    public void beforeQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+        parseSql(boundSql.getSql());
+    }
+
+    @Override
+    public void afterQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+        PluginUtils.mpBoundSql(boundSql).sql(buildSql(boundSql.getSql()));
+    }
+
+    private String buildSql(String originalSql) {
+        String mycatAnno = threadLocal.get();
+        if (StringUtils.isBlank(mycatAnno)) {
+            return originalSql;
+        }
+        return mycatAnno + " " + originalSql;
+    }
+
+    @Override
+    public void beforePrepare(StatementHandler sh, Connection connection, Integer transactionTimeout) {
+        BoundSql boundSql = PluginUtils.mpStatementHandler(sh).boundSql();
+        parseSql(boundSql.getSql());
+    }
+
+    @Override
+    public void afterPrepare(StatementHandler sh, Connection connections, Integer transactionTimeout) {
+        BoundSql boundSql = PluginUtils.mpStatementHandler(sh).boundSql();
+        PluginUtils.mpBoundSql(boundSql).sql(buildSql(boundSql.getSql()));
+    }
+
+    private void parseSql(String originSql) {
+        MyCatAnnotation mycatAnno = findMycatAnno(originSql);
+        if (mycatAnno == null) {
+            return;
+        }
+        if (!mycatAnno.allow) {
+            throw new IllegalArgumentException(String.format("不支持的 mycat 注解语法: %s%s", mycatAnno.prefix, mycatAnno.suffix));
+        }
+        int start = originSql.indexOf(mycatAnno.prefix);
+        int end = originSql.indexOf(mycatAnno.suffix, start);
+        String mycatAnnotation = originSql.substring(start, end + mycatAnno.suffix.length());
+        // mycat 注解中不能使用 #{} . #{} 会被编译成 ? 而导致无法替换参数
+        if (mycatAnnotation.contains(PROHIBITION_SYMBOL)) {
+            throw new IllegalStateException("mybatis 不支持 mycat 注解中使用 #{} 的方式注入参数! 请使用 ${} 代替. 如果是存在 ? ,请删除");
+        }
+        threadLocal.set(mycatAnnotation);
+    }
+
+    private MyCatAnnotation findMycatAnno(String originSql) {
+        for (MyCatAnnotation anno : mycatAnnotation) {
+            if (originSql.contains(anno.prefix)) {
+                return anno;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void afterCompletion() {
+        threadLocal.remove();
+    }
+
+
+    @Data(staticConstructor = "of")
+    public static class MyCatAnnotation {
+
+        private final String prefix;
+        private final String suffix;
+        private final boolean allow;
+
+    }
+}

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PostInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PostInnerInterceptor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2021, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.extension.plugins.inner;
+
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.executor.statement.StatementHandler;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * @author <a href="mailto:xyz327@outlook.com">xizhou</a>
+ * @since 2021/6/2 11:04 上午
+ */
+@SuppressWarnings({"rawtypes"})
+public interface PostInnerInterceptor extends InnerInterceptor {
+
+    /**
+     * {@link this#beforeQuery(Executor, MappedStatement, Object, RowBounds, ResultHandler, BoundSql)} 整体完成之后的处理
+     *
+     * @param executor
+     * @param ms
+     * @param parameter
+     * @param rowBounds
+     * @param resultHandler
+     * @param boundSql
+     * @throws SQLException
+     */
+    default void afterQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+    }
+
+    /**
+     * {@link this#beforeUpdate(Executor, MappedStatement, Object)} 整体完成之后的处理
+     *
+     * @param executor
+     * @param ms
+     * @param parameter
+     */
+    default void afterUpdate(Executor executor, MappedStatement ms, Object parameter) {
+    }
+
+    /**
+     * {@link this#beforeGetBoundSql(StatementHandler)} 整体完成之后的处理
+     *
+     * @param sh
+     */
+    default void afterGetBoundSql(StatementHandler sh) {
+    }
+
+    /**
+     * {@link this#beforePrepare(StatementHandler, Connection, Integer)} 整体完成之后的处理
+     *
+     * @param sh
+     * @param connections
+     * @param transactionTimeout
+     */
+    default void afterPrepare(StatementHandler sh, Connection connections, Integer transactionTimeout) {
+    }
+
+    /**
+     * 整个拦截执行完成之后的处理
+     */
+    default void afterCompletion() {
+    }
+}

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/MycatAnnotationInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/MycatAnnotationInterceptorTest.java
@@ -1,0 +1,28 @@
+package com.baomidou.mybatisplus.extension.plugins.inner;
+
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author <a href="mailto:xyz327@outlook.com">xizhou</a>
+ * @since 2021/6/2 12:16 下午
+ */
+class MycatAnnotationInterceptorTest {
+
+    MycatAnnotationInterceptor mycatAnnotationInterceptor = new MycatAnnotationInterceptor();
+
+    @Test
+    void beforeQuery() throws Exception {
+
+        String sql = "/**mycat: sql=select 1 from test */select * form from t_user2;";
+        BoundSql boundSql = new BoundSql(new Configuration(), sql, null, null);
+        mycatAnnotationInterceptor.beforeQuery(null, null, null, null, null, boundSql);
+        mycatAnnotationInterceptor.afterQuery(null, null, null, null, null, boundSql);
+
+        Assertions.assertTrue(boundSql.getSql().contains("/**mycat"));
+
+    }
+
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue

#3579 

### 修改描述

[mycat1 注解](https://www.yuque.com/ccazhw/tuacvk/dqizp3)
[mycat2注解](https://www.yuque.com/books/share/6606b3b6-3365-4187-94c4-e51116894695/f9f24306bbd3992c1baff00cdb0956a4)

1. Mycat 的注解是基于 sql 注释的, 在 mp 插件解析之后就会去掉注释。在 InnerInterceptor 的基础上增加一个 PostInnerInterceptor 可以在改变 sql 之后再做一些操作。例如先在 beforeQuery 时把 mycat 的注解缓存下来，afterQuery 时在拼接回去。
2. 增加 MycatAnnotationInterceptor 的拦截器去支持 mycat 的注解

### 测试用例



### 修复效果的截屏


