### PR TITLE
修复logicDeletePropertyName配置实体类字段跟生成后的实体类字段不一致

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
@@ -169,6 +169,9 @@ public class TableField {
             this.convert = true;
         }
         this.propertyName = propertyName;
+        if (this.isLogicDeleteField()) {
+            this.propertyName = this.entity.getLogicDeletePropertyName();
+        }
         return this;
     }
 


### PR DESCRIPTION
### 该Pull Request关联的Issue
#5255 


### 修改描述

字段为逻辑删除字段时，没有修改com.baomidou.mybatisplus.generator.config.po.TableField#propertyName 的值引起的bug

### 测试用例



### 修复效果的截屏

1. 配置了logicDeletePropertyName 和logicDeleteColumnName

![全配置](https://user-images.githubusercontent.com/42528634/234513788-f09c97c1-b50c-4674-843a-787fc7f13d92.png)

2. 只配置了logicDeletePropertyName

![只配置logicDeletePropertyName](https://user-images.githubusercontent.com/42528634/234513900-68e2dbec-e7d1-409f-a627-b502a9bf2c69.png)

3. 只配置logicDeleteColumnName

![只配置logicDeleteColumnName](https://user-images.githubusercontent.com/42528634/234513999-2a373273-58df-4113-a2e3-8dc21079a608.png)
