### PR TITLE
feature:支持自定义SQL以Lambda语法的Wrapper查询

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableField.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableField.java
@@ -179,4 +179,15 @@ public @interface TableField {
      * @since 3.1.2
      */
     String numericScale() default "";
+
+    /**
+     * 是否为扩展字段，默认false，
+     * 需要同时设置 {@link TableField#exist()} 为 false 以及 {@link TableField#value()} 的值不为空才会生效
+     * <p>
+     * false：非扩展字段
+     * true：扩展字段，将会缓存到 {@link com.baomidou.mybatisplus.core.metadata.TableInfo#aliasFieldList} 属性中，以提供多表联查的支持
+     *
+     * @since 3.4.4.3
+     */
+    boolean aliasField() default false;
 }

--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableField.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableField.java
@@ -181,10 +181,10 @@ public @interface TableField {
     String numericScale() default "";
 
     /**
-     * 是否为别名扩展字段，默认false，
-     * 需要同时设置 {@link TableField#exist()} 为 false 以及 {@link TableField#value()} 的值不为空才会生效
+     * 是否为别名扩展字段，默认false；为true时，需要同时设置 {@link TableField#exist()} 为 false，
+     * 或者当前属性已在 {@link TableName#excludeProperty()} 中排除， 以及 {@link TableField#value()} 的值不为空才会生效
      * <p>
-     * false：非扩展字段
+     * false：非扩展字段，不会做任何处理
      * true：扩展字段，将会缓存到 {@link com.baomidou.mybatisplus.core.metadata.TableInfo#aliasFieldList} 属性中，以提供多表联查的支持
      *
      * @since 3.4.4.3

--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableField.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableField.java
@@ -181,7 +181,7 @@ public @interface TableField {
     String numericScale() default "";
 
     /**
-     * 是否为扩展字段，默认false，
+     * 是否为别名扩展字段，默认false，
      * 需要同时设置 {@link TableField#exist()} 为 false 以及 {@link TableField#value()} 的值不为空才会生效
      * <p>
      * false：非扩展字段

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
@@ -79,13 +79,17 @@ public abstract class AbstractLambdaWrapper<T, Children extends AbstractLambdaWr
         return getColumnCache(fieldName, instantiatedClass);
     }
 
+    protected Map<String, ColumnCache> getColumnMap(Class<?> entityClass) {
+        return LambdaUtils.getColumnMap(entityClass);
+    }
+
     private void tryInitCache(Class<?> lambdaClass) {
         if (!initColumnMap) {
             final Class<T> entityClass = getEntityClass();
             if (entityClass != null) {
                 lambdaClass = entityClass;
             }
-            columnMap = LambdaUtils.getColumnMap(lambdaClass);
+            columnMap = this.getColumnMap(lambdaClass);
             Assert.notNull(columnMap, "can not find lambda cache for this entity [%s]", lambdaClass.getName());
             initColumnMap = true;
         }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/LambdaAliasQueryWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/LambdaAliasQueryWrapper.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2011-2021, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.conditions.query;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.baomidou.mybatisplus.core.conditions.SharedString;
+import com.baomidou.mybatisplus.core.conditions.segments.MergeSegments;
+import com.baomidou.mybatisplus.core.toolkit.Assert;
+import com.baomidou.mybatisplus.core.toolkit.LambdaUtils;
+import com.baomidou.mybatisplus.core.toolkit.ObjectUtils;
+import com.baomidou.mybatisplus.core.toolkit.StringPool;
+import com.baomidou.mybatisplus.core.toolkit.support.ColumnCache;
+import com.baomidou.mybatisplus.core.toolkit.support.SFunction;
+
+/**
+ * 支持联表查询的{@link LambdaQueryWrapper} 且支持自定义主表别名
+ *
+ * @author huguirong
+ * @since 2021-06-21
+ */
+public class LambdaAliasQueryWrapper<T> extends LambdaQueryWrapper<T> {
+
+    private String alias;
+
+    public LambdaAliasQueryWrapper(String alias) {
+        super();
+        this.setAlias(alias);
+    }
+
+    public LambdaAliasQueryWrapper(T entity, String alias) {
+        super(entity);
+        this.setAlias(alias);
+    }
+
+    public LambdaAliasQueryWrapper(Class<T> entityClass, String alias) {
+        super(entityClass);
+        this.setAlias(alias);
+    }
+
+    LambdaAliasQueryWrapper(T entity, Class<T> entityClass, SharedString sqlSelect, AtomicInteger paramNameSeq,
+                            Map<String, Object> paramNameValuePairs, MergeSegments mergeSegments, SharedString paramAlias,
+                            SharedString lastSql, SharedString sqlComment, SharedString sqlFirst, String alias) {
+        super(entity, entityClass, sqlSelect, paramNameSeq, paramNameValuePairs,
+            mergeSegments, paramAlias, lastSql, sqlComment, sqlFirst);
+        this.setAlias(alias);
+    }
+
+    private void setAlias(String alias) {
+        Assert.notEmpty(alias, "This alias is required; it must not be null");
+        this.alias = alias;
+    }
+
+    @Override
+    protected Map<String, ColumnCache> getColumnMap(Class<?> entityClass) {
+        Map<String, ColumnCache> columnMap = new HashMap<>();
+        Map<String, ColumnCache> cacheColumnMap = LambdaUtils.getColumnMap(entityClass);
+        if (cacheColumnMap == null) {
+            columnMap = new HashMap<>();
+        } else if (!cacheColumnMap.isEmpty()) {
+            final String columnPrefix = alias.concat(StringPool.DOT);
+            columnMap = cacheColumnMap.entrySet().stream().collect(toMap(Map.Entry::getKey, entry -> {
+                ColumnCache cache = entry.getValue();
+                /* 将表字段拼上表别名 */
+                String aliasColumn = columnPrefix.concat(cache.getColumn());
+                return new ColumnCache(aliasColumn, cache.getColumnSelect());
+            }));
+        }
+        /* 给columnMap补充别名扩展字段 */
+        Map<String, ColumnCache> aliasColumnMap = LambdaUtils.getAliasColumnMap(entityClass);
+        if (ObjectUtils.isNotEmpty(aliasColumnMap)) {
+            columnMap.putAll(aliasColumnMap);
+        }
+        Assert.isFalse(columnMap.isEmpty(), String.format("Can not find lambda cache for this entity [%s]", entityClass.getName()));
+        return columnMap;
+    }
+
+    @Override
+    protected LambdaAliasQueryWrapper<T> instance() {
+        return new LambdaAliasQueryWrapper<>(getEntity(), getEntityClass(), null, paramNameSeq, paramNameValuePairs,
+            new MergeSegments(), paramAlias, SharedString.emptyString(), SharedString.emptyString(), SharedString.emptyString(), alias);
+    }
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/AliasFieldInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/AliasFieldInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2021, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.metadata;
+
+import java.lang.reflect.Field;
+
+import org.apache.ibatis.reflection.Reflector;
+
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.core.toolkit.Constants;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * 别名查询扩展字段信息
+ *
+ * @author huguirong
+ * @since 2021-06-21
+ */
+@Getter
+@ToString
+@EqualsAndHashCode
+public class AliasFieldInfo implements Constants {
+
+    /**
+     * 属性
+     */
+    private final Field field;
+    /**
+     * 字段名
+     */
+    private final String column;
+    /**
+     * 属性名
+     */
+    private final String property;
+
+    /**
+     * 属性类型
+     */
+    private final Class<?> propertyType;
+
+    /**
+     * 全新的 存在 TableField 注解时使用的构造函数
+     */
+    public AliasFieldInfo(Field field, TableField tableField, Reflector reflector) {
+        field.setAccessible(true);
+        this.field = field;
+        this.property = field.getName();
+        this.propertyType = reflector.getGetterType(this.property);
+        this.column = tableField.value();
+    }
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/AliasFieldInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/AliasFieldInfo.java
@@ -15,12 +15,10 @@
  */
 package com.baomidou.mybatisplus.core.metadata;
 
+import java.io.Serializable;
 import java.lang.reflect.Field;
 
-import org.apache.ibatis.reflection.Reflector;
-
 import com.baomidou.mybatisplus.annotation.TableField;
-import com.baomidou.mybatisplus.core.toolkit.Constants;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -35,34 +33,23 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class AliasFieldInfo implements Constants {
+public class AliasFieldInfo implements Serializable {
 
     /**
-     * 属性
-     */
-    private final Field field;
-    /**
-     * 字段名
+     * 自定义列名
      */
     private final String column;
+
     /**
      * 属性名
      */
     private final String property;
 
     /**
-     * 属性类型
-     */
-    private final Class<?> propertyType;
-
-    /**
      * 全新的 存在 TableField 注解时使用的构造函数
      */
-    public AliasFieldInfo(Field field, TableField tableField, Reflector reflector) {
-        field.setAccessible(true);
-        this.field = field;
+    public AliasFieldInfo(Field field, TableField tableField) {
         this.property = field.getName();
-        this.propertyType = reflector.getGetterType(this.property);
         this.column = tableField.value();
     }
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
@@ -15,6 +15,21 @@
  */
 package com.baomidou.mybatisplus.core.metadata;
 
+import static java.util.stream.Collectors.joining;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import org.apache.ibatis.mapping.ResultFlag;
+import org.apache.ibatis.mapping.ResultMap;
+import org.apache.ibatis.mapping.ResultMapping;
+import org.apache.ibatis.session.Configuration;
+
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.KeySequence;
 import com.baomidou.mybatisplus.core.toolkit.Assert;
@@ -22,21 +37,12 @@ import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 import com.baomidou.mybatisplus.core.toolkit.Constants;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.core.toolkit.sql.SqlScriptUtils;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import org.apache.ibatis.mapping.ResultFlag;
-import org.apache.ibatis.mapping.ResultMap;
-import org.apache.ibatis.mapping.ResultMapping;
-import org.apache.ibatis.session.Configuration;
-
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
-
-import static java.util.stream.Collectors.joining;
 
 /**
  * 数据库表反射信息
@@ -177,6 +183,13 @@ public class TableInfo implements Constants {
     @Getter
     @Setter
     private List<TableFieldInfo> orderByFields = new LinkedList<>();
+
+    /**
+     * 别名查询扩展字段信息列表
+     *
+     * @since 3.4.4.3
+     */
+    private List<AliasFieldInfo> aliasFieldList;
 
     public TableInfo(Class<?> entityType) {
         this.entityType = entityType;
@@ -469,6 +482,14 @@ public class TableInfo implements Constants {
 
     public List<TableFieldInfo> getFieldList() {
         return Collections.unmodifiableList(fieldList);
+    }
+
+    void setAliasFieldList(List<AliasFieldInfo> aliasFieldList) {
+        this.aliasFieldList = aliasFieldList;
+    }
+
+    public List<AliasFieldInfo> getAliasFieldList() {
+        return CollectionUtils.isEmpty(aliasFieldList) ? Collections.emptyList() : Collections.unmodifiableList(aliasFieldList);
     }
 
     @Deprecated

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
@@ -374,12 +374,10 @@ public class TableInfoHelper {
         if (CollectionUtils.isEmpty(list)) {
             return;
         }
-        ReflectorFactory reflectorFactory = tableInfo.getConfiguration().getReflectorFactory();
-        Reflector reflector = reflectorFactory.findForClass(clazz);
         List<AliasFieldInfo> aliasFields = list.stream()
             //过滤掉排除的属性
             .filter(field -> !excludeProperty.contains(field.getName()))
-            .map(field -> new AliasFieldInfo(field, field.getAnnotation(TableField.class), reflector))
+            .map(field -> new AliasFieldInfo(field, field.getAnnotation(TableField.class)))
             .collect(toList());
 
         tableInfo.setAliasFieldList(aliasFields);

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/LambdaUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/LambdaUtils.java
@@ -16,6 +16,7 @@
 package com.baomidou.mybatisplus.core.toolkit;
 
 import static java.util.Locale.ENGLISH;
+import static java.util.stream.Collectors.toMap;
 
 import java.lang.invoke.SerializedLambda;
 import java.lang.reflect.InvocationTargetException;
@@ -170,7 +171,7 @@ public final class LambdaUtils {
         if (CollectionUtils.isEmpty(aliasFieldList)) {
             return null;
         }
-        return aliasFieldList.stream().collect(Collectors.toMap(field -> formatKey(field.getProperty()),
+        return aliasFieldList.stream().collect(toMap(field -> formatKey(field.getProperty()),
             field -> new ColumnCache(field.getColumn(), field.getColumn())));
     }
 


### PR DESCRIPTION
### 背景

由于原 [LambdaQueryWrapper](https://github.com/baomidou/mybatis-plus/blob/3.0/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/LambdaQueryWrapper.java "LambdaQueryWrapper") 尚未支持自定义SQL的动态查询，而该业务场景又较为常见，因此只能使用 [QueryWrapper](https://github.com/baomidou/mybatis-plus/blob/3.0/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/QueryWrapper.java "QueryWrapper") 进行联表查询，由此会带来几个问题：

* 将列名硬编码到 `java` 源代码中，且较为泛滥

* 当列名变更时维护起来较为困难

因此，基于 `mybatis-plus 3.4.2` 以及反射机制我有实现一版用于支持自定义SQL的动态查询的框架，已经在生产环境上线暂时没有遇到过问题，但反射实现终究比较麻烦，直接修改源代码是最简洁的，所以这也是为什么提交这个 `PR` 的原因

### 使用介绍

1、该 `PR` 增加了  [LambdaAliasQueryWrapper](https://github.com/terminux/mybatis-plus/blob/3.0/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/LambdaAliasQueryWrapper.java "LambdaAliasQueryWrapper") 类，该类继承自  [LambdaQueryWrapper](https://github.com/baomidou/mybatis-plus/blob/3.0/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/LambdaQueryWrapper.java "LambdaQueryWrapper") ，在构造方法中增加了一个参数名为 `alias`   的 `String` 类型的参数，表示自定义  `SQL`  中 **主表** 的别名，其中的一个构造方法代码片段如下：

```java
public LambdaAliasQueryWrapper(Class<T> entityClass, String alias)
```

2、假如我们有两个表 `t_user` ：用户表 ，`t_org`：用户所属组织机构表，建表SQL如下：

```sql
CREATE TABLE `t_user` (
  `id` bigint(20) NOT NULL,
  `user_name` varchar(64)  NOT NULL COMMENT '用户名',
  `org_id` bigint(20) NOT NULL COMMENT '所属组织机构id',
  PRIMARY KEY (`id`) USING BTREE
) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci COMMENT = '用户表' ROW_FORMAT = Dynamic;
```

```sql
CREATE TABLE `t_org` (
  `id` bigint(20) NOT NULL,
  `code` varchar(255) NOT NULL COMMENT '组织机构编号',
  `name` varchar(60) NOT NULL COMMENT '组织机构名称',
  PRIMARY KEY (`id`) USING BTREE
) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci COMMENT = '组织机构表' ROW_FORMAT = Dynamic;
```
各插入一条测试数据：
```sql
INSERT INTO `t_org`(`id`, `code`, `name`) VALUES (1397777654547087362, '1001', '技术部');
INSERT INTO `t_user`(`id`, `user_name`, `org_id`) VALUES (1397777654576447489, '张三', 1397777654547087362);
```

3、现在我们的需求是用户表联合组织机构表查询，获取用户以及用户所在的组织机构信息，操作步骤如下：

* 在 `UserMapper` 中增加一个名为 `listUser` 的方法，例如：
```java
List<User> listUser(@Param(Constants.WRAPPER) Wrapper<User> ew);
```
对应的 `xml` 为
```xml
<select id="listUser" resultType="com.xxx.User">
        SELECT u.`id`, u.`user_name`, u.`org_id`, o.`name` AS `org_name`, o.`code` AS `org_code`
        FROM t_user u
        INNER JOIN t_org o ON u.`org_id` = o.`id`
        ${ew.customSqlSegment}
</select>
```

* 在用户实体类中增加两个属性如下
```java
//组织机构名称
@TableField(exist = false, aliasField = true, value = "o.name")
private String orgName;
 
//所属组织机构编码
@TableField(exist = false, aliasField = true, value = "o.code")
private String orgCode;
```

> `aliasField` 属性为本次 `PR` 新增，表示当前字段是否为别名扩展字段，默认 `false`；若为 `true` 则可以支持多表联查，需要同时设置它的  `value`  属性，以及 `exist` 属性为 `false` 或者当前属性已在 [TableName](https://github.com/baomidou/mybatis-plus/blob/3.0/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableName.java "TableName") 注解的 
`excludeProperty` 属性中排除才生效

* 完成以上步骤后即可在程序中使用  [LambdaAliasQueryWrapper](https://github.com/terminux/mybatis-plus/blob/3.0/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/query/LambdaAliasQueryWrapper.java "LambdaAliasQueryWrapper") 了，代码示例：

```java
LambdaQueryWrapper<User> wrapper = new LambdaAliasQueryWrapper<>(User.class, "u")
                .eq(User::getId, 1397777654576447489L)
                .like(User::getOrgName, "技术")
                .orderByDesc(User::getOrgCode);

List<User> users = userMapper.listUser(wrapper);
System.out.println(JsonUtil.toJsonStr(users));
```

（虽然 `orgName` 和 `orgCode` 都不属于用户表，但依然可以用 `Lambda` 的形式调用）输出结果：
```json
[
    {
        "id":"1397777654576447489",
        "userName":"张三",
        "orgId":"1397777654547087362",
        "orgName":"技术部",
        "orgCode":"0001"
    }
]
```

   
### 总结

以这种方式实现的联表查询较为灵活，且没有修改较多的源码，不太容易影响到旧的功能，也没有偏离 ` mybatis` 的设计理念，即复杂 `SQL` 还是在 `xml` 中维护的。将所有的列名都控制在实体类中，不会造成列名硬编码泛滥的问题，当列名变化时只需要修改实体类即可