### PR TITLE
动态代理SqlSession重写close方法以支持AutoCloseable，整合sqlSession资源的获取和释放，

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/IPage.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/IPage.java
@@ -130,6 +130,8 @@ public interface IPage<T> extends Serializable {
 
     /**
      * 设置每页显示条数
+     * <p>
+     * 为-1时查全表，小于-1不查
      */
     IPage<T> setSize(long size);
 

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -21,6 +21,7 @@ import com.baomidou.mybatisplus.core.metadata.OrderItem;
 import com.baomidou.mybatisplus.core.toolkit.*;
 import com.baomidou.mybatisplus.extension.plugins.pagination.DialectFactory;
 import com.baomidou.mybatisplus.extension.plugins.pagination.DialectModel;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.plugins.pagination.dialects.IDialect;
 import com.baomidou.mybatisplus.extension.toolkit.JdbcUtils;
 import com.baomidou.mybatisplus.extension.toolkit.PropertyMapper;
@@ -121,8 +122,13 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
     @Override
     public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
         IPage<?> page = ParameterUtils.findPage(parameter).orElse(null);
-        if (page == null || page.getSize() < 0 || !page.searchCount()) {
+        if (page == null || page.getSize() == -1 || !page.searchCount()) {
             return true;
+        }
+
+        // page.getSize() 为-1时查全表，小于-1不查
+        if (page.getSize()< -1) {
+            return false;
         }
 
         BoundSql countSql;

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/Page.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/Page.java
@@ -46,6 +46,8 @@ public class Page<T> implements IPage<T> {
     protected long total = 0;
     /**
      * 每页显示条数，默认 10
+     * <p>
+     * 为-1时查全表，小于-1不查
      */
     protected long size = 10;
 

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/SqlRunner.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/SqlRunner.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * SqlRunner 执行 SQL
@@ -221,7 +222,7 @@ public class SqlRunner implements ISqlRunner {
      * 获取Session 默认自动提交
      */
     private SqlSession sqlSession() {
-        return (clazz != null) ? SqlSessionUtils.getSqlSession(GlobalConfigUtils.currentSessionFactory(clazz)) : SqlSessionUtils.getSqlSession(sqlSessionFactory);
+        return SqlSessionUtils.getSqlSession(getSqlSessionFactory());
     }
 
     /**
@@ -230,12 +231,13 @@ public class SqlRunner implements ISqlRunner {
      * @param sqlSession session
      */
     private void closeSqlSession(SqlSession sqlSession) {
-        SqlSessionFactory sqlSessionFactory;
-        if (clazz != null) {
-            sqlSessionFactory = GlobalConfigUtils.currentSessionFactory(clazz);
-        } else {
-            sqlSessionFactory = DEFAULT.sqlSessionFactory;
-        }
-        SqlSessionUtils.closeSqlSession(sqlSession, sqlSessionFactory);
+        SqlSessionUtils.closeSqlSession(sqlSession, getSqlSessionFactory());
+    }
+
+    /**
+     * 获取SqlSessionFactory
+     */
+    private SqlSessionFactory getSqlSessionFactory() {
+        return Optional.ofNullable(clazz).map(GlobalConfigUtils::currentSessionFactory).orElse(sqlSessionFactory);
     }
 }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/SqlSessionProxy.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/SqlSessionProxy.java
@@ -1,0 +1,67 @@
+package com.baomidou.mybatisplus.extension.toolkit;
+
+import com.baomidou.mybatisplus.core.toolkit.Assert;
+import com.baomidou.mybatisplus.core.toolkit.GlobalConfigUtils;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionUtils;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+
+/**
+ * 重写 SqlSession
+ *
+ * @author NanCheung
+ */
+public class SqlSessionProxy implements InvocationHandler {
+
+    public static final String METHOD_CLOSE = "close";
+
+    private final SqlSession sqlSession;
+    private final SqlSessionFactory sqlSessionFactory;
+
+    public SqlSessionProxy(Class<?> clazz, SqlSessionFactory defaultSqlSessionFactory) {
+        Assert.isTrue(clazz != null || defaultSqlSessionFactory != null, "Error: At least one of clazz and sqlSessionFactory is cannot be empty");
+        this.sqlSessionFactory = getSqlSessionFactory(clazz, defaultSqlSessionFactory);
+        this.sqlSession = SqlSessionUtils.getSqlSession(sqlSessionFactory);
+    }
+
+    public SqlSessionProxy(Class<?> clazz) {
+        Assert.isTrue(clazz != null , "Error: Cannot be empty for clazz");
+        this.sqlSessionFactory = getSqlSessionFactory(clazz, null);
+        this.sqlSession = SqlSessionUtils.getSqlSession(sqlSessionFactory);
+    }
+
+    public SqlSession newInstance() {
+        return (SqlSession) Proxy.newProxyInstance(SqlSession.class.getClassLoader(), new Class[]{SqlSession.class}, this);
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (Object.class.equals(method.getDeclaringClass())) {
+            return method.invoke(this, args);
+        }
+
+        // 重写close方法，以支持AutoCloseable
+        if (METHOD_CLOSE.equals(method.getName())) {
+            close();
+            return null;
+        }
+
+        return method.invoke(sqlSession, args);
+    }
+
+    private void close() {
+        SqlSessionUtils.closeSqlSession(sqlSession, sqlSessionFactory);
+    }
+
+    /**
+     * 获取SqlSessionFactory
+     */
+    private SqlSessionFactory getSqlSessionFactory(Class<?> clazz, SqlSessionFactory defaultSqlSessionFactory) {
+        return Optional.ofNullable(clazz).map(GlobalConfigUtils::currentSessionFactory).orElse(defaultSqlSessionFactory);
+    }
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述

🏗️ 代理SqlSession

- 重写close方法以支持AutoCloseable
- 整合sqlSession资源的获取和释放

### 测试用例
使用mybatis-plus-samples项目进行测试
com.baomidou.mybatisplus.samples.ar.SampleTest#aInsert
![image](https://user-images.githubusercontent.com/34061813/120972895-d3f9f280-c7a0-11eb-8504-20de19a03bc4.png)

### 修复效果的截屏
![image](https://user-images.githubusercontent.com/34061813/120972936-dd835a80-c7a0-11eb-9da9-34351e6e4fb6.png)


