### PR TITLE
fix: 优化Wrapper类中boolean方法的名称，解决OGNL解析中method缓存问题

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/Wrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/Wrapper.java
@@ -98,7 +98,7 @@ public abstract class Wrapper<T> implements ISqlSegment {
     /**
      * 查询条件不为空(包含entity)
      */
-    public boolean nonEmptyOfWhere() {
+    public boolean isNonEmptyOfWhere() {
         return !isEmptyOfWhere();
     }
 
@@ -112,7 +112,7 @@ public abstract class Wrapper<T> implements ISqlSegment {
     /**
      * 查询条件为空(不包含entity)
      */
-    public boolean nonEmptyOfNormal() {
+    public boolean isNonEmptyOfNormal() {
         return !isEmptyOfNormal();
     }
 
@@ -121,7 +121,7 @@ public abstract class Wrapper<T> implements ISqlSegment {
      *
      * @return true 不为空
      */
-    public boolean nonEmptyOfEntity() {
+    public boolean isNonEmptyOfEntity() {
         T entity = getEntity();
         if (entity == null) {
             return false;
@@ -160,7 +160,7 @@ public abstract class Wrapper<T> implements ISqlSegment {
      * @return true 为空
      */
     public boolean isEmptyOfEntity() {
-        return !nonEmptyOfEntity();
+        return !isNonEmptyOfEntity();
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Wrappers.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Wrappers.java
@@ -211,7 +211,7 @@ public final class Wrappers {
         }
 
         @Override
-        public boolean nonEmptyOfEntity() {
+        public boolean isNonEmptyOfEntity() {
             return !isEmptyOfEntity();
         }
 


### PR DESCRIPTION
### 该Pull Request关联的Issue
#5379 


### 修改描述
修改boolean方法名称为is开头，使能被`org.apache.ibatis.ognl.getGetMethod(OgnlContext context, Class targetClass, String propertyName)`正确获取到method，从而正常缓存。

### 修复效果的截屏
![image](https://github.com/baomidou/mybatis-plus/assets/30257242/4e4fcd55-3554-459b-94e3-ac66df8e87eb)


