### PR TITLE
feat: 增加IService.lambdaQuery(entity)支持，写法更便捷

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/LambdaQueryChainWrapper.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/LambdaQueryChainWrapper.java
@@ -41,6 +41,18 @@ public class LambdaQueryChainWrapper<T> extends AbstractChainWrapper<T, SFunctio
         super.wrapperChildren = new LambdaQueryWrapper<>();
     }
 
+    public LambdaQueryChainWrapper(BaseMapper<T> baseMapper, T entity) {
+        super();
+        this.baseMapper = baseMapper;
+        super.wrapperChildren = new LambdaQueryWrapper<>(entity);
+    }
+
+    public LambdaQueryChainWrapper(BaseMapper<T> baseMapper, Class<T> entityClass) {
+        super();
+        this.baseMapper = baseMapper;
+        super.wrapperChildren = new LambdaQueryWrapper<>(entityClass);
+    }
+
     @SafeVarargs
     @Override
     public final LambdaQueryChainWrapper<T> select(SFunction<T, ?>... columns) {

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/IService.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/IService.java
@@ -519,7 +519,18 @@ public interface IService<T> {
      * @return LambdaQueryWrapper 的包装类
      */
     default LambdaQueryChainWrapper<T> lambdaQuery() {
-        return ChainWrappers.lambdaQueryChain(getBaseMapper());
+        return ChainWrappers.lambdaQueryChain(getBaseMapper(), getEntityClass());
+    }
+
+    /**
+     * 链式查询 lambda 式
+     * <p>注意：不支持 Kotlin </p>
+     *
+     * @param entity 实体对象
+     * @return LambdaQueryWrapper 的包装类
+     */
+    default LambdaQueryChainWrapper<T> lambdaQuery(T entity) {
+        return ChainWrappers.lambdaQueryChain(getBaseMapper(), entity);
     }
 
     /**

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/ChainWrappers.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/ChainWrappers.java
@@ -57,6 +57,26 @@ public final class ChainWrappers {
 
     /**
      * 链式查询 lambda 式
+     * <p>注意：不支持 Kotlin </p>
+     *
+     * @return LambdaQueryWrapper 的包装类
+     */
+    public static <T> LambdaQueryChainWrapper<T> lambdaQueryChain(BaseMapper<T> mapper, T entity) {
+        return new LambdaQueryChainWrapper<>(mapper, entity);
+    }
+
+    /**
+     * 链式查询 lambda 式
+     * <p>注意：不支持 Kotlin </p>
+     *
+     * @return LambdaQueryWrapper 的包装类
+     */
+    public static <T> LambdaQueryChainWrapper<T> lambdaQueryChain(BaseMapper<T> mapper, Class<T> entityClass) {
+        return new LambdaQueryChainWrapper<>(mapper, entityClass);
+    }
+
+    /**
+     * 链式查询 lambda 式
      * 仅支持 Kotlin
      *
      * @return KtQueryWrapper 的包装类

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
@@ -575,4 +575,16 @@ class H2UserTest extends BaseTest {
         userService.removeBatchByIds(Arrays.asList(1L, 2L, h2User),2,false);
     }
 
+    @Test
+    void testServiceImplInnerLambdaQueryConstructorSetEntity() {
+        H2User condition = new H2User();
+        condition.setName("Tomcat");
+        H2User user = userService.lambdaQuery(condition).one();
+        Assertions.assertNotNull(user);
+        Assertions.assertTrue("Tomcat".equals(user.getName()));
+        H2User h2User = userService.lambdaQuery().setEntity(condition).one();
+        Assertions.assertNotNull(h2User);
+        Assertions.assertTrue("Tomcat".equals(h2User.getName()));
+    }
+
 }


### PR DESCRIPTION
### 该Pull Request关联的Issue

无

### 修改描述

与Wrappers.lambdaQuery(entity)用法一致，无需IService.lambdaQuery().setEntity(entity)

### 测试用例

`mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java`

![image](https://user-images.githubusercontent.com/16534815/188350530-1fec2a02-11f7-4da3-828a-9d69a1a6bf47.png)


### 修复效果的截屏
![image](https://user-images.githubusercontent.com/16534815/188350576-e46cbc0f-7f61-4567-bed7-29f406daabb1.png)

