### PR TITLE
处理sqlserver2005分页方言存在partition by order by时截取排序SQL错误

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/SQLServer2005Dialect.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/SQLServer2005Dialect.java
@@ -28,13 +28,16 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.DialectModel;
 public class SQLServer2005Dialect implements IDialect {
 
     private static String getOrderByPart(String sql) {
-        String loweredString = sql.toLowerCase();
-        int orderByIndex = loweredString.indexOf("order by");
-        if (orderByIndex != -1) {
-            return sql.substring(orderByIndex);
-        } else {
-            return StringPool.EMPTY;
+        final String loweredString = sql.toLowerCase();
+        final int partitionByIndex = loweredString.lastIndexOf("partition by");
+        final int orderByIndex = loweredString.indexOf("order by", partitionByIndex);
+        final int lastOrderByIndex = loweredString.lastIndexOf("order by");
+        if (partitionByIndex >= 0 && orderByIndex != lastOrderByIndex) {
+            return sql.substring(lastOrderByIndex);
+        } else if(lastOrderByIndex >= 0) {
+            return sql.substring(lastOrderByIndex);
         }
+        return StringPool.EMPTY;
     }
 
     @Override


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述

修复如下SQL处理：

```
SELECT
ROW_NUMBER() OVER(PARTITION BY task.i_id ORDER  BY task.i_id) AS rowNumbers,
*
FROM
t_duty_task task

SELECT
ROW_NUMBER() OVER(PARTITION BY task.i_id ORDER  BY task.i_id) AS rowNumbers,
*
FROM
t_duty_task task
ORDER BY updated_time DESC 
```

### 测试用例



### 修复效果的截屏


