### PR TITLE
:sparkles: 分页插件-自定义count添加默认msid规则

### DIFF
--- a/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/MybatisPlusTestApplication.java
+++ b/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/MybatisPlusTestApplication.java
@@ -1,12 +1,24 @@
 package com.baomidou.mybatisplus.test.autoconfigure;
 
+import com.baomidou.mybatisplus.annotation.DbType;
+import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * @author miemie
  * @since 2020-05-27
  */
+@Configuration
 @SpringBootApplication
 public class MybatisPlusTestApplication {
-
+    @Bean
+    public MybatisPlusInterceptor mybatisPlusInterceptor() {
+        MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+        // 向MyBatis-Plus的过滤器链中添加分页拦截器，需要设置数据库类型（主要用于分页方言）
+        interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
+        return interceptor;
+    }
 }

--- a/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/PaginationTest.java
+++ b/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/PaginationTest.java
@@ -1,0 +1,57 @@
+package com.baomidou.mybatisplus.test.autoconfigure;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MybatisPlusTest
+public class PaginationTest {
+    @Autowired
+    private SampleMapper sampleMapper;
+    private Page<Sample> page = new Page<>(1, 3);
+
+    /**
+     * 手动配置的ount查询: sampleList_customCOUNT 方法
+     */
+    @Test
+    void customPage() {
+        // 使用
+        page.setCountId("sampleList_customCOUNT");
+        Page<Sample> samplePage = sampleMapper.sampleList(page,null);
+        // 总页数
+        assertThat(samplePage.getPages()).isEqualTo(4L);
+        // 总行数
+        assertThat(samplePage.getTotal()).isEqualTo(10L);
+
+    }
+
+    /**
+     * 默认的Count查询: sampleList_COUNT 方法
+     *
+     */
+    @Test
+    void rulePage(){
+        Page<Sample> samplePage = sampleMapper.sampleList(page,"A");
+        // 总页数
+        assertThat(samplePage.getPages()).isEqualTo(2L);
+        // 总行数
+        assertThat(samplePage.getTotal()).isEqualTo(5L);
+    }
+
+    @BeforeEach
+    public void beforeAll(){
+        for (int i = 1; i <= 10; i++) {
+            Sample sample;
+            if (i % 2  == 0){
+                sample = new Sample((long) i,"A");
+            }else {
+                sample = new Sample((long) i,"B");
+            }
+            sampleMapper.insert(sample);
+        }
+    }
+}

--- a/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/Sample.java
+++ b/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/Sample.java
@@ -1,12 +1,16 @@
 package com.baomidou.mybatisplus.test.autoconfigure;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * @author miemie
  * @since 2020-05-27
  */
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class Sample {
     private Long id;
     private String name;

--- a/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/SampleMapper.java
+++ b/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/SampleMapper.java
@@ -1,7 +1,12 @@
 package com.baomidou.mybatisplus.test.autoconfigure;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
 
 /**
  * @author miemie
@@ -9,4 +14,26 @@ import org.apache.ibatis.annotations.Mapper;
  */
 @Mapper
 public interface SampleMapper extends BaseMapper<Sample> {
+
+    @Select({
+        "<script>",
+        "SELECT count(*) from sample ",
+        "<where> <if test='name != null'> name = #{name}  </if> </where>",
+        "</script>"})
+    Long sampleList_customCOUNT(@Param("name") String name);
+
+    @Select({
+        "<script>",
+            "SELECT count(*) from sample ",
+            "<where> <if test='name != null'> name = #{name}  </if> </where>",
+        "</script>"})
+    Long sampleList_COUNT(@Param("name") String name);
+
+
+    @Select({
+        "<script>",
+            "SELECT * from sample ",
+            "<where> <if test='name != null'> name = #{name}  </if> </where>",
+        "</script>"})
+    Page<Sample> sampleList(Page<Sample> page, @Param("name") String name);
 }


### PR DESCRIPTION
### 修改描述
分页插件如果想自定义配置 count 查询，需要手动设置自定义查询的 countId
```java
Page<Sample> page = new Page<>(1, 3);
// 自定义Count 方法
page.setCountId("sampleList_customCOUNT");
// 分页查询
sampleMapper.sampleList(page,"A");
```

**这种方式需要手动填写mapp接口内的方法名，而且是字符串类型的，会有写错或者接口名变更 countId未变更的问题。**

---



改变后：**约定大于配置**

既可以使用之前设置 countId的方式，也可以直接在 mapper 中添加 `msId + “_COUNT” ` 的接口

```java
// 自定义的 count 查询方法
// 统一的 msid + _COUNT 后缀
Long sampleList_COUNT(@Param("name") String name);
// 分页的 mapper接口方法
Page<Sample> sampleList(Page<Sample> page, @Param("name") String name);


//-----------

Page<Sample> page = new Page<>(1, 3);
// 分页查询
// 1. 如果设置了 countId 直接使用
// 2. 如果编写了 msId + COUNT 接口的方法，直接使用
// 3. 都没有使用 autoCountSql 方法生成
sampleMapper.sampleList(page,"A");

```

### 测试用例

详细见pr 中的 PaginationTest 文件
