### PR TITLE
FIX #4998 SetOperationList  cannot be cast to class PlainSelect 

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
@@ -120,7 +120,7 @@ public class TenantLineInnerInterceptor extends BaseMultiTableInnerInterceptor i
         }
 
         Select select = insert.getSelect();
-        if (select != null) {
+        if (select != null && (select.getSelectBody() instanceof PlainSelect)) { //fix github issue 4998  修复升级到4.5版本的问题
             this.processInsertSelect(select.getSelectBody(), (String) obj);
         } else if (insert.getItemsList() != null) {
             // fixed github pull/295


### PR DESCRIPTION
### 该Pull Request关联的Issue

FIX #4998
class net.sf.jsqlparser.statement.select.SetOperationList cannot be cast to class net.sf.jsqlparser.statement.select.PlainSelect (net.sf.jsqlparser.statement.select.SetOperationList and net.sf.jsqlparser.statement.select.PlainSelect

### 修改描述
修复升到到jsqlparser到4.5版本的时候 租户插件Insert报错的问题。同时也兼容原有的4.4版本





### 修复效果的截屏
![1676535810308](https://user-images.githubusercontent.com/8952611/219308448-9880158f-65e4-4de1-a05e-aee154aa4f24.jpg)


