### PR TITLE
针对动态表名插件增加一个表名处理器的provider以实现更包容的处理策略。

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DynamicTableNameInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DynamicTableNameInnerInterceptor.java
@@ -19,6 +19,7 @@ import com.baomidou.mybatisplus.core.plugins.InterceptorIgnoreHelper;
 import com.baomidou.mybatisplus.core.toolkit.PluginUtils;
 import com.baomidou.mybatisplus.core.toolkit.TableNameParser;
 import com.baomidou.mybatisplus.extension.plugins.handler.TableNameHandler;
+import com.baomidou.mybatisplus.extension.plugins.provider.TableNameHandlerProvider;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -34,7 +35,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * 动态表名
@@ -48,7 +48,7 @@ import java.util.Map;
 @SuppressWarnings({"rawtypes"})
 public class DynamicTableNameInnerInterceptor implements InnerInterceptor {
 
-    private Map<String, TableNameHandler> tableNameHandlerMap;
+    private TableNameHandlerProvider tableNameHandlerProvider;
 
     @Override
     public void beforeQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
@@ -80,7 +80,7 @@ public class DynamicTableNameInnerInterceptor implements InnerInterceptor {
             if (start != last) {
                 builder.append(sql, last, start);
                 String value = name.getValue();
-                TableNameHandler handler = tableNameHandlerMap.get(value);
+                TableNameHandler handler = tableNameHandlerProvider.get(value);
                 if (handler != null) {
                     builder.append(handler.dynamicTableName(sql, value));
                 } else {

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/provider/TableNameHandlerProvider.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/provider/TableNameHandlerProvider.java
@@ -1,0 +1,18 @@
+package com.baomidou.mybatisplus.extension.plugins.provider;
+
+import com.baomidou.mybatisplus.extension.plugins.handler.TableNameHandler;
+
+/**
+ * @author Langel
+ * @since 2021-08-04
+ **/
+public interface TableNameHandlerProvider {
+
+    /**
+     * get {@link TableNameHandler} by table name
+     * @param value tableName
+     * @return {@link TableNameHandler}
+     */
+    TableNameHandler get(String value);
+
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue
无

### 修改描述
原有DynamicTableNameInnerInterceptor依赖Map<String, TableNameHandler> tableNameHandlerMap 从而限制了表名称和处理器的关系，当多个表名甚至所有表名使用同一个处理器时产生局限。
现在DynamicTableNameInnerInterceptor依赖TableNameHandlerProvider，使用者可以在TableNameHandlerProvider中针对表名提供任意的处理器。

### 测试用例
com.baomidou.mybatisplus.extension.plugins.inner.DynamicTableNameInnerInterceptorTest

### 修复效果的截屏
![image](https://user-images.githubusercontent.com/31590534/128139895-4daf186f-6872-4d12-9285-60f8bce43be0.png)


