### PR TITLE
fix: 当逻辑删除字段默认值为null时，阻止全表更新插件失效

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BlockAttackInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BlockAttackInnerInterceptor.java
@@ -28,6 +28,7 @@ import net.sf.jsqlparser.expression.Parenthesis;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
+import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
 import net.sf.jsqlparser.expression.operators.relational.NotEqualsTo;
 import net.sf.jsqlparser.statement.delete.Delete;
 import net.sf.jsqlparser.statement.update.Update;
@@ -76,11 +77,20 @@ public class BlockAttackInnerInterceptor extends JsqlParserSupport implements In
         if (where == null) {
             return true;
         }
-        if (StringUtils.isNotBlank(logicField) && (where instanceof BinaryExpression)) {
+        if (StringUtils.isNotBlank(logicField)) {
 
-            BinaryExpression binaryExpression = (BinaryExpression) where;
-            if (StringUtils.equals(binaryExpression.getLeftExpression().toString(), logicField) || StringUtils.equals(binaryExpression.getRightExpression().toString(), logicField)) {
-                return true;
+            if (where instanceof BinaryExpression) {
+                BinaryExpression binaryExpression = (BinaryExpression) where;
+                if (StringUtils.equals(binaryExpression.getLeftExpression().toString(), logicField) || StringUtils.equals(binaryExpression.getRightExpression().toString(), logicField)) {
+                    return true;
+                }
+            }
+
+            if (where instanceof IsNullExpression) {
+                IsNullExpression binaryExpression = (IsNullExpression) where;
+                if (StringUtils.equals(binaryExpression.getLeftExpression().toString(), logicField)) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述
fix: 当逻辑删除字段默认值为null时，`BlockAttackInnerInterceptor` 插件失效

### 测试用例
1. 设置 `mybatis-plus.global-config.db-config.logic-not-delete-value` 为 `null`
![image](https://user-images.githubusercontent.com/34061813/133837291-b5a7a14c-3549-4522-a461-1833308aa93d.png)
2. 执行无条件delete操作，可以成功
![image](https://user-images.githubusercontent.com/34061813/133837781-7752829b-5988-44da-87fc-2f35922b037d.png)

### 修复效果的截屏
![image](https://user-images.githubusercontent.com/34061813/133838188-18b1eb26-03ed-4dba-8c56-9043dbc168df.png)


