### PR TITLE
MybatisPlusTest去掉@OverrideAutoConfiguration

### DIFF
--- a/mybatis-plus-boot-starter-test/src/main/java/com/baomidou/mybatisplus/test/autoconfigure/MybatisPlusTest.java
+++ b/mybatis-plus-boot-starter-test/src/main/java/com/baomidou/mybatisplus/test/autoconfigure/MybatisPlusTest.java
@@ -15,10 +15,15 @@
  */
 package com.baomidou.mybatisplus.test.autoconfigure;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -29,8 +34,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.lang.annotation.*;
 
 /**
  * Annotation that can be used in combination with {@code @RunWith(SpringRunner.class)}(JUnit 4) and
@@ -58,7 +61,6 @@ import java.lang.annotation.*;
 @Inherited
 @BootstrapWith(MybatisPlusTestContextBootstrapper.class)
 @ExtendWith(SpringExtension.class)
-@OverrideAutoConfiguration(enabled = false)
 @TypeExcludeFilters(MybatisPlusTypeExcludeFilter.class)
 @Transactional
 @AutoConfigureCache

--- a/mybatis-plus-boot-starter-test/src/test/resources/application.yml
+++ b/mybatis-plus-boot-starter-test/src/test/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
-    datasource:
-        schema: classpath:schema.sql
-
+    sql:
+        init:
+            schema-locations: schema.sql
 logging:
     level:
         org.springframework.jdbc: debug


### PR DESCRIPTION
### 该Pull Request关联的Issue

无

### 修改描述
spring boot 2.5.*    spring.datasource.schema已过时替换成spring.sql.init.schema-locations
使用@MybatisPlusTest导致schema.sql并没有初始化执行
<img width="1080" alt="image" src="https://user-images.githubusercontent.com/78771329/156323119-027c1990-c4ad-4587-8910-5b9475ad1f98.png">
原因是MybatisPlusTest注解使用了OverrideAutoConfiguration导致spring boot 2.5.*版本DataSourceScriptDatabaseInitializer没有自动配置
### 测试用例

<img width="719" alt="image" src="https://user-images.githubusercontent.com/78771329/156325036-c24b6fc9-1d89-452d-9a4f-63990d232fbb.png">


### 修复效果的截屏
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/78771329/156325116-9d3678e2-9c69-4e8d-873d-00a0a5a3c2b2.png">


