### PR TITLE
:bug: Fix pageSize小于0时查全表

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -167,14 +167,6 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
             buildSql = this.concatOrderBy(buildSql, orders);
         }
 
-        // size 小于 0 不构造分页sql
-        if (page.getSize() < 0) {
-            if (addOrdered) {
-                PluginUtils.mpBoundSql(boundSql).sql(buildSql);
-            }
-            return;
-        }
-
         handlerLimit(page);
         IDialect dialect = findIDialect(executor);
 
@@ -450,7 +442,7 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
         final long size = page.getSize();
         Long pageMaxLimit = page.maxLimit();
         Long limit = pageMaxLimit != null ? pageMaxLimit : maxLimit;
-        if (limit != null && limit > 0 && size > limit) {
+        if (size < 0 || (limit != null && limit > 0 && size > limit)) {
             page.setSize(limit);
         }
     }


### PR DESCRIPTION
Closes github #3599

### 该Pull Request关联的Issue

#3599

### 修改描述
- pageSize小于0时则使用maxLimit


### 测试用例

```java
    @Bean
    public MybatisPlusInterceptor mybatisPlusInterceptor() {
        MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
        PaginationInnerInterceptor paginationInnerInterceptor = new PaginationInnerInterceptor(DbType.H2);
        paginationInnerInterceptor.setMaxLimit(5L);
        interceptor.addInnerInterceptor(paginationInnerInterceptor);
        return interceptor;
    }
```

```java
    @Test
    void lambdaPagination() {
        Page<User> page = new Page<>(1, -1);
        Page<User> result = mapper.selectPage(page, Wrappers.<User>lambdaQuery().ge(User::getAge, 1).orderByAsc(User::getAge));
        System.out.println(result.getRecords().size());
        
        
        Page<User> page2 = new Page<>(1, 4);
        Page<User> result2 = mapper.selectPage(page2, Wrappers.<User>lambdaQuery().ge(User::getAge, 1).orderByAsc(User::getAge));
        System.out.println(result2.getRecords().size());
        
        
        Page<User> page3 = new Page<>(1, 10);
        Page<User> result3 = mapper.selectPage(page3, Wrappers.<User>lambdaQuery().ge(User::getAge, 1).orderByAsc(User::getAge));
        System.out.println(result3.getRecords().size());
    }
```

### 修复效果的截屏

![image](https://user-images.githubusercontent.com/34061813/121293011-7fc84d00-c91d-11eb-9e50-a1fb13c61eca.png)

