### PR TITLE
wrapper clear 将sqlSegment重置为空串 缓存标志重置为true

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/segments/MergeSegments.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/segments/MergeSegments.java
@@ -80,6 +80,8 @@ public class MergeSegments implements ISqlSegment {
      * @since 3.3.1
      */
     public void clear() {
+        sqlSegment = StringPool.EMPTY;
+        cacheSqlSegment = true;
         normal.clear();
         groupBy.clear();
         having.clear();


### PR DESCRIPTION
### 该Pull Request关联的Issue

#3733 

### 修改描述

wrapper clear 将sqlSegment重置为空串 缓存标志重置为true

### 测试用例

    @Test
    void testQueryWrapper() {
        QueryWrapper<Entity> queryWrapper = new QueryWrapper<Entity>().or()
                .ge("age", 3).or().ge("age", 3).ge("age", 3).or().or().or().or();
        System.out.println(queryWrapper.getSqlSegment());
        queryWrapper.clear();
        assertThat(queryWrapper.getSqlSegment().trim()).isEqualTo(StringPool.EMPTY);
    }

### 修复效果的截屏
![image](https://user-images.githubusercontent.com/10581550/125579717-896587bb-0038-4b49-8c85-7c089e65afb8.png)


