### PR TITLE
添加 limit API

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
@@ -33,6 +33,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 
 import static com.baomidou.mybatisplus.core.enums.SqlKeyword.*;
+import static com.baomidou.mybatisplus.core.enums.SqlKeyword.LIMIT;
 import static com.baomidou.mybatisplus.core.enums.WrapperKeyword.APPLY;
 import static java.util.stream.Collectors.joining;
 
@@ -206,6 +207,21 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
     @Override
     public Children or(boolean condition, Consumer<Children> consumer) {
         return or(condition).addNestedCondition(condition, consumer);
+    }
+
+    @Override
+    public Children limitOne(boolean condition) {
+        return last(condition, LIMIT.getSqlSegment() + StringPool.SPACE + StringPool.ZERO + StringPool.COMMA + StringPool.ONE);
+    }
+
+    @Override
+    public Children limit(boolean condition, int num) {
+        return last(condition, LIMIT.getSqlSegment() + StringPool.SPACE + StringPool.ZERO + StringPool.COMMA + num);
+    }
+
+    @Override
+    public Children limit(boolean condition, int start, int num) {
+        return last(condition, LIMIT.getSqlSegment() + StringPool.SPACE + start + StringPool.COMMA + num);
     }
 
     @Override

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
@@ -282,4 +282,59 @@ public interface Compare<Children, R> extends Serializable {
      * @return children
      */
     Children likeRight(boolean condition, R column, Object val);
+
+    /**
+     * ignore
+     *
+     * @return children
+     */
+    default Children limitOne() {
+        return limitOne(true);
+    }
+
+    /**
+     * ignore
+     *
+     * @return children
+     */
+    Children limitOne(boolean condition);
+
+    /**
+     * 从 0 开始取 size 个数
+     *
+     * @param num 个数
+     * @return children
+     */
+    default Children limit(int num) {
+        return limit(true, num);
+    }
+
+    /**
+     * 从 0 开始取 size 个数
+     *
+     * @param num 个数
+     * @return children
+     */
+    Children limit(boolean condition, int num);
+
+    /**
+     * 从 start 开始取 size 个
+     *
+     * @param start 起始位置
+     * @param num   个数
+     * @return children
+     */
+    default Children limit(int start, int num) {
+        return limit(true, start, num);
+    }
+
+    /**
+     * 从 start 开始取 size 个
+     *
+     * @param condition 执行条件
+     * @param start     起始位置
+     * @param num       个数
+     * @return children
+     */
+    Children limit(boolean condition, int start, int num);
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlKeyword.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlKeyword.java
@@ -34,6 +34,7 @@ public enum SqlKeyword implements ISqlSegment {
     IN("IN"),
     NOT_IN("NOT IN"),
     LIKE("LIKE"),
+    LIMIT("LIMIT"),
     NOT_LIKE("NOT LIKE"),
     EQ(StringPool.EQUALS),
     NE("<>"),

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/AbstractChainWrapper.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/AbstractChainWrapper.java
@@ -152,6 +152,22 @@ public abstract class AbstractChainWrapper<T, R, Children extends AbstractChainW
         return typedThis;
     }
 
+    public Children limitOne(boolean condition) {
+        getWrapper().limitOne(condition);
+        return typedThis;
+    }
+
+    public Children limit(boolean condition, int num) {
+        getWrapper().limit(condition, num);
+        return typedThis;
+    }
+
+    @Override
+    public Children limit(boolean condition, int start, int num) {
+        getWrapper().limit(condition, start, num);
+        return typedThis;
+    }
+
     @Override
     public Children isNull(boolean condition, R column) {
         getWrapper().isNull(condition, column);


### PR DESCRIPTION
添加 limit API，避免使用Mybatis-plus的时候使用addLast(" ")做硬编码开发，另外可以使用mybatis-plus组合出高效分页插件


### 该Pull Request关联的Issue



### 修改描述
1. limitOne()。如果想获取一个列表数据的前一条可以使用limitOne();

2. limit(int num)。如果想获取一个列表的前几条数据可以使用limit(int num); 该方法可以作为高效分页查询的基石之一，传统limit方式分页会导致数据库遍历到无效数据然后再丢弃无效数据，计算出边界主键id可以使用迭代法封装出高效分页插件（是封装基于mybatis-plus的分页插件，而不是mybatis-plus的分页插件），例如分页插件从第200万个开始获取200个商品：complaintPOQueryWrapper.lambda().ge(ComplaintPO::getComplaintId, 2000000 ).limit(200) 等价于下面sql ：select ite_introduction, item_price from t_item where item_id >= 2000000 limit 0,200。

3. limit(int start, int num)。该API是提供灵活的limit操作。

### 测试用例

QueryWrapper<ComplaintPO> complaintPOQueryWrapper = new QueryWrapper<>();
// 获取第一条
complaintPOQueryWrapper.lambda().limitOne();
// 获取第一条
complaintPOQueryWrapper.lambda().limit(1);
// 从第一条开始获取两条
complaintPOQueryWrapper.lambda().limit(1,2);
complaintMapper.selectOne(complaintPOQueryWrapper);

### 修复效果的截屏
![image](https://user-images.githubusercontent.com/50826426/121293010-7f2fb680-c91d-11eb-9907-76e0097fb812.png)


