### PR TITLE
增加一种typeHandler的创建方式，支持传入Field字段。

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableFieldInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableFieldInfo.java
@@ -39,7 +39,9 @@ import org.apache.ibatis.type.TypeAliasRegistry;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
 import org.apache.ibatis.type.UnknownTypeHandler;
+import org.apache.ibatis.type.TypeException;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.Map;
 
@@ -565,7 +567,16 @@ public class TableFieldInfo implements Constants {
         if (typeHandler != null && typeHandler != UnknownTypeHandler.class) {
             TypeHandler<?> typeHandler = registry.getMappingTypeHandler(this.typeHandler);
             if (typeHandler == null) {
-                typeHandler = registry.getInstance(propertyType, this.typeHandler);
+                try {
+                    typeHandler = registry.getInstance(propertyType, this.typeHandler);
+                }catch (Exception e){
+                    try {
+                        Constructor c = this.typeHandler.getConstructor(Field.class);
+                        typeHandler =  (TypeHandler)c.newInstance(this.field);
+                    } catch (Exception var6) {
+                        throw new TypeException("Failed invoking constructor for handler " + this.typeHandler, var6);
+                    }
+                }
                 // todo 这会有影响 registry.register(typeHandler);
             }
             builder.typeHandler(typeHandler);


### PR DESCRIPTION
### 该Pull Request关联的Issue
没有相关issue


### 修改描述
增加一种typeHandler的创建方式，支持传入Field字段。
目的：这样用户能拿到更多字段信息，对字段的处理也更丰富。
比如下面的场景：
```
@Data
public class User {
    private long id;
    private String name;

    @TableField(typeHandler = XXXX1.class)
    private List<Address> listField;

   @TableField(typeHandler = XXXX2.class)
    private Map<String,List<Address>> mapField;
}
```
现在的typeHandler只支持两种构造方法：一是传入class对象的构造方法，一个是无参构造方法。
但是针对上面listField字段或者mapField字段，就必须定义两个不同的typeHandler。
显然用户系统中可能还有各种类型的List： ``List<A>``  ``List<B>``  ``List<C>`` 等等，那么就需要分别定义不同的typeHandler
那样的话typeHandler的数量就会爆炸。

如果增加一个支持传入Field类型的typeHandler，那么用户只需要定义一个typeHandler就满足各种各样List / Set / Map，比如下面的typeHandler
```
@MappedJdbcTypes(value = {JdbcType.VARCHAR}, includeNullJdbcType = true)
public class XXXTypeHandler extends AbstractJsonTypeHandler<Object> {
    private Field field;

    public XXXTypeHandler(Field field) {
        this.field = field;
    }

    @Override
    protected Object parse(String json) {
        return JSON.parseObject(json, this.field.getGenericType());
    }

    @Override
    protected String toJson(Object obj) {
        return JSON.toJSONString(obj);
    }
}

//上面的JSON类来自fastjson
```
有了这样一个typeHandler，就能支持各种泛型了

如果考虑merge的话，建议框架再集成一个类似上面的typeHandler，这样用户都不用定义这样的typeHandler了。如果可以话我也很乐意贡献这样的typeHandler

### 测试用例

```
@Test
public void f2() throws NoSuchFieldException {
    List<Address> addressList = new ArrayList<>();
    addressList.add(Address.builder().detailAddress("a").city("a").build());
    addressList.add(Address.builder().detailAddress("b").city("b").build());

    Field addresses = User.class.getDeclaredField("listField");
    Object o = JSON.parseObject(JSON.toJSONString(addressList), addresses.getGenericType());
    System.out.println(Objects.equals(o, addressList));

    Map<String, List<Address>> maps = new HashMap<>();
    maps.put("1", addressList);
    maps.put("2", addressList);
    Field map = User.class.getDeclaredField("mapField");
    Object ox = JSON.parseObject(JSON.toJSONString(maps), map.getGenericType());
    System.out.println(Objects.equals(ox, maps));
}
```


### 修复效果的截屏


