### PR TITLE
修复bug : logicDeletePropertyName配置实体类字段跟生成后的实体类字段不一致

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
@@ -170,6 +170,7 @@ public class TableField {
         }
         this.propertyName = propertyName;
         if (this.isLogicDeleteField()) {
+            this.convert = true;
             this.propertyName = this.entity.getLogicDeletePropertyName();
         }
         return this;

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
@@ -169,6 +169,9 @@ public class TableField {
             this.convert = true;
         }
         this.propertyName = propertyName;
+        if (this.isLogicDeleteField()) {
+            this.propertyName = this.entity.getLogicDeletePropertyName();
+        }
         return this;
     }
 


### PR DESCRIPTION
### 该Pull Request关联的Issue

#5255 

### 修改描述

逻辑删除字段，未修改 com.baomidou.mybatisplus.generator.config.po.TableField#propertyName 导致的bug

### 测试用例



### 修复效果的截屏

1.  配置了logicDeleteColumnName 和logicDeletePropertyName

![全配置](https://user-images.githubusercontent.com/42528634/234521013-d994f141-6bad-465f-ab62-594a0d6f6c46.png)

![全配置2](https://user-images.githubusercontent.com/42528634/234522740-76c32adc-5e02-4fb2-95bf-567e43b92680.png)


2.   配置了logicDeleteColumnName 

![只配置logicDeleteColumnName](https://user-images.githubusercontent.com/42528634/234521119-d80618a7-04fa-43c3-a013-199fa9e188d7.png)

3. 配置了 logicDeletePropertyName

![只配置logicDeletePropertyName](https://user-images.githubusercontent.com/42528634/234521203-56ce5001-5ce7-484d-b62a-d7e21e2f3c72.png)
