### PR TITLE
feature:实现父类字段可以自定义物理表继承关系

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableField.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/TableField.java
@@ -179,4 +179,60 @@ public @interface TableField {
      * @since 3.1.2
      */
     String numericScale() default "";
+
+    /**
+     *
+     * 指定字段是否可以被继承（物理表的继承，继承时子类的表中需要定义父类的字段。否则不需要定义）
+     * <br></br>
+     * 适用于基础表+多子类扩展表设计
+     * <p></p>
+     *
+     * <pre class="code">
+     * 例子:
+     * &#064;TableName("cu_user_base")
+     * public class UserModel extends Model<UserModel>  {
+     *
+     *     &#064;TableId(type = IdType.AUTO)
+     *     private Long id;
+     *
+     *     &#064;TableField(canExtends = false)
+     *     private String name;
+     *
+     *     &#064;TableField(canExtends = false)
+     *     private String header;
+     * }
+     * </pre>
+     * <pre class="code">
+     * // admin用户属于用户，所以继承UserModel，通过id相同关联cu_user_base，
+     * // 使用cu_user_base维护管理员用户的name和header，cu_user_admin维护admin用户独有的position字段
+     * &#064;TableName("cu_user_admin")
+     * public class AdminUser extends UserModel  {
+     *
+     *     private String position;
+     * }
+     * </pre>
+     * <pre class="code">
+     * // member与admin逻辑一样，只是特有的字段与admin不一致
+     * &#064;TableName("cu_user_member")
+     * public class MemberUser extends UserModel  {
+     *
+     *     private String email;
+     * }
+     * </pre>
+     * <pre class="code">
+     * 产生的表结构
+     * cu_user_base(id, name, header)
+     * cu_user_admin(id, position)
+     * cu_user_member(id, email)
+     * </pre>
+     * <p>
+     *     在数据设计中 cu_user_base 包含用户基础的id，name，header。<br></br>
+     *     cu_user_admin 表只会存在id和position。通过id相同与cu_user_base关联起来。保证在逻辑上admin是用户。cu_user_member同理。<br></br>
+     *     在这样的设计中会出现三个Mapper。对于基础用户会出现的功能我们都直接通过cu_user_base去实现。只有特定于amdin或者member时我们才通过对应的表实现。<br></br>
+     *     在默认情况下父类的字段可以直接被子类继承
+     * </p>
+     * <p></p>
+     * @since 3.5.2
+     */
+    boolean canExtends() default true;
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
@@ -491,6 +491,7 @@ public class TableInfoHelper {
     /**
      * <p>
      * 获取该类的所有属性列表
+     * 将父类不可继承的字段排除
      * </p>
      *
      * @param clazz 反射类
@@ -502,7 +503,15 @@ public class TableInfoHelper {
             .filter(field -> {
                 /* 过滤注解非表字段属性 */
                 TableField tableField = field.getAnnotation(TableField.class);
-                return (tableField == null || tableField.exist());
+                boolean result = tableField == null || tableField.exist();
+                if (result) {
+                    Class<?> targetClazz = field.getDeclaringClass();
+                    if (targetClazz != clazz) {
+                        // 父类的字段
+                        result =  tableField == null || tableField.canExtends();
+                    }
+                }
+                return result;
             }).collect(toList());
     }
 


### PR DESCRIPTION
子类继承父类时可以在父类中设置字段是否被子类在物理表结构中继承，使用于基础表+多子类扩展表结构中

### 该Pull Request关联的Issue

NONE

### 修改描述
给TableField注解新增canExtends属性，使在Model具有继承关系时在父类中设置某些字段是否可以被子类在物理表结构中继承。对于非物理表结构继承的字段在子类生成tableInfo时会将这些字段排除。该模式适用于物理表结构设计为基础字段表+多子类扩展表结构中。

**举例**
物理表cu_user_base：表示所有用户类型通用属性，字段有id,name,header
物理表cu_user_admin：表示管理用户类型属性，字段有id,position
物理表cu_user_member：表示会员用户类型属性，字段有id,email

在逻辑结构上member，admin都属于用户且用户基础字段name,header。物理表上字需要使用id相等即可关联起来。在Model定义时为了保持逻辑继承关系时如下
```
@TableName(value = "cu_user")
public class UserModel extends Model<UserModel> {

    @TableId(type = IdType.AUTO)
    @TableField(canExtends = true)
    private Long id;

    @TableField(canExtends = false)
    private String name;

    @TableField(canExtends = false)
    private String header;
}

@TableName(value = "cu_user_admin")
public class AdminModel extends UserModel {
    private String position;

}

@TableName(value = "cu_user_member")
public class MemberModel extends UserModel {
    private String email;
}


```
在UserModel的name，header字段设置不可继承时，admin，member的tableinfo将不会存在这两个字段。使得amdin，member的数据库操作正常执行。


### 测试用例

本地项目测试通过

### 修复效果的截屏
![image](https://user-images.githubusercontent.com/24504763/151382408-f7765251-1fd7-4bf3-a65b-de1784e92a45.png)

查询打印的sql：
![image](https://user-images.githubusercontent.com/24504763/151378724-e220dd91-821d-42f7-9feb-1d8d43942f90.png)
![image](https://user-images.githubusercontent.com/24504763/151378824-302ee127-c7ad-4aed-ba9d-091dd80e30dd.png)

insert打印的sql：
![image](https://user-images.githubusercontent.com/24504763/151379335-55093ce6-a05c-473a-87c2-ffb553968f17.png)
![image](https://user-images.githubusercontent.com/24504763/151379360-7b4a72ae-5dcd-47fd-b447-03a7f6ae6c6f.png)


