### PR TITLE
fix mapping for null value enum

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/handlers/MybatisEnumTypeHandler.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/handlers/MybatisEnumTypeHandler.java
@@ -116,7 +116,7 @@ public class MybatisEnumTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E
     @Override
     public E getNullableResult(ResultSet rs, String columnName) throws SQLException {
         Object value = rs.getObject(columnName, this.propertyType);
-        if (null == value && rs.wasNull()) {
+        if (null == value || rs.wasNull()) {
             return null;
         }
         return this.valueOf(value);
@@ -125,7 +125,7 @@ public class MybatisEnumTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E
     @Override
     public E getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
         Object value = rs.getObject(columnIndex, this.propertyType);
-        if (null == value && rs.wasNull()) {
+        if (null == value || rs.wasNull()) {
             return null;
         }
         return this.valueOf(value);
@@ -134,7 +134,7 @@ public class MybatisEnumTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E
     @Override
     public E getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
         Object value = cs.getObject(columnIndex, this.propertyType);
-        if (null == value && cs.wasNull()) {
+        if (null == value || cs.wasNull()) {
             return null;
         }
         return this.valueOf(value);

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/handlers/MybatisEnumTypeHandlerTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/handlers/MybatisEnumTypeHandlerTest.java
@@ -129,6 +129,13 @@ public class MybatisEnumTypeHandlerTest extends BaseTypeHandlerTest {
         assertNull(GRADE_ENUM_ENUM_TYPE_HANDLER.getResult(callableStatement, 6));
     }
 
+    @Test
+    public void testNullButReturnZero() throws Exception {
+        when(callableStatement.getObject(1, Integer.class)).thenReturn(0);
+        when(callableStatement.wasNull()).thenReturn(true);
+        assertNull(SEX_ENUM_ENUM_TYPE_HANDLER.getResult(callableStatement, 1));
+    }
+
     @Getter
     @AllArgsConstructor
     enum SexEnum implements IEnum<Integer> {


### PR DESCRIPTION
### 该Pull Request关联的Issue

fix #5266 

### 修改描述

mysql驱动在老版本中, 数据库中数据为null却返回0, 导致映射成0值的枚举. 在`MybatisEnumTypeHandler`的判断逻辑中修改只要wasNull是true就返回null

### 测试用例

com.baomidou.mybatisplus.test.handlers.MybatisEnumTypeHandlerTest#testNullButReturnZero

### 修复效果的截屏

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/20450037/235169099-b9cffb0d-1e68-4320-b129-a638d6b40afd.png">

