### PR TITLE
修复：修复当select列中包含left join表字段时，countSql仍然被优化的问题。

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -338,6 +338,13 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
                             break;
                         }
 
+                        // 如果select中包含join表的字段则不优化
+                        for (SelectItem item : plainSelect.getSelectItems()) {
+                            if (item.toString().contains(str)) {
+                                return lowLevelCountSql(select.toString());
+                            }
+                        }
+
                         for (Expression expression : join.getOnExpressions()) {
                             if (expression.toString().contains(StringPool.QUESTION_MARK)) {
                                 /* 如果 join 里包含 ?(代表有入参) 就不移除 join */


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
优化countSql时考虑select列中包含left join的情况。


### 测试用例
`select a.*, b.col1 from table1 a left join table2 b on (b.rid = a.id)`会被优化为`select a.*, b.col1 from table1 a`。此时会导致b.col1因不存在导致异常。


### 修复效果的截屏
无

