### PR TITLE
解决错误匹配注释字符串/*的bug，之前提交的转义符号被github吞了

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlInjectionUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlInjectionUtils.java
@@ -33,7 +33,7 @@ public class SqlInjectionUtils {
     /**
      * 使用'、;或注释截断SQL检查正则
      */
-    private static final Pattern SQL_COMMENT_PATTERN = Pattern.compile("'.*(or|union|--|#|\/\*|;)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SQL_COMMENT_PATTERN = Pattern.compile("'.*(or|union|--|#|\\/\\*|;)", Pattern.CASE_INSENSITIVE);
 
     /**
      * 检查参数是否存在 SQL 注入

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlInjectionUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlInjectionUtils.java
@@ -33,7 +33,7 @@ public class SqlInjectionUtils {
     /**
      * 使用'、;或注释截断SQL检查正则
      */
-    private static final Pattern SQL_COMMENT_PATTERN = Pattern.compile("'.*(or|union|--|#|/*|;)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SQL_COMMENT_PATTERN = Pattern.compile("'.*(or|union|--|#|\/\*|;)", Pattern.CASE_INSENSITIVE);
 
     /**
      * 检查参数是否存在 SQL 注入


### PR DESCRIPTION
### 该Pull Request关联的Issue
https://github.com/baomidou/mybatis-plus/issues/5424 order by field 自定义排序中的列举值的单引号被错误的移除了

### 修改描述
根本原因是SqlInjectionUtils 错误地判断了order by的字符串有sql注释字符/*。
解决方法：修改正则表达式，添加转义符号

### 测试用例
field(status,'SUCCESS','FAILED','CLOSED') 字符串用之前的正则可以匹配中，期望应该匹配不中，现在已修复

### 修复效果的截屏
field(status,'SUCCESS','FAILED','CLOSED') 字符串用之前的正则可以匹配中，期望应该匹配不中，现在已修复


