### PR TITLE
过时ReflectionKit#isPrimitiveOrWrapper方法,优化SqlRunner#selectCount

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisParameterHandler.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisParameterHandler.java
@@ -22,7 +22,6 @@ import com.baomidou.mybatisplus.core.metadata.TableInfo;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.core.toolkit.Constants;
 import com.baomidou.mybatisplus.core.toolkit.GlobalConfigUtils;
-import com.baomidou.mybatisplus.core.toolkit.ReflectionKit;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.executor.parameter.ParameterHandler;
@@ -30,6 +29,7 @@ import org.apache.ibatis.mapping.*;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.SimpleTypeRegistry;
 import org.apache.ibatis.type.TypeException;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
@@ -72,8 +72,7 @@ public class MybatisParameterHandler implements ParameterHandler {
         if (parameter != null
             && (SqlCommandType.INSERT == this.sqlCommandType || SqlCommandType.UPDATE == this.sqlCommandType)) {
             //检查 parameterObject
-            if (ReflectionKit.isPrimitiveOrWrapper(parameter.getClass())
-                || parameter.getClass() == String.class) {
+            if (SimpleTypeRegistry.isSimpleType(parameter.getClass())) {
                 return parameter;
             }
             Collection<Object> parameters = getParameters(parameter);

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/SqlRunnerInjector.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/SqlRunnerInjector.java
@@ -136,7 +136,7 @@ public class SqlRunnerInjector {
             return;
         }
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, ISqlRunner.SQL_SCRIPT, Map.class);
-        createSelectMappedStatement(ISqlRunner.COUNT, sqlSource, Integer.class);
+        createSelectMappedStatement(ISqlRunner.COUNT, sqlSource, Long.class);
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
@@ -30,6 +30,7 @@ import org.apache.ibatis.mapping.ResultMap;
 import org.apache.ibatis.mapping.SqlCommandType;
 import org.apache.ibatis.reflection.Reflector;
 import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.type.SimpleTypeRegistry;
 
 import java.lang.reflect.Field;
 import java.util.*;
@@ -73,7 +74,7 @@ public class TableInfoHelper {
      * @return 数据库表反射信息
      */
     public static TableInfo getTableInfo(Class<?> clazz) {
-        if (clazz == null || ReflectionKit.isPrimitiveOrWrapper(clazz) || clazz == String.class || clazz.isInterface()) {
+        if (clazz == null || clazz.isPrimitive() || SimpleTypeRegistry.isSimpleType(clazz) || clazz.isInterface()) {
             return null;
         }
         // https://github.com/baomidou/mybatis-plus/issues/299

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKit.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKit.java
@@ -20,8 +20,6 @@ import com.baomidou.mybatisplus.core.toolkit.reflect.GenericTypeUtils;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.security.AccessController;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +42,7 @@ public final class ReflectionKit {
      */
     private static final Map<Class<?>, List<Field>> CLASS_FIELD_CACHE = new ConcurrentHashMap<>();
 
+    @Deprecated
     private static final Map<Class<?>, Class<?>> PRIMITIVE_WRAPPER_TYPE_MAP = new IdentityHashMap<>(8);
 
     private static final Map<Class<?>, Class<?>> PRIMITIVE_TYPE_TO_WRAPPER_MAP = new IdentityHashMap<>(8);
@@ -57,9 +56,6 @@ public final class ReflectionKit {
         PRIMITIVE_WRAPPER_TYPE_MAP.put(Integer.class, int.class);
         PRIMITIVE_WRAPPER_TYPE_MAP.put(Long.class, long.class);
         PRIMITIVE_WRAPPER_TYPE_MAP.put(Short.class, short.class);
-        PRIMITIVE_WRAPPER_TYPE_MAP.put(String.class, String.class);
-        PRIMITIVE_WRAPPER_TYPE_MAP.put(BigInteger.class, BigInteger.class);
-        PRIMITIVE_WRAPPER_TYPE_MAP.put(BigDecimal.class, BigDecimal.class);
         for (Map.Entry<Class<?>, Class<?>> entry : PRIMITIVE_WRAPPER_TYPE_MAP.entrySet()) {
             PRIMITIVE_TYPE_TO_WRAPPER_MAP.put(entry.getValue(), entry.getKey());
         }
@@ -175,6 +171,7 @@ public final class ReflectionKit {
      * @param clazz class
      * @return 是否基本类型或基本包装类型
      */
+    @Deprecated
     public static boolean isPrimitiveOrWrapper(Class<?> clazz) {
         Assert.notNull(clazz, "Class must not be null");
         return (clazz.isPrimitive() || PRIMITIVE_WRAPPER_TYPE_MAP.containsKey(clazz));

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/toolkit/ReflectionKitTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/toolkit/ReflectionKitTest.java
@@ -148,7 +148,7 @@ class ReflectionKitTest {
 
     @Test
     void testIsPrimitiveOrWrapper() {
-        Assertions.assertTrue(ReflectionKit.isPrimitiveOrWrapper(String.class));
+        Assertions.assertFalse(ReflectionKit.isPrimitiveOrWrapper(String.class));
         Assertions.assertTrue(ReflectionKit.isPrimitiveOrWrapper(Boolean.class));
         Assertions.assertTrue(ReflectionKit.isPrimitiveOrWrapper(boolean.class));
         Assertions.assertTrue(ReflectionKit.isPrimitiveOrWrapper(byte.class));

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/SqlRunner.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/SqlRunner.java
@@ -192,8 +192,7 @@ public class SqlRunner implements ISqlRunner {
     public long selectCount(String sql, Object... args) {
         SqlSession sqlSession = sqlSession();
         try {
-            Object count = sqlSession.selectOne(COUNT, sqlMap(sql, args));
-            return null == count ? 0 : Long.valueOf(String.valueOf(count));
+            return SqlHelper.retCount(sqlSession.<Long>selectOne(COUNT, sqlMap(sql, args)));
         } finally {
             closeSqlSession(sqlSession);
         }


### PR DESCRIPTION
1.恢复被改出歧义的方法isPrimitiveOrWrapper并过时不再使用.
2.修改SqlRunner注入selectCount返回值类型.


