### PR TITLE
升级jsqlparser至4.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
         springVersion = '5.3.15',
         springBootVersion = '2.5.3',
         springCloudVersion = '3.1.1',
-        jsqlparserVersion = '4.4', // 4.5 有bug
+        jsqlparserVersion = '4.6',
         junitVersion = '5.9.0',
     ]
 

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptorTest.java
@@ -45,6 +45,8 @@ class TenantLineInnerInterceptorTest {
         // batch
         assertSql("insert into entity (id,name) values (?,?),(?,?)",
             "INSERT INTO entity (id, name, tenant_id) VALUES (?, ?, 1), (?, ?, 1)");
+        assertSql("insert into entity (id) values (?),(?)",
+                  "INSERT INTO entity (id, tenant_id) VALUES (?, 1), (?, 1)");
         // 无 insert的列
         assertSql("insert into entity value (?,?)",
             "INSERT INTO entity VALUES (?, ?)");


### PR DESCRIPTION
### 该Pull Request关联的Issue
#4998  
class net.sf.jsqlparser.statement.select.SetOperationList cannot be cast to class net.sf.jsqlparser.statement.select.PlainSelect (net.sf.jsqlparser.statement.select.SetOperationList and net.sf.jsqlparser.statement.select.PlainSelect
#5159 多个left join sql 在分页插件join优化时会一直报警告
https://github.com/baomidou/mybatis-plus/issues/5142 [bug] 不支持使用cs、ur、uu等隔离级别的关键字
#5086 使用多租户插件功能，解析SQL语句中有表别名为ur时，解析报错

### 修改描述
升级jsqlparser至4.6，适配Insert 的selectBody为SetOperationList的情况。


### 测试用例
除了原有的测试用例外，还在TenantLineInnerInterceptorTest 类的insert中添加了如下测试用例
```SQL
assertSql("insert into entity (id) values (?),(?)",
                  "INSERT INTO entity (id, tenant_id) VALUES (?, 1), (?, 1)");
```



### 修复效果的截屏
![image](https://user-images.githubusercontent.com/30334421/221393316-521cb7fd-fe57-4090-8cf6-e678dbc48c3d.png)


