### PR TITLE
修复logicDeletePropertyName配置实体类字段跟生成后的实体类字段不一致

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
@@ -169,6 +169,10 @@ public class TableField {
             this.convert = true;
         }
         this.propertyName = propertyName;
+        if (this.isLogicDeleteField() && StringUtils.isNotBlank(this.entity.getLogicDeletePropertyName())) {
+            this.convert = true;
+            this.propertyName = this.entity.getLogicDeletePropertyName();
+        }
         return this;
     }
 


### PR DESCRIPTION
### 该Pull Request关联的Issue

#5255 

### 修改描述

逻辑删除字段，未修改 com.baomidou.mybatisplus.generator.config.po.TableField#propertyName 导致的bug

### 测试用例



### 修复效果的截屏

1. 配置了logicDeleteColumnName 和logicDeletePropertyName

![全配置](https://user-images.githubusercontent.com/42528634/234529325-6c566bcb-e659-4b91-8ace-e4aaff1f42b8.png)

![全配置2](https://user-images.githubusercontent.com/42528634/234529386-f3f4d09e-5d3e-49ef-8d88-4c9bd1d7b24c.png)

2. 配置了logicDeleteColumnName

![只配置logicDeleteColumnName](https://user-images.githubusercontent.com/42528634/234529516-2adc9b3f-19a1-4812-b15b-9129da2d69b3.png)

![只配置logicDeleteColumnName2](https://user-images.githubusercontent.com/42528634/234529572-f1b9c970-fc6f-416d-8c9d-021bbb68bd88.png)

3.  配置了 logicDeletePropertyName

![只配置logicDeletePropertyName](https://user-images.githubusercontent.com/42528634/234529749-f025183b-3df7-4777-ad1f-a88ce1b828de.png)

![只配置logicDeletePropertyName2](https://user-images.githubusercontent.com/42528634/234529787-85892c34-55fd-4e6a-80a3-0a1ce17406e1.png)


