### PR TITLE
fix: 不支持使用cs、ur、uu等隔离级别的关键字

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
         springVersion = '5.3.15',
         springBootVersion = '2.5.3',
         springCloudVersion = '3.1.1',
-        jsqlparserVersion = '4.4', // 4.5 有bug
+        jsqlparserVersion = '4.3', // 4.5 有bug
         junitVersion = '5.9.0',
     ]
 

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/JSqlParserTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/JSqlParserTest.java
@@ -17,7 +17,9 @@ package com.baomidou.mybatisplus.test;
 
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.delete.Delete;
+import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.update.Update;
@@ -62,4 +64,13 @@ class JSqlParserTest {
         Delete delete = (Delete) CCJSqlParserUtil.parse("delete from tableName t");
         Assertions.assertNull(delete.getWhere());
     }
+
+    @Test
+    void isolationKeywordParser() throws Exception {
+        Select select = (Select) CCJSqlParserUtil.parse("SELECT a FROM tableName cs");
+
+        PlainSelect ps = (PlainSelect) select.getSelectBody();
+        Assertions.assertEquals("a", ps.getSelectItems().get(0).toString());
+    }
+
 }


### PR DESCRIPTION
### 该Pull Request关联的Issue
#5142 [bug] 不支持使用cs、ur、uu等隔离级别的关键字


### 修改描述
将JSqlParser 降级至4.3，并增加了对隔离级别关键字解析的用例


### 测试用例
```java
@Test
void isolationKeywordParser() throws Exception {
    Select select = (Select) CCJSqlParserUtil.parse("SELECT a FROM tableName cs");

    PlainSelect ps = (PlainSelect) select.getSelectBody();
    Assertions.assertEquals("a", ps.getSelectItems().get(0).toString());
}
```


### 修复效果的截屏
![image](https://user-images.githubusercontent.com/30334421/219604421-fa7ba825-695d-4c63-a586-63889b516371.png)

测试用例除都已通过
![image](https://user-images.githubusercontent.com/30334421/219615660-0d19e1f6-df67-4fc1-b38e-bf495fbabb87.png)


