### PR TITLE
添加对Gbase 8s （informix）数据库支持

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -101,6 +101,7 @@ public enum DbType {
      */
     GBASE("gbase", "南大通用(华库)数据库"),
     GBASEDBT("gbasedbt", "南大通用数据库"),
+    GBASE_INFORMIX("gbase 8s", "南大通用数据库 GBase 8s"),
     /**
      * Oscar
      */

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
@@ -80,6 +80,8 @@ public class DialectFactory {
                 dialect = new SybaseDialect();
             } else if (dbType == DbType.GBASEDBT) {
                 dialect = new GBasedbtDialect();
+            } else if (dbType == DbType.GBASE_INFORMIX){
+                dialect = new GBaseInfromixDialect();
             }
             DIALECT_ENUM_MAP.put(dbType, dialect);
         }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/GBaseInfromixDialect.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/GBaseInfromixDialect.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2011-2022, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.extension.plugins.pagination.dialects;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.DialectModel;
+
+/**
+ * GBase 8s V8.8 数据库分页语句组装实现
+ * 通用分页版本
+ *
+ * @author lix lixhbs@163.com
+ * @since 2022年03月28日19:25:46
+ */
+public class GBaseInfromixDialect implements IDialect
+{
+
+    @Override
+    public DialectModel buildPaginationSql(String originalSql, long offset, long limit)
+    {
+        int slot = originalSql.toLowerCase().indexOf("select");
+        StringBuilder sql = new StringBuilder();
+        if (slot == 0)
+        {
+            sql.append("SELECT");
+            sql.append(" SKIP ").append(offset);
+            sql.append(" FIRST ").append(limit);
+            sql.append(originalSql.substring(6));
+            return new DialectModel(sql.toString());
+        } else
+        {
+            return null;
+        }
+
+    }
+}

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
@@ -98,6 +98,8 @@ public class JdbcUtils {
             return DbType.GBASE;
         } else if (jdbcUrl.contains(":gbasedbt-sqli:")) {
             return DbType.GBASEDBT;
+        } else if (jdbcUrl.contains(":informix-sqli:")) {
+            return DbType.GBASE_INFORMIX;
         } else if (jdbcUrl.contains(":clickhouse:")) {
             return DbType.CLICK_HOUSE;
         } else if (jdbcUrl.contains(":oscar:")) {


### PR DESCRIPTION
### 该Pull Request关联的Issue
#2877 #2117

#3763 这个是Gbase 8s另外一种连接地址；

需求的连接地址为 ： ":informix-sqli:"

### 修改描述
1、添加南大通用GBase 8s （informix）数据库的支持（GBASE_INFORMIX) ；
2、增加对南大通用GBase 8s数据库的分页语法方言支持；
3、添加 GBaseInfromixDialect 分页语句实现类
