### PR TITLE
修复like不匹配_、\、%等特殊字符

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.time.LocalDateTime
 
 allprojects {
     group = 'com.baomidou'
-    version = "3.5.2.5-SNAPSHOT"
+    version = "3.5.2.6-SNAPSHOT"
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.time.LocalDateTime
 
 allprojects {
     group = 'com.baomidou'
-    version = "3.5.2.4-SNAPSHOT"
+    version = "3.5.2.5-SNAPSHOT"
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.time.LocalDateTime
 
 allprojects {
     group = 'com.baomidou'
-    version = "3.5.2.3-SNAPSHOT"
+    version = "3.5.2.4-SNAPSHOT"
 }
 
 ext {

--- a/changelog-temp.md
+++ b/changelog-temp.md
@@ -4,3 +4,4 @@
 - feat: 分页新增informix数据库支持
 - feat: 支持spring-boot 2.7以上版本
 - feat: 雪花id新增反解时间戳方法`Sequence#parseIdTimestamp`
+- feat: BaseMapper.selectCount生成语句加入中`AS total`

--- a/changelog-temp.md
+++ b/changelog-temp.md
@@ -3,3 +3,4 @@
 - fix: 补全`mybatis-plus-boot-starter-test`遗漏配置
 - feat: 分页新增informix数据库支持
 - feat: 支持spring-boot 2.7以上版本
+- feat: 雪花id新增反解时间戳方法`Sequence#parseIdTimestamp`

--- a/changelog-temp.md
+++ b/changelog-temp.md
@@ -1,3 +1,5 @@
 - 多租户插件:多表join表名必需起别名,否则追加的过滤条件不带前缀
 - fix: InterceptorIgnore 不能过滤 selectKey 的问题
 - fix: 补全`mybatis-plus-boot-starter-test`遗漏配置
+- feat: 分页新增informix数据库支持
+- feat: 支持spring-boot 2.7以上版本

--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -172,6 +172,11 @@ public enum DbType {
      * redshift
      */
     REDSHIFT("redshift", "亚马逊redshift数据库"),
+
+    /**
+     * openGauss
+     */
+    OPENGAUSS("openGauss","华为 opengauss 数据库"),
     /**
      * UNKONWN DB
      */

--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -169,7 +169,7 @@ public enum DbType {
      */
     XCloud("xcloud", "行云数据库"),
     /**
-     * xcloud
+     * redshift
      */
     REDSHIFT("redshift", "亚马逊redshift数据库"),
     /**

--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -176,7 +176,13 @@ public enum DbType {
     /**
      * openGauss
      */
-    OPENGAUSS("openGauss","华为 opengauss 数据库"),
+    OPENGAUSS("openGauss", "华为 opengauss 数据库"),
+
+    /**
+     * TDengine
+     */
+    TDENGINE("TDengine", "TDengine数据库"),
+
     /**
      * UNKONWN DB
      */

--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -169,6 +169,10 @@ public enum DbType {
      */
     XCloud("xcloud", "行云数据库"),
     /**
+     * xcloud
+     */
+    REDSHIFT("redshift", "亚马逊redshift数据库"),
+    /**
      * UNKONWN DB
      */
     OTHER("other", "其他数据库");

--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -182,6 +182,10 @@ public enum DbType {
      * TDengine
      */
     TDENGINE("TDengine", "TDengine数据库"),
+    /**
+     * Informix
+     */
+    INFORMIX("informix", "Informix数据库"),
 
     /**
      * UNKONWN DB

--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -186,6 +186,11 @@ public enum DbType {
      * Informix
      */
     INFORMIX("informix", "Informix数据库"),
+    
+    /**
+     * uxdb
+     */
+    UXDB("uxdb", "优炫数据库"),
 
     /**
      * UNKONWN DB

--- a/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/MybatisPlusSampleTest.java
+++ b/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/MybatisPlusSampleTest.java
@@ -1,5 +1,7 @@
 package com.baomidou.mybatisplus.test.autoconfigure;
 
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -19,7 +21,17 @@ class MybatisPlusSampleTest {
     @Test
     void testInsert() {
         Sample sample = new Sample();
+        sample.setId(1L);
+        sample.setName("aaa");
         sampleMapper.insert(sample);
         assertThat(sample.getId()).isNotNull();
+    }
+
+    @Test
+    void testLike() {
+        testInsert();
+        List<Sample> sampleList = sampleMapper.selectList(
+            new LambdaQueryWrapper<Sample>().like(Sample::getName, "a_a"));
+        assertThat(sampleList).isNotEmpty();
     }
 }

--- a/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
+++ b/mybatis-plus-boot-starter/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
@@ -18,6 +18,7 @@ package com.baomidou.mybatisplus.autoconfigure;
 
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.config.GlobalConfig;
+import com.baomidou.mybatisplus.core.handlers.JoinTableInfoInitHandler;
 import com.baomidou.mybatisplus.core.handlers.MetaObjectHandler;
 import com.baomidou.mybatisplus.core.incrementer.IKeyGenerator;
 import com.baomidou.mybatisplus.core.incrementer.IdentifierGenerator;
@@ -207,6 +208,8 @@ public class MybatisPlusAutoConfiguration implements InitializingBean {
         GlobalConfig globalConfig = this.properties.getGlobalConfig();
         // TODO 注入填充器
         this.getBeanThen(MetaObjectHandler.class, globalConfig::setMetaObjectHandler);
+        // TODO 注入参与器
+        this.getBeanThen(JoinTableInfoInitHandler.class, globalConfig::setJoinTableInfoInitHandler);
         // TODO 注入主键生成器
         this.getBeansThen(IKeyGenerator.class, i -> globalConfig.getDbConfig().setKeyGenerators(i));
         // TODO 注入sql注入器

--- a/mybatis-plus-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/mybatis-plus-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+com.baomidou.mybatisplus.autoconfigure.IdentifierGeneratorAutoConfiguration
+com.baomidou.mybatisplus.autoconfigure.MybatisPlusLanguageDriverAutoConfiguration
+com.baomidou.mybatisplus.autoconfigure.MybatisPlusAutoConfiguration

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
@@ -79,7 +79,8 @@ public class GlobalConfig implements Serializable {
     /**
      * 参与 TableInfo 的初始化
      */
-    private JoinTableInfoInitHandler joinTableInfoInitHandler;
+    private JoinTableInfoInitHandler joinTableInfoInitHandler = new JoinTableInfoInitHandler() {
+    };
     /**
      * 主键生成器
      */

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
@@ -18,6 +18,7 @@ package com.baomidou.mybatisplus.core.config;
 import com.baomidou.mybatisplus.annotation.FieldStrategy;
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.core.handlers.JoinTableInfoInitHandler;
 import com.baomidou.mybatisplus.core.handlers.MetaObjectHandler;
 import com.baomidou.mybatisplus.core.incrementer.IKeyGenerator;
 import com.baomidou.mybatisplus.core.incrementer.IdentifierGenerator;
@@ -75,6 +76,10 @@ public class GlobalConfig implements Serializable {
      * 元对象字段填充控制器
      */
     private MetaObjectHandler metaObjectHandler;
+    /**
+     * 参与 TableInfo 的初始化
+     */
+    private JoinTableInfoInitHandler joinTableInfoInitHandler;
     /**
      * 主键生成器
      */

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
@@ -63,7 +63,7 @@ public enum SqlMethod {
     SELECT_BATCH_BY_IDS("selectBatchIds", "根据ID集合，批量查询数据", "<script>SELECT %s FROM %s WHERE %s IN (%s) %s </script>"),
     @Deprecated
     SELECT_ONE("selectOne", "查询满足条件一条数据", "<script>%s SELECT %s FROM %s %s %s\n</script>"),
-    SELECT_COUNT("selectCount", "查询满足条件总记录数", "<script>%s SELECT COUNT(%s) FROM %s %s %s\n</script>"),
+    SELECT_COUNT("selectCount", "查询满足条件总记录数", "<script>%s SELECT COUNT(%s) AS total FROM %s %s %s\n</script>"),
     SELECT_LIST("selectList", "查询满足条件所有数据", "<script>%s SELECT %s FROM %s %s %s %s\n</script>"),
     SELECT_PAGE("selectPage", "查询满足条件所有数据（并翻页）", "<script>%s SELECT %s FROM %s %s %s %s\n</script>"),
     SELECT_MAPS("selectMaps", "查询满足条件所有数据", "<script>%s SELECT %s FROM %s %s %s %s\n</script>"),
@@ -91,5 +91,4 @@ public enum SqlMethod {
     public String getSql() {
         return sql;
     }
-
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/handlers/JoinTableInfoInitHandler.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/handlers/JoinTableInfoInitHandler.java
@@ -1,0 +1,30 @@
+package com.baomidou.mybatisplus.core.handlers;
+
+import com.baomidou.mybatisplus.core.metadata.TableFieldInfo;
+import com.baomidou.mybatisplus.core.metadata.TableInfo;
+import org.apache.ibatis.session.Configuration;
+
+/**
+ * 初始化 TableInfo 同时进行一些操作
+ *
+ * @author miemie
+ * @since 2022-09-20
+ */
+public interface JoinTableInfoInitHandler {
+
+    /**
+     * 参与 TableFieldInfo 初始化
+     *
+     * @param fieldInfo     TableFieldInfo
+     * @param configuration Configuration
+     */
+    void joinTableFieldInfo(TableFieldInfo fieldInfo, Configuration configuration);
+
+    /**
+     * 参与 TableInfo 初始化
+     *
+     * @param tableInfo     TableInfo
+     * @param configuration Configuration
+     */
+    void joinTableInfo(TableInfo tableInfo, Configuration configuration);
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/handlers/JoinTableInfoInitHandler.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/handlers/JoinTableInfoInitHandler.java
@@ -18,7 +18,9 @@ public interface JoinTableInfoInitHandler {
      * @param fieldInfo     TableFieldInfo
      * @param configuration Configuration
      */
-    void joinTableFieldInfo(TableFieldInfo fieldInfo, Configuration configuration);
+    default void joinTableFieldInfo(TableFieldInfo fieldInfo, Configuration configuration) {
+        // ignore
+    }
 
     /**
      * 参与 TableInfo 初始化
@@ -26,5 +28,7 @@ public interface JoinTableInfoInitHandler {
      * @param tableInfo     TableInfo
      * @param configuration Configuration
      */
-    void joinTableInfo(TableInfo tableInfo, Configuration configuration);
+    default void joinTableInfo(TableInfo tableInfo, Configuration configuration) {
+        // ignore
+    }
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfoHelper.java
@@ -179,9 +179,7 @@ public class TableInfoHelper {
         /* 自动构建 resultMap */
         tableInfo.initResultMapIfNeed();
         JoinTableInfoInitHandler joinTableInfoInitHandler = globalConfig.getJoinTableInfoInitHandler();
-        if (joinTableInfoInitHandler != null) {
-            joinTableInfoInitHandler.joinTableInfo(tableInfo, configuration);
-        }
+        joinTableInfoInitHandler.joinTableInfo(tableInfo, configuration);
         TABLE_INFO_CACHE.put(clazz, tableInfo);
         TABLE_NAME_INFO_CACHE.put(tableInfo.getTableName(), tableInfo);
 
@@ -332,19 +330,15 @@ public class TableInfoHelper {
             /* 有 @TableField 注解的字段初始化 */
             if (tableField != null) {
                 TableFieldInfo tableFieldInfo = new TableFieldInfo(dbConfig, tableInfo, field, tableField, reflector, existTableLogic, isOrderBy);
-                if (initTableInfoHandler != null) {
-                    initTableInfoHandler.joinTableFieldInfo(tableFieldInfo, configuration);
-                }
                 fieldList.add(tableFieldInfo);
+                initTableInfoHandler.joinTableFieldInfo(tableFieldInfo, configuration);
                 continue;
             }
 
             /* 无 @TableField  注解的字段初始化 */
             TableFieldInfo tableFieldInfo = new TableFieldInfo(dbConfig, tableInfo, field, reflector, existTableLogic, isOrderBy);
-            if (initTableInfoHandler != null) {
-                initTableInfoHandler.joinTableFieldInfo(tableFieldInfo, configuration);
-            }
             fieldList.add(tableFieldInfo);
+            initTableInfoHandler.joinTableFieldInfo(tableFieldInfo, configuration);
         }
 
         /* 字段列表 */

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Sequence.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Sequence.java
@@ -37,7 +37,7 @@ public class Sequence {
     /**
      * 时间起始标记点，作为基准，一般取系统的最近时间（一旦确定不能变动）
      */
-    private final long twepoch = 1288834974657L;
+    private static final long twepoch = 1288834974657L;
     /**
      * 机器标识位数
      */
@@ -199,4 +199,20 @@ public class Sequence {
         return SystemClock.now();
     }
 
+    /**
+     * 反解id的时间戳部分
+     */
+    public static long parseIdTimestamp(long id) {
+        String s = Long.toBinaryString(id);
+        int x = 64 - s.length();
+        StringBuilder b = new StringBuilder();
+        for (int i = 0; i < x; i++) {
+            b.append("0");
+        }
+        s = b + s;
+        s = s.substring(1, 42);
+        long l = Long.parseUnsignedLong(s, 2);
+        l += twepoch;
+        return l;
+    }
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlUtils.java
@@ -49,12 +49,27 @@ public abstract class SqlUtils implements Constants {
     public static String concatLike(Object str, SqlLike type) {
         switch (type) {
             case LEFT:
-                return PERCENT + str;
+                return PERCENT + escapeChar(String.valueOf(str));
             case RIGHT:
-                return str + PERCENT;
+                return escapeChar(String.valueOf(str)) + PERCENT;
             default:
-                return PERCENT + str + PERCENT;
+                return PERCENT + escapeChar(String.valueOf(str)) + PERCENT;
         }
+    }
+
+    /**
+     * 转义字符
+     *
+     * @param before 转义前字符
+     * @return 转义后字符
+     */
+    public static String escapeChar(String before) {
+        if (StringUtils.isNotBlank(before)) {
+            before = before.replaceAll("\\\\", "\\\\\\\\");
+            before = before.replaceAll("_", "\\\\_");
+            before = before.replaceAll("%", "\\\\%");
+        }
+        return before;
     }
 
     public static List<String> findPlaceholder(String sql) {

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/SequenceTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/SequenceTest.java
@@ -1,0 +1,31 @@
+package com.baomidou.mybatisplus.core.toolkit;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author miemie
+ * @since 2022-10-17
+ */
+class SequenceTest {
+
+    @Test
+    void nextId() {
+        Sequence sequence = new Sequence(null);
+        long id = sequence.nextId();
+        LocalDateTime now = LocalDateTime.now();
+        System.out.println(sequence.nextId() + "---" + now);
+
+        long timestamp = Sequence.parseIdTimestamp(id);
+        Instant instant = Instant.ofEpochMilli(timestamp);
+        ZoneId zone = ZoneId.systemDefault();
+        LocalDateTime time = LocalDateTime.ofInstant(instant, zone);
+        System.out.println(timestamp + "---" + time);
+        assertThat(now).isAfter(time);
+    }
+}

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
@@ -95,6 +95,8 @@ public class DialectFactory {
                 || dbType == DbType.GBASEDBT
                 || dbType == DbType.GBASE_INFORMIX) {
                 dialect = new GBase8sDialect();
+            }else if(dbType==DbType.INFORMIX){
+                dialect = new InformixDialect();
             }
             DIALECT_ENUM_MAP.put(dbType, dialect);
         }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
@@ -66,7 +66,8 @@ public class DialectFactory {
                 || dbType == DbType.SAP_HANA
                 || dbType == DbType.IMPALA
                 || dbType == DbType.HIGH_GO
-                || dbType == DbType.VERTICA) {
+                || dbType == DbType.VERTICA
+                || dbType == DbType.REDSHIFT) {
                 dialect = new PostgreDialect();
             }
             // other types

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
@@ -69,7 +69,8 @@ public class DialectFactory {
                 || dbType == DbType.VERTICA
                 || dbType == DbType.REDSHIFT
                 || dbType == DbType.OPENGAUSS
-                || dbType == DbType.TDENGINE) {
+                || dbType == DbType.TDENGINE
+                || dbType == DbType.UXDB) {
                 dialect = new PostgreDialect();
             }
             // other types

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
@@ -68,7 +68,8 @@ public class DialectFactory {
                 || dbType == DbType.HIGH_GO
                 || dbType == DbType.VERTICA
                 || dbType == DbType.REDSHIFT
-                || dbType ==DbType.OPENGAUSS ) {
+                || dbType == DbType.OPENGAUSS
+                || dbType == DbType.TDENGINE) {
                 dialect = new PostgreDialect();
             }
             // other types
@@ -86,7 +87,7 @@ public class DialectFactory {
                 dialect = new GBasedbtDialect();
             } else if (dbType == DbType.GBASE_INFORMIX) {
                 dialect = new GBaseInfromixDialect();
-            }else if (dbType == DbType.XCloud){
+            } else if (dbType == DbType.XCloud) {
                 dialect = new XCloudDialect();
             } else if (dbType == DbType.FIREBIRD) {
                 dialect = new FirebirdDialect();

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
@@ -67,7 +67,8 @@ public class DialectFactory {
                 || dbType == DbType.IMPALA
                 || dbType == DbType.HIGH_GO
                 || dbType == DbType.VERTICA
-                || dbType == DbType.REDSHIFT) {
+                || dbType == DbType.REDSHIFT
+                || dbType ==DbType.OPENGAUSS ) {
                 dialect = new PostgreDialect();
             }
             // other types

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/InformixDialect.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/InformixDialect.java
@@ -1,0 +1,16 @@
+package com.baomidou.mybatisplus.extension.plugins.pagination.dialects;
+import com.baomidou.mybatisplus.core.toolkit.StringPool;
+import com.baomidou.mybatisplus.extension.plugins.pagination.DialectModel;
+public class InformixDialect implements IDialect{
+    @Override
+    public DialectModel buildPaginationSql(String originalSql, long offset, long limit) {
+        /*StringBuilder ret = new StringBuilder();
+        ret.append(String.format("select skip %s first %s ", FIRST_MARK+"",SECOND_MARK+""));
+        ret.append(originalSql.replaceFirst("(?i)select", ""));
+        return new DialectModel(ret.toString(), offset, limit).setConsumerChain();*/
+        StringBuilder ret = new StringBuilder();
+        ret.append(String.format("select skip %s first %s ", offset+"",limit+""));
+        ret.append(originalSql.replaceFirst("(?i)select", ""));
+        return new DialectModel(ret.toString());
+    }
+}

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
@@ -49,7 +49,6 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.core.NestedIOException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -539,7 +538,7 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
             try {
                 targetConfiguration.setDatabaseId(this.databaseIdProvider.getDatabaseId(this.dataSource));
             } catch (SQLException e) {
-                throw new NestedIOException("Failed getting a databaseId", e);
+                throw new IOException("Failed getting a databaseId", e);
             }
         }
 
@@ -550,7 +549,7 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
                 xmlConfigBuilder.parse();
                 LOGGER.debug(() -> "Parsed configuration file: '" + this.configLocation + "'");
             } catch (Exception ex) {
-                throw new NestedIOException("Failed to parse config resource: " + this.configLocation, ex);
+                throw new IOException("Failed to parse config resource: " + this.configLocation, ex);
             } finally {
                 ErrorContext.instance().reset();
             }
@@ -573,7 +572,7 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
                             targetConfiguration, mapperLocation.toString(), targetConfiguration.getSqlFragments());
                         xmlMapperBuilder.parse();
                     } catch (Exception e) {
-                        throw new NestedIOException("Failed to parse mapping resource: '" + mapperLocation + "'", e);
+                        throw new IOException("Failed to parse mapping resource: '" + mapperLocation + "'", e);
                     } finally {
                         ErrorContext.instance().reset();
                     }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
@@ -125,6 +125,8 @@ public class JdbcUtils {
             return DbType.XCloud;
         } else if (url.contains(":firebirdsql:")) {
             return DbType.FIREBIRD;
+        } else if (url.contains(":redshift:")) {
+            return DbType.REDSHIFT;
         } else {
             logger.warn("The jdbcUrl is " + jdbcUrl + ", Mybatis Plus Cannot Read Database type or The Database's Not Supported!");
             return DbType.OTHER;

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
@@ -131,9 +131,11 @@ public class JdbcUtils {
             return DbType.OPENGAUSS;
         } else if (url.contains(":taos:") || url.contains(":taos-rs:")) {
             return DbType.TDENGINE;
-        }else if (url.contains(":informix")) {
-           return DbType.INFORMIX;
-        }  else {
+        } else if (url.contains(":informix")) {
+            return DbType.INFORMIX;
+        } else if (url.contains(":uxdb:")) {
+            return DbType.UXDB;
+        } else {
             logger.warn("The jdbcUrl is " + jdbcUrl + ", Mybatis Plus Cannot Read Database type or The Database's Not Supported!");
             return DbType.OTHER;
         }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
@@ -127,6 +127,8 @@ public class JdbcUtils {
             return DbType.FIREBIRD;
         } else if (url.contains(":redshift:")) {
             return DbType.REDSHIFT;
+        } else if (url.contains(":opengauss:")) {
+            return DbType.OPENGAUSS;
         } else {
             logger.warn("The jdbcUrl is " + jdbcUrl + ", Mybatis Plus Cannot Read Database type or The Database's Not Supported!");
             return DbType.OTHER;

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
@@ -17,6 +17,7 @@ package com.baomidou.mybatisplus.extension.toolkit;
 
 import com.baomidou.mybatisplus.annotation.DbType;
 import com.baomidou.mybatisplus.core.toolkit.Assert;
+import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 import com.baomidou.mybatisplus.core.toolkit.ExceptionUtils;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import org.apache.ibatis.executor.Executor;
@@ -49,7 +50,7 @@ public class JdbcUtils {
     public static DbType getDbType(Executor executor) {
         try {
             Connection conn = executor.getTransaction().getConnection();
-            return JDBC_DB_TYPE_CACHE.computeIfAbsent(conn.getMetaData().getURL(), JdbcUtils::getDbType);
+            return CollectionUtils.computeIfAbsent(JDBC_DB_TYPE_CACHE, conn.getMetaData().getURL(), JdbcUtils::getDbType);
         } catch (SQLException e) {
             throw ExceptionUtils.mpe(e);
         }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
@@ -131,7 +131,9 @@ public class JdbcUtils {
             return DbType.OPENGAUSS;
         } else if (url.contains(":TAOS:")) {
             return DbType.TDENGINE;
-        } else {
+        }else if (url.contains(":informix")) {
+           return DbType.INFORMIX;
+        }  else {
             logger.warn("The jdbcUrl is " + jdbcUrl + ", Mybatis Plus Cannot Read Database type or The Database's Not Supported!");
             return DbType.OTHER;
         }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
@@ -129,6 +129,8 @@ public class JdbcUtils {
             return DbType.REDSHIFT;
         } else if (url.contains(":opengauss:")) {
             return DbType.OPENGAUSS;
+        } else if (url.contains(":TAOS:")) {
+            return DbType.TDENGINE;
         } else {
             logger.warn("The jdbcUrl is " + jdbcUrl + ", Mybatis Plus Cannot Read Database type or The Database's Not Supported!");
             return DbType.OTHER;

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
@@ -129,7 +129,7 @@ public class JdbcUtils {
             return DbType.REDSHIFT;
         } else if (url.contains(":opengauss:")) {
             return DbType.OPENGAUSS;
-        } else if (url.contains(":TAOS:")) {
+        } else if (url.contains(":taos:") || url.contains(":taos-rs:")) {
             return DbType.TDENGINE;
         }else if (url.contains(":informix")) {
            return DbType.INFORMIX;

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/DynamicTableNameInnerInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/DynamicTableNameInnerInterceptorTest.java
@@ -42,5 +42,9 @@ class DynamicTableNameInnerInterceptorTest {
         // 别名被声明要替换
         origin = "SELECT t_user.* FROM t_user_real t_user";
         assertEquals("SELECT t_user.* FROM t_user_real_r t_user", interceptor.changeTable(origin));
+
+        // 别名被声明要替换
+        origin = "SELECT t.* FROM t_user_real t left join entity e on e.id = t.id";
+        assertEquals("SELECT t.* FROM t_user_real_r t left join entity e on e.id = t.id", interceptor.changeTable(origin));
     }
 }


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
原有的like：
```
Sample sample = new Sample();
        sample.setId(1L);
        sample.setName("aaa");
        sampleMapper.insert(sample);
List<Sample> sampleList = sampleMapper.selectList(
            new LambdaQueryWrapper<Sample>().like(Sample::getName, "a_a"));
```
a_a是可以匹配到aaa，因为'%_%'等于'%%',\、%都有相同问题，所以没办法匹配到特殊字符，修复方式为在SqlUtils新增escapeChar方法对参数中包含的特殊字符进行转义

### 测试用例

![image](https://user-images.githubusercontent.com/30498960/185388035-c2db2988-82dc-4756-9546-b3bb16315a72.png)



### 修复效果的截屏

![image](https://user-images.githubusercontent.com/30498960/185388187-2673e5f1-c9ec-4f9e-ba09-c62ad613e07a.png)

