### PR TITLE
FIX #5087 多线程环境下使用同个queryWrapper获取sqlSegment时可能为空

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/segments/MergeSegments.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/segments/MergeSegments.java
@@ -63,14 +63,20 @@ public class MergeSegments implements ISqlSegment {
         if (cacheSqlSegment) {
             return sqlSegment;
         }
-        cacheSqlSegment = true;
-        if (normal.isEmpty()) {
-            if (!groupBy.isEmpty() || !orderBy.isEmpty()) {
-                sqlSegment = groupBy.getSqlSegment() + having.getSqlSegment() + orderBy.getSqlSegment();
+        synchronized (this) {
+            if (cacheSqlSegment) {
+                return sqlSegment;
             }
-        } else {
-            sqlSegment = normal.getSqlSegment() + groupBy.getSqlSegment() + having.getSqlSegment() + orderBy.getSqlSegment();
+            if (normal.isEmpty()) {
+                if (!groupBy.isEmpty() || !orderBy.isEmpty()) {
+                    sqlSegment = groupBy.getSqlSegment() + having.getSqlSegment() + orderBy.getSqlSegment();
+                }
+            } else {
+                sqlSegment = normal.getSqlSegment() + groupBy.getSqlSegment() + having.getSqlSegment() + orderBy.getSqlSegment();
+            }
+            cacheSqlSegment = true;
         }
+
         return sqlSegment;
     }
 

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/ConcurrencyQueryWrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/ConcurrencyQueryWrapperTest.java
@@ -1,0 +1,41 @@
+package com.baomidou.mybatisplus.core.conditions;
+
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import lombok.Data;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConcurrencyQueryWrapperTest extends BaseWrapperTest {
+    @Test
+    void testSqlSegmentInMultiThread() {
+        QueryWrapper<Table> lqw = new QueryWrapper<>();
+        lqw.eq("id", 1);
+        for (int i = 0; i < 10; i++) {
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    String sqlSegment = lqw.getSqlSegment();
+                    System.out.println(Thread.currentThread().getName() + ":" + sqlSegment);
+                    Assertions.assertEquals("(id = #{ew.paramNameValuePairs.MPGENVAL1})", sqlSegment);
+                }
+            }).start();
+        }
+        String sqlSegment = lqw.getSqlSegment();
+        System.out.println(Thread.currentThread().getName() + ":" + sqlSegment);
+        Assertions.assertEquals("(id = #{ew.paramNameValuePairs.MPGENVAL1})", sqlSegment);
+    }
+
+    @Data
+    @TableName("xxx")
+    private static class Table {
+
+        @TableId("`id`")
+        private Long id;
+
+        @TableField("`name`")
+        private Long name;
+    }
+}


### PR DESCRIPTION
### 该Pull Request关联的Issue
https://github.com/baomidou/mybatis-plus/issues/5087


### 修改描述
将生成sqlSegment的代码段包含在synchronized语句中


### 测试用例
ConcurrencyQueryWrapperTest


### 修复效果的截屏
![image](https://user-images.githubusercontent.com/83471894/226854851-838a8878-9109-406e-839b-18086434a298.png)


