### PR TITLE
deleteBatchIds支持传入实体(实现Serializable)删除.

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/DeleteBatchByIds.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/DeleteBatchByIds.java
@@ -37,14 +37,20 @@ public class DeleteBatchByIds extends AbstractMethod {
         if (tableInfo.isWithLogicDelete()) {
             sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(), sqlLogicSet(tableInfo),
                 tableInfo.getKeyColumn(),
-                SqlScriptUtils.convertForeach("#{item}", COLLECTION, null, "item", COMMA),
+                SqlScriptUtils.convertForeach(
+                    SqlScriptUtils.convertChoose("@com.baomidou.mybatisplus.core.toolkit.ReflectionKit@isPrimitiveOrWrapper(item.getClass())",
+                        "#{item}", "#{item." + tableInfo.getKeyProperty() + "}"),
+                    COLLECTION, null, "item", COMMA),
                 tableInfo.getLogicDeleteSql(true, true));
             SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, Object.class);
             return addUpdateMappedStatement(mapperClass, modelClass, getMethod(sqlMethod), sqlSource);
         } else {
             sqlMethod = SqlMethod.DELETE_BATCH_BY_IDS;
             sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(), tableInfo.getKeyColumn(),
-                SqlScriptUtils.convertForeach("#{item}", COLLECTION, null, "item", COMMA));
+                SqlScriptUtils.convertForeach(
+                    SqlScriptUtils.convertChoose("@com.baomidou.mybatisplus.core.toolkit.ReflectionKit@isPrimitiveOrWrapper(item.getClass())",
+                        "#{item}", "#{item." + tableInfo.getKeyProperty() + "}"),
+                    COLLECTION, null, "item", COMMA));
             SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, Object.class);
             return this.addDeleteMappedStatement(mapperClass, getMethod(sqlMethod), sqlSource);
         }


### PR DESCRIPTION
在实体实现序列化接口的情况下,能够调用deleteBatchIds实现删除效果.
原deleteById传入实体或id都是正常的
deleteBatchIds只能传入id