### PR TITLE
解决UpdateWrapper使用set方法时自定义TypeHandler无效

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
@@ -443,8 +443,9 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
      * @param val        条件值
      */
     protected Children addCondition(boolean condition, R column, SqlKeyword sqlKeyword, Object val) {
-        return maybeDo(condition, () -> appendSqlSegments(columnToSqlSegment(column), sqlKeyword,
-            () -> formatParam(null, val)));
+        ISqlSegment segment = columnToSqlSegment(column);
+        String mapping = this.fieldMappings.get(segment.getSqlSegment());
+        return maybeDo(condition, () -> appendSqlSegments(segment, sqlKeyword, () -> formatParam(mapping, val)));
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/LambdaUpdateWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/LambdaUpdateWrapper.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @SuppressWarnings("serial")
 public class LambdaUpdateWrapper<T> extends AbstractLambdaWrapper<T, LambdaUpdateWrapper<T>>
-    implements Update<LambdaUpdateWrapper<T>, SFunction<T, ?>> {
+        implements Update<LambdaUpdateWrapper<T>, SFunction<T, ?>> {
 
     /**
      * SQL 更新字段内容，例如：name='1', age=2
@@ -61,8 +61,8 @@ public class LambdaUpdateWrapper<T> extends AbstractLambdaWrapper<T, LambdaUpdat
     }
 
     LambdaUpdateWrapper(T entity, Class<T> entityClass, List<String> sqlSet, AtomicInteger paramNameSeq,
-                        Map<String, Object> paramNameValuePairs, MergeSegments mergeSegments, SharedString paramAlias,
-                        SharedString lastSql, SharedString sqlComment, SharedString sqlFirst) {
+            Map<String, Object> paramNameValuePairs, MergeSegments mergeSegments, SharedString paramAlias,
+            SharedString lastSql, SharedString sqlComment, SharedString sqlFirst) {
         super.setEntity(entity);
         super.setEntityClass(entityClass);
         this.sqlSet = sqlSet;
@@ -73,6 +73,15 @@ public class LambdaUpdateWrapper<T> extends AbstractLambdaWrapper<T, LambdaUpdat
         this.lastSql = lastSql;
         this.sqlComment = sqlComment;
         this.sqlFirst = sqlFirst;
+    }
+
+    @Override
+    public LambdaUpdateWrapper<T> set(boolean condition, SFunction<T, ?> column, Object val) {
+        return maybeDo(condition, () -> {
+            String columnValue = columnToString(column);
+            String sql = formatParam(this.fieldMappings.get(columnValue), val);
+            sqlSet.add(columnValue + Constants.EQUALS + sql);
+        });
     }
 
     @Override
@@ -102,7 +111,7 @@ public class LambdaUpdateWrapper<T> extends AbstractLambdaWrapper<T, LambdaUpdat
     @Override
     protected LambdaUpdateWrapper<T> instance() {
         return new LambdaUpdateWrapper<>(getEntity(), getEntityClass(), null, paramNameSeq, paramNameValuePairs,
-            new MergeSegments(), paramAlias, SharedString.emptyString(), SharedString.emptyString(), SharedString.emptyString());
+                new MergeSegments(), paramAlias, SharedString.emptyString(), SharedString.emptyString(), SharedString.emptyString());
     }
 
     @Override

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/UpdateWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/UpdateWrapper.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @SuppressWarnings("serial")
 public class UpdateWrapper<T> extends AbstractWrapper<T, String, UpdateWrapper<T>>
-    implements Update<UpdateWrapper<T>, String> {
+        implements Update<UpdateWrapper<T>, String> {
 
     /**
      * SQL 更新字段内容，例如：name='1', age=2
@@ -54,8 +54,8 @@ public class UpdateWrapper<T> extends AbstractWrapper<T, String, UpdateWrapper<T
     }
 
     private UpdateWrapper(T entity, List<String> sqlSet, AtomicInteger paramNameSeq,
-                          Map<String, Object> paramNameValuePairs, MergeSegments mergeSegments, SharedString paramAlias,
-                          SharedString lastSql, SharedString sqlComment, SharedString sqlFirst) {
+            Map<String, Object> paramNameValuePairs, MergeSegments mergeSegments, SharedString paramAlias,
+            SharedString lastSql, SharedString sqlComment, SharedString sqlFirst) {
         super.setEntity(entity);
         this.sqlSet = sqlSet;
         this.paramNameSeq = paramNameSeq;
@@ -73,6 +73,12 @@ public class UpdateWrapper<T> extends AbstractWrapper<T, String, UpdateWrapper<T
             return null;
         }
         return String.join(Constants.COMMA, sqlSet);
+    }
+
+    @Override
+    public UpdateWrapper<T> set(boolean condition, String column, Object val) {
+        String mapping = this.fieldMappings.get(column);
+        return set(condition, column, val, mapping);
     }
 
     @Override
@@ -101,13 +107,13 @@ public class UpdateWrapper<T> extends AbstractWrapper<T, String, UpdateWrapper<T
      */
     public LambdaUpdateWrapper<T> lambda() {
         return new LambdaUpdateWrapper<>(getEntity(), getEntityClass(), sqlSet, paramNameSeq, paramNameValuePairs,
-            expression, paramAlias, lastSql, sqlComment, sqlFirst);
+                expression, paramAlias, lastSql, sqlComment, sqlFirst);
     }
 
     @Override
     protected UpdateWrapper<T> instance() {
         return new UpdateWrapper<>(getEntity(), null, paramNameSeq, paramNameValuePairs, new MergeSegments(),
-            paramAlias, SharedString.emptyString(), SharedString.emptyString(), SharedString.emptyString());
+                paramAlias, SharedString.emptyString(), SharedString.emptyString(), SharedString.emptyString());
     }
 
     @Override


### PR DESCRIPTION
### 修改描述
字段上增加自定义TypeHandler之后使用UpdateWrapper对象的set方法设置相关字段值时，TypeHandler无效，修改AbstractWrapper、UpdateWrapper、LambdaUpdateWrapper，当调用set方法时，添加字段对应的mapping信息


