### PR TITLE
fix(mybatis-plus-extension):JOIN语句租户解析异常

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
@@ -470,8 +470,6 @@ public class TenantLineInnerInterceptor extends JsqlParserSupport implements Inn
                     if (leftTable != null) {
                         onTables = Collections.singletonList(leftTable);
                     }
-                } else if (join.isLeft()) {
-                    onTables = Collections.singletonList(joinTable);
                 } else if (join.isInner()) {
                     if (mainTable == null) {
                         onTables = Collections.singletonList(joinTable);
@@ -479,6 +477,9 @@ public class TenantLineInnerInterceptor extends JsqlParserSupport implements Inn
                         onTables = Arrays.asList(mainTable, joinTable);
                     }
                     mainTable = null;
+                } else {
+                    // 如果是left join或者join直接走默认逻辑，保持与3.4.3.x版本逻辑一致
+                    onTables = Collections.singletonList(joinTable);
                 }
 
                 mainTables = new ArrayList<>();

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
@@ -414,6 +414,23 @@ class TenantLineInnerInterceptorTest {
 
     }
 
+    @Test
+    void selectJoin() {
+        // join
+        assertSql("SELECT * FROM entity e " +
+                "join entity1 e1 on e1.id = e.id " +
+                "WHERE e.id = ? OR e.name = ?",
+            "SELECT * FROM entity e " +
+                "JOIN entity1 e1 ON e1.id = e.id AND e1.tenant_id = 1 " +
+                "WHERE (e.id = ? OR e.name = ?) AND e.tenant_id = 1");
+
+        assertSql("SELECT * FROM entity e " +
+                "join entity1 e1 on e1.id = e.id " +
+                "WHERE (e.id = ? OR e.name = ?)",
+            "SELECT * FROM entity e " +
+                "JOIN entity1 e1 ON e1.id = e.id AND e1.tenant_id = 1 " +
+                "WHERE (e.id = ? OR e.name = ?) AND e.tenant_id = 1");
+    }
 
     @Test
     void selectWithAs() {


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
expected: "SELECT * FROM entity e JOIN entity1 e1 ON e1.id = e.id AND e1.tenant_id = 1 WHERE (e.id = ? OR e.name = ?) AND e.tenant_id = 1"
 but was: "SELECT * FROM entity e JOIN entity1 e1 ON e1.id = e.id WHERE (e.id = ? OR e.name = ?) AND e.tenant_id = 1"

默认的JOIN语句在执行时，JOIN的那张表被忽略掉了


### 测试用例

```
    @Test
    void selectJoin() {
        // join
        assertSql("SELECT * FROM entity e " +
                "join entity1 e1 on e1.id = e.id " +
                "WHERE e.id = ? OR e.name = ?",
            "SELECT * FROM entity e " +
                "JOIN entity1 e1 ON e1.id = e.id AND e1.tenant_id = 1 " +
                "WHERE (e.id = ? OR e.name = ?) AND e.tenant_id = 1");

        assertSql("SELECT * FROM entity e " +
                "join entity1 e1 on e1.id = e.id " +
                "WHERE (e.id = ? OR e.name = ?)",
            "SELECT * FROM entity e " +
                "JOIN entity1 e1 ON e1.id = e.id AND e1.tenant_id = 1 " +
                "WHERE (e.id = ? OR e.name = ?) AND e.tenant_id = 1");
    }

```



### 修复效果的截屏
![image](https://user-images.githubusercontent.com/26601421/191655116-9db340aa-79f6-4af6-a320-cfeb2a798ffb.png)

