### PR TITLE
:bug: fix left join 条件构造会多一个的问题，以及对于尾缀多个 OnExpression 类似的连接 SQL 支持

### DIFF
--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
@@ -157,7 +157,7 @@ class TenantLineInnerInterceptorTest {
     }
 
     @Test
-    void selectBodySubSelect(){
+    void selectBodySubSelect() {
         assertSql("select t1.col1,(select t2.col2 from t2 t2 where t1.col1=t2.col1) from t1 t1",
             "SELECT t1.col1, (SELECT t2.col2 FROM t2 t2 WHERE t1.col1 = t2.col1 AND t2.tenant_id = 1) FROM t1 t1 WHERE t1.tenant_id = 1");
     }
@@ -178,6 +178,32 @@ class TenantLineInnerInterceptorTest {
             "SELECT * FROM entity e " +
                 "LEFT JOIN entity1 e1 ON e1.id = e.id AND e1.tenant_id = 1 " +
                 "WHERE (e.id = ? OR e.name = ?) AND e.tenant_id = 1");
+    }
+
+    @Test
+    void selectLeftJoinMultipleTrailingOn() {
+        // 多个 on 尾缀的
+        assertSql("SELECT * FROM entity e " +
+                "LEFT JOIN entity1 e1 " +
+                "LEFT JOIN entity2 e2 ON e2.id = e1.id " +
+                "ON e1.id = e.id " +
+                "WHERE (e.id = ? OR e.NAME = ?)",
+            "SELECT * FROM entity e " +
+                "LEFT JOIN entity1 e1 " +
+                "LEFT JOIN entity2 e2 ON e2.id = e1.id AND e2.tenant_id = 1 " +
+                "ON e1.id = e.id AND e1.tenant_id = 1 " +
+                "WHERE (e.id = ? OR e.NAME = ?) AND e.tenant_id = 1");
+
+        assertSql("SELECT * FROM entity e " +
+                "LEFT JOIN entity1 e1 " +
+                "LEFT JOIN with_as_A e2 ON e2.id = e1.id " +
+                "ON e1.id = e.id " +
+                "WHERE (e.id = ? OR e.NAME = ?)",
+            "SELECT * FROM entity e " +
+                "LEFT JOIN entity1 e1 " +
+                "LEFT JOIN with_as_A e2 ON e2.id = e1.id " +
+                "ON e1.id = e.id AND e1.tenant_id = 1 " +
+                "WHERE (e.id = ? OR e.NAME = ?) AND e.tenant_id = 1");
     }
 
     @Test
@@ -204,6 +230,7 @@ class TenantLineInnerInterceptorTest {
 //                "INNER JOIN entity1 e1 ON e1.id = e.id AND e1.tenant_id = 1 " +
 //                "WHERE (e.id = ? OR e.name = ?) AND e.tenant_id = 1");
     }
+
 
     @Test
     void selectWithAs() {


### PR DESCRIPTION

### 修改描述

由于升级 jsqlparese，导致租户拦截器对于 left join 的 on 条件注入时，会添加重复 on 条件。

jsqlparese 已将getOnExpression 和 setOnExpression 方法标记为@Deprecated。

需要切换为 getOnExpressions 和 setOnExpressions
```java
    @Deprecated
    public Expression getOnExpression() {
        return onExpressions.get(0);
    }

    @Deprecated
    public void setOnExpression(Expression expression) {
        onExpressions.add(0, expression);
    }
    
    public Collection<Expression> getOnExpressions() {
        return onExpressions;
    }
    
    public Join setOnExpressions(Collection<Expression> expressions) {
        onExpressions.clear();
        onExpressions.addAll(expressions);
        return this;
    }
```

### 测试用例

TenantLineInnerInterceptorTest#selectLeftJoin

