### PR TITLE
修改propertyFormat的默认值为带双引号的，大部分情况下，带上双引号，没问题，兼容直接s%

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableFieldInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableFieldInfo.java
@@ -269,7 +269,7 @@ public class TableFieldInfo implements Constants {
             // 存在指定转换属性
             String propertyFormat = dbConfig.getPropertyFormat();
             if (StringUtils.isBlank(propertyFormat)) {
-                propertyFormat = "%s";
+                propertyFormat = "\"%s\"";
             }
             this.sqlSelect += (AS + String.format(propertyFormat, tableField.property()));
         } else if (tableInfo.getResultMap() == null && !tableInfo.isAutoInitResultMap() &&


### PR DESCRIPTION
没有设置propertyFormat属性，导致默认设置property="company.id", 报错。as 后面加""，可以避免很多默认问题
