### PR TITLE
修复先添加PaginationInnerInterceptor插件，再增加DynamicTableNameInnerIn

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptor.java
@@ -17,6 +17,7 @@ package com.baomidou.mybatisplus.extension.plugins;
 
 import com.baomidou.mybatisplus.core.toolkit.ClassUtils;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
+import com.baomidou.mybatisplus.extension.plugins.inner.DynamicTableNameInnerInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.inner.InnerInterceptor;
 import com.baomidou.mybatisplus.extension.toolkit.PropertyMapper;
 import lombok.Setter;
@@ -115,7 +116,11 @@ public class MybatisPlusInterceptor implements Interceptor {
     }
 
     public void addInnerInterceptor(InnerInterceptor innerInterceptor) {
-        this.interceptors.add(innerInterceptor);
+        if (innerInterceptor instanceof DynamicTableNameInnerInterceptor) {
+            this.interceptors.add(0, innerInterceptor);
+        } else {
+            this.interceptors.add(innerInterceptor);
+        }
     }
 
     public List<InnerInterceptor> getInterceptors() {

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptorTest.java
@@ -1,6 +1,7 @@
 package com.baomidou.mybatisplus.extension.plugins;
 
 import com.baomidou.mybatisplus.annotation.DbType;
+import com.baomidou.mybatisplus.extension.plugins.inner.DynamicTableNameInnerInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.inner.InnerInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
 import org.junit.jupiter.api.Test;
@@ -36,4 +37,14 @@ class MybatisPlusInterceptorTest {
         assertThat(pii.getMaxLimit()).isEqualTo(10);
         assertThat(pii.getDbType()).isEqualTo(DbType.H2);
     }
+
+    @Test
+    void testInterceptorOrder() {
+        MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+        interceptor.addInnerInterceptor(new PaginationInnerInterceptor());
+        interceptor.addInnerInterceptor(new DynamicTableNameInnerInterceptor());
+        assertThat(interceptor.getInterceptors().get(0)).isInstanceOf(DynamicTableNameInnerInterceptor.class);
+    }
+
+
 }


### PR DESCRIPTION
修复先添加分页插件，再增加动态表名插件，分页插件count时表名未更新

### 该Pull Request关联的Issue
无


### 修改描述

`

    public MybatisPlusInterceptor mybatisPlusInterceptor() {
        MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
        //添加分页插件
        interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
        //添加动态表名插件
        final DynamicTableNameInnerInterceptor nameInnerInterceptor = new DynamicTableNameInnerInterceptor();
        nameInnerInterceptor.setTableNameHandler((sql, tableName) -> {
            // 返回新表名
            return "newTableName";
        });
        interceptor.addInnerInterceptor(nameInnerInterceptor);
        return interceptor;
    }
`

 如上代码，先添加分页插件，分页插件执行时，会先执行count查询，这时候动态表名插件未执行，所以动态表名未生效。

    可选解决方案： 
      1：由用户调整插件添加顺序
      2：代码中把动态表名插件放到第一个

    结论：为了减少用户操作，所以选择第2种解决方案，在增加插件时，把动态表名插件放到第一个




