### PR TITLE
domain上condition的like支持多数据库兼容，现有的不兼容oracle，更改后oracle、mysql、达梦可以兼容

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/SqlCondition.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/SqlCondition.java
@@ -33,7 +33,7 @@ public class SqlCondition {
     /**
      * % 两边 %
      */
-    public static final String LIKE = "%s LIKE CONCAT('%%',#{%s},'%%')";
+    public static final String LIKE = "%s LIKE CONCAT(CONCAT('%%',#{%s}),'%%')";
     /**
      * % 左
      */


### PR DESCRIPTION
### 该Pull Request关联的Issue

无

### 修改描述
SqlCondition常量类的LIKE兼容多数据库，修改前不支持oracle


### 测试用例



### 修复效果的截屏


