### PR TITLE
修复 removeByIds方法报错

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKit.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKit.java
@@ -55,6 +55,9 @@ public final class ReflectionKit {
         PRIMITIVE_WRAPPER_TYPE_MAP.put(Integer.class, int.class);
         PRIMITIVE_WRAPPER_TYPE_MAP.put(Long.class, long.class);
         PRIMITIVE_WRAPPER_TYPE_MAP.put(Short.class, short.class);
+        PRIMITIVE_WRAPPER_TYPE_MAP.put(String.class, String.class);
+        PRIMITIVE_WRAPPER_TYPE_MAP.put(BigInteger.class, BigInteger.class);
+        PRIMITIVE_WRAPPER_TYPE_MAP.put(BigDecimal.class, BigDecimal.class);
         for (Map.Entry<Class<?>, Class<?>> entry : PRIMITIVE_WRAPPER_TYPE_MAP.entrySet()) {
             PRIMITIVE_TYPE_TO_WRAPPER_MAP.put(entry.getValue(), entry.getKey());
         }


### PR DESCRIPTION
增加基本类型或包装类型

### 该Pull Request关联的Issue
https://github.com/baomidou/mybatis-plus/issues/3874


### 修改描述

com.baomidou.mybatisplus.core.toolkit.ReflectionKit->PRIMITIVE_WRAPPER_TYPE_MAP 中定义的基本类型中比mybatis 缺少 String、BigDecimal、BigInteger，导致com.baomidou.mybatisplus.core.toolkit.ReflectionKit@isPrimitiveOrWrapper 判断错误，
com.baomidou.mybatisplus.core.injector.methods@injectMappedStatement 生成的foreach 脚本多了item, 而基本类型是不需要用item的

### 测试用例



### 修复效果的截屏


