### PR TITLE
[Feature] ASSIGN_ID 支持覆盖值为 0 的 Id 值

### DIFF
--- a/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/MybatisPlusSampleTest.java
+++ b/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/MybatisPlusSampleTest.java
@@ -1,5 +1,6 @@
 package com.baomidou.mybatisplus.test.autoconfigure;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -21,5 +22,13 @@ class MybatisPlusSampleTest {
         Sample sample = new Sample();
         sampleMapper.insert(sample);
         assertThat(sample.getId()).isNotNull();
+    }
+
+    @Test
+    void testInsertZeroId() {
+        Sample sample = new Sample();
+        sample.setId(0L);
+        sampleMapper.insert(sample);
+        Assertions.assertTrue(sample.getId() != 0);
     }
 }

--- a/mybatis-plus-boot-starter-test/src/test/resources/application.yml
+++ b/mybatis-plus-boot-starter-test/src/test/resources/application.yml
@@ -6,3 +6,7 @@ logging:
     level:
         org.springframework.jdbc: debug
         com.baomidou.mybatisplus.test.autoconfigure: debug
+mybatis-plus:
+    global-config:
+        db-config:
+            override-zero-id: true

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
@@ -86,6 +86,12 @@ public class GlobalConfig implements Serializable {
          * 主键类型
          */
         private IdType idType = IdType.ASSIGN_ID;
+
+        /**
+         * 是否覆盖值为 0 的 ID。仅当主键类型为 IdType.ASSIGN_ID 且 ID 为数字类型时才生效。
+         */
+        private boolean overrideZeroId = false;
+
         /**
          * 表名前缀
          */


### PR DESCRIPTION
### 该Pull Request关联的Issue

该 PR 主要解决 kotlin 语言或其他框架导致的 id 不得不为 0 时仍希望自动填充雪花 id 的问题。参考：
#2442、#4230

### 修改描述
1. 修改 `MybatisParameterHandler` 中 `ASSIGN_ID` 的工作逻辑，允许覆盖数字类型的 0 值 id；
2. 将上述功能作为一个默认关闭的配置项`mybatis-plus.global-config.db-config.override-zero-id`，以保持向后兼容。

### 测试用例
已补充到 test 模块中。

### 修复效果的截屏
![image](https://user-images.githubusercontent.com/8530661/148488871-5fd6a6d6-75a1-4836-be50-692d5a30ae66.png)


