### PR TITLE
FIX #4998 SetOperationList cannot be cast to class PlainSelect 

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
@@ -120,7 +120,7 @@ public class TenantLineInnerInterceptor extends BaseMultiTableInnerInterceptor i
         }
 
         Select select = insert.getSelect();
-        if (select != null) {
+        if (select != null && (select.getSelectBody() instanceof PlainSelect)) { //fix github issue 4998  修复升级到4.5版本的问题
             this.processInsertSelect(select.getSelectBody(), (String) obj);
         } else if (insert.getItemsList() != null) {
             // fixed github pull/295

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
@@ -21,6 +21,7 @@ import com.baomidou.mybatisplus.extension.plugins.handler.TenantLineHandler;
 import com.baomidou.mybatisplus.extension.toolkit.PropertyMapper;
 import lombok.*;
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.RowConstructor;
 import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
@@ -128,6 +129,10 @@ public class TenantLineInnerInterceptor extends BaseMultiTableInnerInterceptor i
             Expression tenantId = tenantLineHandler.getTenantId();
             if (itemsList instanceof MultiExpressionList) {
                 ((MultiExpressionList) itemsList).getExpressionLists().forEach(el -> el.getExpressions().add(tenantId));
+            }else if(itemsList instanceof ExpressionList){//fix github issue 4998
+                List<Expression> expressions = ((ExpressionList) itemsList).getExpressions();
+                expressions.forEach(it-> ((RowConstructor)it).getExprList().addExpressions(tenantId));
+
             } else {
                 ((ExpressionList) itemsList).getExpressions().add(tenantId);
             }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
@@ -132,7 +132,6 @@ public class TenantLineInnerInterceptor extends BaseMultiTableInnerInterceptor i
             }else if(itemsList instanceof ExpressionList){//fix github issue 4998
                 List<Expression> expressions = ((ExpressionList) itemsList).getExpressions();
                 expressions.forEach(it-> ((RowConstructor)it).getExprList().addExpressions(tenantId));
-
             } else {
                 ((ExpressionList) itemsList).getExpressions().add(tenantId);
             }

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
@@ -37,6 +37,8 @@ class TenantLineInnerInterceptorTest {
 
     @Test
     void insert() {
+        assertSql("insert into entity (id) values (?)",
+            "INSERT INTO entity (id, tenant_id) VALUES (?, 1)");
         // plain
         assertSql("insert into entity (id,name) values (?,?)",
             "INSERT INTO entity (id, name, tenant_id) VALUES (?, ?, 1)");

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
@@ -39,6 +39,10 @@ class TenantLineInnerInterceptorTest {
     void insert() {
         assertSql("insert into entity (id) values (?)",
             "INSERT INTO entity (id, tenant_id) VALUES (?, 1)");
+        assertSql("insert into entity (id) values (?),(?) ",
+            "INSERT INTO entity (id, tenant_id) VALUES (?, 1), (?, 1)");
+        assertSql("insert into entity (id) values (?),(?) ",
+            "INSERT INTO entity (id, tenant_id) VALUES (?, 1),(?, 1)");
         // plain
         assertSql("insert into entity (id,name) values (?,?)",
             "INSERT INTO entity (id, name, tenant_id) VALUES (?, ?, 1)");


### PR DESCRIPTION
### 该Pull Request关联的Issue
FIX https://github.com/baomidou/mybatis-plus/issues/4998
class net.sf.jsqlparser.statement.select.SetOperationList cannot be cast to class net.sf.jsqlparser.statement.select.PlainSelect (net.sf.jsqlparser.statement.select.SetOperationList and net.sf.jsqlparser.statement.select.PlainSelect


### 修改描述
修复升到到jsqlparser到4.5版本的时候 租户插件Insert报错的问题。同时也兼容原有的4.4版本


### 测试用例
TenantLineInnerInterceptorTest 已通过


### 修复效果的截屏
![image](https://user-images.githubusercontent.com/8952611/219552734-d9aec515-61e6-4508-af6a-e69680c1321d.png)


