### PR TITLE
处理sqlserver2005分页方言存在row_number order by时截取排序SQL错误

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/SQLServer2005Dialect.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/SQLServer2005Dialect.java
@@ -32,8 +32,10 @@ public class SQLServer2005Dialect implements IDialect {
         final int rowNumberIndex = loweredString.lastIndexOf("row_number");
         final int orderByIndex = loweredString.indexOf("order by", rowNumberIndex);
         final int lastOrderByIndex = loweredString.lastIndexOf("order by");
-        if (rowNumberIndex >= 0 && orderByIndex != lastOrderByIndex) {
-            return sql.substring(lastOrderByIndex);
+        if (rowNumberIndex >= 0) {
+            if(orderByIndex != lastOrderByIndex) {
+               return sql.substring(lastOrderByIndex);
+            }
         } else if(lastOrderByIndex >= 0) {
             return sql.substring(lastOrderByIndex);
         }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/SQLServer2005Dialect.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/SQLServer2005Dialect.java
@@ -28,13 +28,16 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.DialectModel;
 public class SQLServer2005Dialect implements IDialect {
 
     private static String getOrderByPart(String sql) {
-        String loweredString = sql.toLowerCase();
-        int orderByIndex = loweredString.indexOf("order by");
-        if (orderByIndex != -1) {
-            return sql.substring(orderByIndex);
-        } else {
-            return StringPool.EMPTY;
+        final String loweredString = sql.toLowerCase();
+        final int partitionByIndex = loweredString.lastIndexOf("partition by");
+        final int orderByIndex = loweredString.indexOf("order by", partitionByIndex);
+        final int lastOrderByIndex = loweredString.lastIndexOf("order by");
+        if (partitionByIndex >= 0 && orderByIndex != lastOrderByIndex) {
+            return sql.substring(lastOrderByIndex);
+        } else if(lastOrderByIndex >= 0) {
+            return sql.substring(lastOrderByIndex);
         }
+        return StringPool.EMPTY;
     }
 
     @Override

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/SQLServer2005Dialect.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/dialects/SQLServer2005Dialect.java
@@ -29,10 +29,10 @@ public class SQLServer2005Dialect implements IDialect {
 
     private static String getOrderByPart(String sql) {
         final String loweredString = sql.toLowerCase();
-        final int partitionByIndex = loweredString.lastIndexOf("partition by");
-        final int orderByIndex = loweredString.indexOf("order by", partitionByIndex);
+        final int rowNumberIndex = loweredString.lastIndexOf("row_number");
+        final int orderByIndex = loweredString.indexOf("order by", rowNumberIndex);
         final int lastOrderByIndex = loweredString.lastIndexOf("order by");
-        if (partitionByIndex >= 0 && orderByIndex != lastOrderByIndex) {
+        if (rowNumberIndex >= 0 && orderByIndex != lastOrderByIndex) {
             return sql.substring(lastOrderByIndex);
         } else if(lastOrderByIndex >= 0) {
             return sql.substring(lastOrderByIndex);


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述

```
SELECT
ROW_NUMBER() OVER(PARTITION BY task.i_id ORDER BY task.i_id) AS rowNumbers,
*
FROM
t_duty_task task
-------------
SELECT
ROW_NUMBER() OVER(PARTITION BY task.i_id ORDER BY task.i_id) AS rowNumbers,
*
FROM
t_duty_task task
ORDER BY updated_time DESC 
```

上面两个SQL旧版截取如下：

```
ORDER BY task.i_id) AS rowNumbers,
*
FROM
t_duty_task task
-------------
ORDER BY task.i_id) AS rowNumbers,
*
FROM
t_duty_task task
ORDER BY updated_time DESC 
```

修改以后截取如下：

```

-------------
ORDER BY updated_time DESC 
```

### 测试用例



### 修复效果的截屏


