### PR TITLE
Adapting SpringBoot OSS 3.0.0-M5 to the changes made to the auto-config class

### DIFF
--- a/mybatis-plus-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/mybatis-plus-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+com.baomidou.mybatisplus.autoconfigure.IdentifierGeneratorAutoConfiguration
+com.baomidou.mybatisplus.autoconfigure.MybatisPlusLanguageDriverAutoConfiguration
+com.baomidou.mybatisplus.autoconfigure.MybatisPlusAutoConfiguration

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/spring/MybatisSqlSessionFactoryBean.java
@@ -49,7 +49,6 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.core.NestedIOException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -539,7 +538,7 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
             try {
                 targetConfiguration.setDatabaseId(this.databaseIdProvider.getDatabaseId(this.dataSource));
             } catch (SQLException e) {
-                throw new NestedIOException("Failed getting a databaseId", e);
+                throw new IOException("Failed getting a databaseId", e);
             }
         }
 
@@ -550,7 +549,7 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
                 xmlConfigBuilder.parse();
                 LOGGER.debug(() -> "Parsed configuration file: '" + this.configLocation + "'");
             } catch (Exception ex) {
-                throw new NestedIOException("Failed to parse config resource: " + this.configLocation, ex);
+                throw new IOException("Failed to parse config resource: " + this.configLocation, ex);
             } finally {
                 ErrorContext.instance().reset();
             }
@@ -573,7 +572,7 @@ public class MybatisSqlSessionFactoryBean implements FactoryBean<SqlSessionFacto
                             targetConfiguration, mapperLocation.toString(), targetConfiguration.getSqlFragments());
                         xmlMapperBuilder.parse();
                     } catch (Exception e) {
-                        throw new NestedIOException("Failed to parse mapping resource: '" + mapperLocation + "'", e);
+                        throw new IOException("Failed to parse mapping resource: '" + mapperLocation + "'", e);
                     } finally {
                         ErrorContext.instance().reset();
                     }


### PR DESCRIPTION
### 该Pull Request关联的Issue

- Fixes https://github.com/baomidou/mybatis-plus/issues/3883 .
- Fixes https://github.com/baomidou/mybatis-plus/issues/4552 .
- Fixes https://github.com/baomidou/mybatis-plus/pull/4818 .
- Fixes https://github.com/baomidou/mybatis-plus/issues/4836 .
- Fixes https://github.com/baomidou/mybatis-plus/issues/4842 .
- Fixes https://github.com/baomidou/mybatis-plus/pull/4843 .
- Fixes https://github.com/baomidou/mybatis-plus/issues/4846 .

### 修改描述

- Adapting SpringBoot OSS 3.0.0-M5 to the changes made to the auto-config class.
- This will continue to maintain support for SpringBoot OSS < `2.7.0`. Reference https://github.com/remkop/picocli/pull/1778#issuecomment-1242654922 .
- Linkes to https://github.com/apache/shardingsphere/issues/21225 .
- Since Mybatis has not released a milestone version, users need to explicitly specify the version of `mybatis-spring-boot-starter` in `pom.xml`. Refer to https://github.com/mybatis/spring-boot-starter/issues/607 .
```xml
<dependencies>
    <dependency>
        <groupId>org.mybatis.spring.boot</groupId>
        <artifactId>mybatis-spring-boot-starter</artifactId>
        <version>3.0.0-SNAPSHOT</version>
    </dependency>
</dependencies>
<repositories>
    <repository>
        <id>ossrh</id>
        <name>OSS Snapshot repository</name>
        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
        <releases>
            <enabled>false</enabled>
        </releases>
        <snapshots>
            <enabled>true</enabled>
        </snapshots>
    </repository>
</repositories>
```

### 测试用例

- This is no extra handling of unit tests is required.

### 修复效果的截屏

- Null.
