### PR TITLE
QueryWrapper和UpdateWrapper添加构造方法，支持自定义columnToString方法

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/QueryWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/QueryWrapper.java
@@ -25,7 +25,9 @@ import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -43,8 +45,18 @@ public class QueryWrapper<T> extends AbstractWrapper<T, String, QueryWrapper<T>>
      */
     private final SharedString sqlSelect = new SharedString();
 
+    /**
+     * 列名转换
+     */
+    private Function<String, String> columnToString = s -> s;
+
     public QueryWrapper() {
-        this(null);
+        this((T) null);
+    }
+
+    public QueryWrapper(Function<String, String> columnToString) {
+        this((T) null);
+        this.columnToString = Objects.requireNonNull(columnToString);
     }
 
     public QueryWrapper(T entity) {
@@ -126,5 +138,10 @@ public class QueryWrapper<T> extends AbstractWrapper<T, String, QueryWrapper<T>>
     public void clear() {
         super.clear();
         sqlSelect.toNull();
+    }
+
+    @Override
+    protected String columnToString(String column) {
+        return columnToString.apply(column);
     }
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/UpdateWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/UpdateWrapper.java
@@ -25,7 +25,9 @@ import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 /**
  * Update 条件封装
@@ -42,9 +44,19 @@ public class UpdateWrapper<T> extends AbstractWrapper<T, String, UpdateWrapper<T
      */
     private final List<String> sqlSet;
 
+    /**
+     * 列名转换
+     */
+    private Function<String, String> columnToString = s -> s;
+
     public UpdateWrapper() {
         // 如果无参构造函数，请注意实体 NULL 情况 SET 必须有否则 SQL 异常
-        this(null);
+        this((T) null);
+    }
+
+    public UpdateWrapper(Function<String, String> columnToString) {
+        this((T) null);
+        this.columnToString = Objects.requireNonNull(columnToString);
     }
 
     public UpdateWrapper(T entity) {
@@ -79,7 +91,7 @@ public class UpdateWrapper<T> extends AbstractWrapper<T, String, UpdateWrapper<T
     public UpdateWrapper<T> set(boolean condition, String column, Object val, String mapping) {
         return maybeDo(condition, () -> {
             String sql = formatParam(mapping, val);
-            sqlSet.add(column + Constants.EQUALS + sql);
+            sqlSet.add(columnToString(column) + Constants.EQUALS + sql);
         });
     }
 
@@ -114,5 +126,10 @@ public class UpdateWrapper<T> extends AbstractWrapper<T, String, UpdateWrapper<T
     public void clear() {
         super.clear();
         sqlSet.clear();
+    }
+
+    @Override
+    protected String columnToString(String column) {
+        return columnToString.apply(column);
     }
 }

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/BaseWrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/BaseWrapperTest.java
@@ -4,6 +4,7 @@ import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.core.toolkit.Constants;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import lombok.Data;
+import lombok.experimental.FieldNameConstants;
 import org.assertj.core.api.Assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +35,7 @@ class BaseWrapperTest {
     }
 
     @Data
+    @FieldNameConstants
     protected static class Entity {
         private Integer id;
 

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/QueryWrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/QueryWrapperTest.java
@@ -3,6 +3,7 @@ package com.baomidou.mybatisplus.core.conditions;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +15,14 @@ import java.util.*;
  * @since 2021-01-27
  */
 class QueryWrapperTest extends BaseWrapperTest {
+
+    @Test
+    void testColumnToString() {
+        QueryWrapper<Entity> ew = new QueryWrapper<Entity>(StringUtils::camelToUnderline)
+            .eq(Entity.Fields.id, 123)
+            .eq(Entity.Fields.roleId, 213);
+        logSqlWhere("QueryWrapper#columnToString测试", ew, "(id = ? AND role_id = ?)");
+    }
 
     @Test
     void testCacheSqlSegment() {

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/UpdateWrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/UpdateWrapperTest.java
@@ -1,6 +1,7 @@
 package com.baomidou.mybatisplus.core.conditions;
 
 import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.test.User;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,19 @@ import org.junit.jupiter.api.Test;
  * @since 2021-01-27
  */
 class UpdateWrapperTest extends BaseWrapperTest {
+
+    @Test
+    void testColumnToString() {
+        UpdateWrapper<User> wrapper = new UpdateWrapper<User>(StringUtils::camelToUnderline)
+            .set(User.Fields.id, 1)
+            .set(User.Fields.roleId, 12)
+            .eq(User.Fields.id, 2)
+            .eq(User.Fields.roleId, 12);
+
+        logSqlSet("xx", wrapper, "id=#{ew.paramNameValuePairs.MPGENVAL1},role_id=#{ew.paramNameValuePairs.MPGENVAL2}");
+        logSqlWhere("xx", wrapper, "(id = ? AND role_id = ?)");
+        logParams(wrapper);
+    }
 
     @Test
     void test1() {

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/User.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/User.java
@@ -18,9 +18,11 @@ package com.baomidou.mybatisplus.test;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
+import lombok.experimental.FieldNameConstants;
 
 @TableName("sys_user")
 @Data
+@FieldNameConstants
 public class User {
 
     private Integer id;


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述

QueryWrapper和UpdateWrapper添加构造方法，支持自定义columnToString方法

很多时候，使用QueryWrapper或者UpdateWrapper时，列名和对象对的属性名并不一致，需要转一下才能使用，非常麻烦。
支持自定义columnToString方法后，配合lombok的@FieldNameConstants，使用起来很方便

### 测试用例

已提交

### 修复效果的截屏


