### PR TITLE
BaseMapper新增deleteById(T entity)方法

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
@@ -348,10 +348,7 @@ public abstract class AbstractMethod implements Constants {
             return null;
         }
         /* 缓存逻辑处理 */
-        boolean isSelect = false;
-        if (sqlCommandType == SqlCommandType.SELECT) {
-            isSelect = true;
-        }
+        boolean isSelect = sqlCommandType == SqlCommandType.SELECT;
         return builderAssistant.addMappedStatement(id, sqlSource, StatementType.PREPARED, sqlCommandType,
             null, null, null, parameterType, resultMap, resultType,
             null, !isSelect, isSelect, false, keyGenerator, keyProperty, keyColumn,

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
@@ -99,6 +99,14 @@ public interface BaseMapper<T> extends Mapper<T> {
     int deleteById(Serializable id);
 
     /**
+     * 根据实体(ID)删除
+     *
+     * @param entity 实体对象
+     * @since 3.4.4
+     */
+    int deleteById(T entity);
+
+    /**
      * 根据 columnMap 条件，删除记录
      *
      * @param columnMap 表字段 map 对象

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/injector/methods/LogicDeleteByIdWithFill.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/injector/methods/LogicDeleteByIdWithFill.java
@@ -39,9 +39,11 @@ import static java.util.stream.Collectors.toList;
  * </p>
  *
  * @author miemie
+ * @deprecated 3.4.4 {@link com.baomidou.mybatisplus.core.injector.methods.DeleteById}
  * @since 2018-11-09
  */
 @SuppressWarnings("serial")
+@Deprecated
 public class LogicDeleteByIdWithFill extends AbstractMethod {
 
     @Override

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/IService.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/IService.java
@@ -109,6 +109,16 @@ public interface IService<T> {
     }
 
     /**
+     * 根据实体(ID)删除
+     *
+     * @param entity 实体
+     * @since 3.4.4
+     */
+    default boolean removeById(T entity) {
+        return SqlHelper.retBool(getBaseMapper().deleteById(entity));
+    }
+
+    /**
      * 根据 columnMap 条件，删除记录
      *
      * @param columnMap 表字段 map 对象

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2StudentMapperTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2StudentMapperTest.java
@@ -25,6 +25,7 @@ import com.baomidou.mybatisplus.test.h2.entity.H2Student;
 import com.baomidou.mybatisplus.test.h2.enums.GenderEnum;
 import com.baomidou.mybatisplus.test.h2.enums.GradeEnum;
 import com.baomidou.mybatisplus.test.h2.mapper.H2StudentMapper;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -104,4 +105,10 @@ class H2StudentMapperTest extends BaseTest {
         System.out.println(wrapper2.getSqlSegment());
     }
 
+    @Test
+    void testDeleteByIdWithEntity() {
+        H2Student h2Student = new H2Student(111L, "测试根据实体删除", 12);
+        studentMapper.insert(h2Student);
+        Assertions.assertEquals(studentMapper.deleteById(h2Student), 1);
+    }
 }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
@@ -498,6 +498,18 @@ class H2UserTest extends BaseTest {
         Assertions.assertTrue(userService.update(lambdaUpdateWrapper.eq(H2User::getName, "小红")));
     }
 
+    @Test
+    void testLogicDelWithFill() {
+        H2User h2User = new H2User("逻辑删除(根据ID)不填充", AgeEnum.TWO);
+        userService.save(h2User);
+        userService.removeById(h2User.getTestId());
+        Assertions.assertNull(h2User.getLastUpdatedDt());
+        h2User = new H2User("测试逻辑(根据实体)删除填充", AgeEnum.TWO);
+        userService.save(h2User);
+        userService.removeById(h2User);
+        Assertions.assertNotNull(h2User.getLastUpdatedDt());
+    }
+
     /**
      * 观察 {@link com.baomidou.mybatisplus.core.toolkit.LambdaUtils#extract(SFunction)}
      */

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/logicdel/LogicDelTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/logicdel/LogicDelTest.java
@@ -34,6 +34,13 @@ public class LogicDelTest extends BaseDbTest<EntityMapper> {
             assertThat(entity).isNotNull();
             assertThat(entity.getDeleted()).isTrue();
         });
+
+        doTest(mapper -> {
+            Entity entity = new Entity();
+            entity.setName("测试根据实体删除");
+            mapper.insert(entity);
+            assertThat(mapper.deleteById(entity)).isEqualTo(1);
+        });
     }
 
     @Override


### PR DESCRIPTION
1.新增基础方法,可传入实体进行记录删除.
2.支持逻辑删除填充属性
3.过时LogicDeleteByIdWithFill