### PR TITLE
恢复ById方法入参调整,增加SqlRunner资源释放方法

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/DeleteBatchByIds.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/DeleteBatchByIds.java
@@ -29,11 +29,11 @@ import org.apache.ibatis.mapping.SqlSource;
  * @since 2018-04-06
  */
 public class DeleteBatchByIds extends AbstractMethod {
-    
+
     public DeleteBatchByIds() {
         super("deleteBatchIds");
     }
-    
+
     /**
      * @param name 方法名
      * @since 3.4.4
@@ -41,7 +41,7 @@ public class DeleteBatchByIds extends AbstractMethod {
     public DeleteBatchByIds(String name) {
         super(name);
     }
-    
+
     @Override
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         String sql;
@@ -54,7 +54,7 @@ public class DeleteBatchByIds extends AbstractMethod {
                         "#{item}", "#{item." + tableInfo.getKeyProperty() + "}"),
                     COLLECTION, null, "item", COMMA),
                 tableInfo.getLogicDeleteSql(true, true));
-            SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, tableInfo.getKeyType());
+            SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, Object.class);
             return addUpdateMappedStatement(mapperClass, modelClass, this.name, sqlSource);
         } else {
             sqlMethod = SqlMethod.DELETE_BATCH_BY_IDS;
@@ -63,7 +63,7 @@ public class DeleteBatchByIds extends AbstractMethod {
                     SqlScriptUtils.convertChoose("@org.apache.ibatis.type.SimpleTypeRegistry@isSimpleType(item.getClass())",
                         "#{item}", "#{item." + tableInfo.getKeyProperty() + "}"),
                     COLLECTION, null, "item", COMMA));
-            SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, tableInfo.getKeyType());
+            SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, Object.class);
             return this.addDeleteMappedStatement(mapperClass, this.name, sqlSource);
         }
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/DeleteById.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/DeleteById.java
@@ -69,13 +69,13 @@ public class DeleteById extends AbstractMethod {
                     tableInfo.getKeyColumn(), tableInfo.getKeyProperty(),
                     tableInfo.getLogicDeleteSql(true, true));
             }
-            SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, tableInfo.getKeyType());
+            SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, Object.class);
             return addUpdateMappedStatement(mapperClass, modelClass, this.name, sqlSource);
         } else {
             sqlMethod = SqlMethod.DELETE_BY_ID;
             sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(), tableInfo.getKeyColumn(),
                 tableInfo.getKeyProperty());
-            SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, tableInfo.getKeyType());
+            SqlSource sqlSource = languageDriver.createSqlSource(configuration, sql, Object.class);
             return this.addDeleteMappedStatement(mapperClass, this.name, sqlSource);
         }
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectBatchByIds.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectBatchByIds.java
@@ -29,11 +29,11 @@ import org.apache.ibatis.mapping.SqlSource;
  * @since 2018-04-06
  */
 public class SelectBatchByIds extends AbstractMethod {
-    
+
     public SelectBatchByIds() {
         super(SqlMethod.SELECT_BATCH_BY_IDS.getMethod());
     }
-    
+
     /**
      * @param name 方法名
      * @since 3.4.4
@@ -41,14 +41,14 @@ public class SelectBatchByIds extends AbstractMethod {
     public SelectBatchByIds(String name) {
         super(name);
     }
-    
+
     @Override
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_BATCH_BY_IDS;
         SqlSource sqlSource = languageDriver.createSqlSource(configuration, String.format(sqlMethod.getSql(),
                 sqlSelectColumns(tableInfo, false), tableInfo.getTableName(), tableInfo.getKeyColumn(),
                 SqlScriptUtils.convertForeach("#{item}", COLLECTION, null, "item", COMMA),
-                tableInfo.getLogicDeleteSql(true, true)), tableInfo.getKeyType());
+                tableInfo.getLogicDeleteSql(true, true)), Object.class);
         return addSelectMappedStatementForTable(mapperClass, this.name, sqlSource, tableInfo);
     }
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectById.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/SelectById.java
@@ -29,11 +29,11 @@ import org.apache.ibatis.scripting.defaults.RawSqlSource;
  * @since 2018-04-06
  */
 public class SelectById extends AbstractMethod {
-    
+
     public SelectById() {
         super(SqlMethod.SELECT_BY_ID.getMethod());
     }
-    
+
     /**
      * @param name 方法名
      * @since 3.4.4
@@ -41,14 +41,14 @@ public class SelectById extends AbstractMethod {
     public SelectById(String name) {
         super(name);
     }
-    
+
     @Override
     public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
         SqlMethod sqlMethod = SqlMethod.SELECT_BY_ID;
         SqlSource sqlSource = new RawSqlSource(configuration, String.format(sqlMethod.getSql(),
                 sqlSelectColumns(tableInfo, false),
                 tableInfo.getTableName(), tableInfo.getKeyColumn(), tableInfo.getKeyProperty(),
-                tableInfo.getLogicDeleteSql(true, true)), tableInfo.getKeyType());
+                tableInfo.getLogicDeleteSql(true, true)), Object.class);
         return this.addSelectMappedStatementForTable(mapperClass, this.name, sqlSource, tableInfo);
     }
 }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
@@ -26,6 +26,7 @@ import com.baomidou.mybatisplus.core.toolkit.Assert;
 import com.baomidou.mybatisplus.core.toolkit.GlobalConfigUtils;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import com.baomidou.mybatisplus.extension.toolkit.SqlHelper;
+import com.baomidou.mybatisplus.extension.toolkit.SqlRunner;
 import lombok.Setter;
 import org.apache.ibatis.builder.xml.XMLMapperBuilder;
 import org.apache.ibatis.cache.Cache;
@@ -427,7 +428,8 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
         notNull(dataSource, "Property 'dataSource' is required");
         state((configuration == null && configLocation == null) || !(configuration != null && configLocation != null),
             "Property 'configuration' and 'configLocation' can not specified with together");
-
+        //TODO 清理掉资源  建议不要保留这个玩意了
+        SqlRunner.DEFAULT.close();
         this.sqlSessionFactory = buildSqlSessionFactory();
     }
 
@@ -604,7 +606,7 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
         }
 
         final SqlSessionFactory sqlSessionFactory = new MybatisSqlSessionFactoryBuilder().build(targetConfiguration);
-
+        System.out.println(sqlSessionFactory);
         // TODO SqlRunner
         SqlHelper.FACTORY = sqlSessionFactory;
 

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/SqlRunner.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/SqlRunner.java
@@ -27,6 +27,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionUtils;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,7 +38,7 @@ import java.util.Optional;
  * @author Caratacus
  * @since 2016-12-11
  */
-public class SqlRunner implements ISqlRunner {
+public class SqlRunner implements ISqlRunner, Closeable {
 
     private final Log log = LogFactory.getLog(SqlRunner.class);
     // 单例Query
@@ -239,4 +240,10 @@ public class SqlRunner implements ISqlRunner {
     private SqlSessionFactory getSqlSessionFactory() {
         return Optional.ofNullable(clazz).map(GlobalConfigUtils::currentSessionFactory).orElse(sqlSessionFactory);
     }
+
+    @Override
+    public void close() {
+        DEFAULT.sqlSessionFactory = null;
+    }
+
 }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/BaseDbTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/BaseDbTest.java
@@ -7,6 +7,7 @@ import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 import com.baomidou.mybatisplus.core.toolkit.ExceptionUtils;
 import com.baomidou.mybatisplus.core.toolkit.GlobalConfigUtils;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
+import com.baomidou.mybatisplus.extension.toolkit.SqlRunner;
 import org.apache.ibatis.builder.xml.XMLMapperBuilder;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.logging.slf4j.Slf4jImpl;
@@ -41,6 +42,7 @@ public abstract class BaseDbTest<T> extends TypeReference<T> {
 
     @SuppressWarnings("unchecked")
     public BaseDbTest() {
+        SqlRunner.DEFAULT.close();
         DataSource ds = dataSource();
         List<String> tableSql = tableSql();
         String tableDataSql = tableDataSql();

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/MybatisMapperRegistryTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/MybatisMapperRegistryTest.java
@@ -86,7 +86,7 @@ class MybatisMapperRegistryTest extends BaseTest {
             H2StudentMapper studentMapper = mapperRegistry.getMapper(H2StudentMapper.class, sqlSession);
 
             Assertions.assertTrue(configuration.hasStatement(H2StudentMapper.class.getName() + ".selectById"));
-            studentMapper.selectById(1L);
+            studentMapper.selectById(1);
 
             Field field = mapperRegistry.getClass().getDeclaredField("knownMappers");
             field.setAccessible(true);
@@ -99,7 +99,7 @@ class MybatisMapperRegistryTest extends BaseTest {
             Map<Method, ?> methodCache = mybatisMapperProxyFactory.getMethodCache();
             Assertions.assertTrue(methodCache.isEmpty());
 
-            h2StudentChildrenMapper.selectById(2L);
+            h2StudentChildrenMapper.selectById(2);
             methodCache = mybatisMapperProxyFactory.getMethodCache();
             Assertions.assertFalse(methodCache.isEmpty());
         }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/SqlRunnerTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/SqlRunnerTest.java
@@ -25,6 +25,7 @@ import com.baomidou.mybatisplus.test.h2.service.IH2StudentService;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,8 +36,9 @@ import java.util.List;
  * SqlRunner测试
  * @author nieqiurong 2018/8/25 11:05.
  */
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ExtendWith(SpringExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @ContextConfiguration(locations = {"classpath:h2/spring-test-h2.xml"})
 class SqlRunnerTest {
 

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/logicdel/LogicDelTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/logicdel/LogicDelTest.java
@@ -19,7 +19,7 @@ public class LogicDelTest extends BaseDbTest<EntityMapper> {
     void logicDel() {
         doTestAutoCommit(i -> {
             int delete = i.deleteById(1L);
-            assertThat(delete).isEqualTo(1L);
+            assertThat(delete).isEqualTo(1);
 
             delete = i.delete(Wrappers.<Entity>lambdaQuery().eq(Entity::getId, 2));
             assertThat(delete).isEqualTo(1);


### PR DESCRIPTION
1.恢复ById不限制类型,拥有更灵活的入参处理度.
2.增加SqlRunner实现Closeable,容器刷新时清空sqlSessionFactory值.
3.单元测试与回滚.

### 该Pull Request关联的Issue



### 修改描述



### 测试用例



### 修复效果的截屏


