### PR TITLE
[BugFix] 使用字符串类型注入 key 之前加上类型检查，避免类型不匹配导致注入失败。

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisParameterHandler.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisParameterHandler.java
@@ -146,8 +146,10 @@ public class MybatisParameterHandler implements ParameterHandler {
                         } else {
                             throw new MybatisPlusException("Key type '" + keyType + "' not supported");
                         }
-                    } else {
+                    } else if (String.class.isAssignableFrom(keyType)) {
                         metaObject.setValue(keyProperty, identifierGenerator.nextId(entity).toString());
+                    } else {
+                        metaObject.setValue(keyProperty, identifierGenerator.nextId(entity));
                     }
                 } else if (idType.getKey() == IdType.ASSIGN_UUID.getKey()) {
                     metaObject.setValue(keyProperty, identifierGenerator.nextUUID(entity));


### PR DESCRIPTION
### 该Pull Request关联的Issue
#4231 


### 修改描述
3.5.1 及之后的版本 `IdentifierGenerator` 支持自定义 `assignId` 方法，但在赋值的时候还有一点点小问题。目前的实现是如果不是 Number 类型就直接用 id.toString() 之后进行赋值。这会导致主键没有实现 Number 接口也不是 String 的时候因为类型转换而失败。例如 Kotlin 的 Long 类型就并没有实现 java 的 Number 接口（在Java 程序里会被检测为基本类型 long）。

> 其实 3.5.1 发布之后第一时间就测试发现了这个问题，但是当时项目实在太忙了没时间搞 pr，是临时用 IdType.NONE 然后手动赋值解决的 orz

### 测试用例
使用 Spring Initializer 随便创建一个 Kotlin 项目，导入 mp 3.5.2 版本，创建一个测试类，id type 选用 ASSIGN_ID。
```Kotlin
@TableName("table_test")
data class TestDo(
    @TableId(type = IdType.ASSIGN_ID)
    var id: Long = 0,
    val text: String? = null,
)
```
使用自定义的 generator（这里是为了演示所以写的最简单的自增，实际项目中是雪花）:
```Kotlin
@Component
class IdGenerator : IdentifierGenerator {

    var nextId = 1L

    override fun nextId(entity: Any?): Number {
        return nextId++
    }

    override fun assignId(idValue: Any?): Boolean {
        return idValue == null || (idValue == 0L)
    }
}
```

测试写入：
```Kotlin
        val entity = TestDo(0, "sample text")
        mapper.insert(entity)
```

运行报错：
> org.mybatis.spring.MyBatisSystemException: nested exception is org.apache.ibatis.reflection.ReflectionException: Could not set property 'id' of 'class com.example.demo.entity.TestDo' with value '1' Cause: java.lang.IllegalArgumentException: argument type mismatch
>
>	at org.mybatis.spring.MyBatisExceptionTranslator.translateExceptionIfPossible(MyBatisExceptionTranslator.java:96)
	at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:441)
	at com.sun.proxy.$Proxy57.insert(Unknown Source)
	at org.mybatis.spring.SqlSessionTemplate.insert(SqlSessionTemplate.java:272)
	at com.baomidou.mybatisplus.core.override.MybatisMapperMethod.execute(MybatisMapperMethod.java:59)
	at com.baomidou.mybatisplus.core.override.MybatisMapperProxy$PlainMethodInvoker.invoke(MybatisMapperProxy.java:148)
	at com.baomidou.mybatisplus.core.override.MybatisMapperProxy.invoke(MybatisMapperProxy.java:89)
...//省略剩余堆栈
Caused by: org.apache.ibatis.reflection.ReflectionException: Could not set property 'id' of 'class com.example.demo.entity.TestDo' with value '1' Cause: java.lang.IllegalArgumentException: argument type mismatch
	at org.apache.ibatis.reflection.wrapper.BeanWrapper.setBeanProperty(BeanWrapper.java:185)
	at org.apache.ibatis.reflection.wrapper.BeanWrapper.set(BeanWrapper.java:59)
	at org.apache.ibatis.reflection.MetaObject.setValue(MetaObject.java:140)
	at com.baomidou.mybatisplus.core.MybatisParameterHandler.populateKeys(MybatisParameterHandler.java:150)
	at com.baomidou.mybatisplus.core.MybatisParameterHandler.process(MybatisParameterHandler.java:115)
	at com.baomidou.mybatisplus.core.MybatisParameterHandler.processParameter(MybatisParameterHandler.java:83)
...//省略剩余堆栈

### 修复方案
维持原有 Number 逻辑不变，在使用 String 类型插入之前做一次类型检查，如不可赋值为 String 类型，则使用 IdentifierGenerator#nextId 函数返回的原始值。

在 classpath 下使用修改后的 `MybatisParameterHandler` 类测试通过。

