### PR TITLE
解决错误匹配注释字符串/*的问题，同时解决无法匹配insert省略into关键字的sql注入校验。添加了一些检验sql注入测试语句。

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlInjectionUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlInjectionUtils.java
@@ -29,11 +29,11 @@ public class SqlInjectionUtils {
      * SQL语法检查正则：符合两个关键字（有先后顺序）才算匹配
      */
     private static final Pattern SQL_SYNTAX_PATTERN = Pattern.compile("(insert|delete|update|select|create|drop|truncate|grant|alter|deny|revoke|call|execute|exec|declare|show|rename|set)" +
-        "\\s+.*(into|from|set|where|table|database|view|index|on|cursor|procedure|trigger|for|password|union|and|or)|(select\\s*\\*\\s*from\\s+)", Pattern.CASE_INSENSITIVE);
+        "\\s+.*(into|from|set|where|table|database|view|index|on|cursor|procedure|trigger|for|password|union|and|or|value|values)|(select\\s*\\*\\s*from\\s+)|(and|or)\\s+.*(like|=|>|<|in|between|is|not|exists)", Pattern.CASE_INSENSITIVE);
     /**
      * 使用'、;或注释截断SQL检查正则
      */
-    private static final Pattern SQL_COMMENT_PATTERN = Pattern.compile("'.*(or|union|--|#|/*|;)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SQL_COMMENT_PATTERN = Pattern.compile("'.*(or|union|--|#|/\\*|;)", Pattern.CASE_INSENSITIVE);
 
     /**
      * 检查参数是否存在 SQL 注入

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlInjectionUtilsTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlInjectionUtilsTest.java
@@ -40,6 +40,18 @@ public class SqlInjectionUtilsTest {
         assertSql(false, "SELECT*FROMuser");
         // 该字符串里包含 setT or
         assertSql(false, "databaseType desc,orderNum desc)");
+
+        assertSql(false, "insert");
+        assertSql(true, "insert user (id,age) values (1, 18)");
+        assertSql(false, "union");
+        assertSql(false, "or");
+        assertSql(false, "delete");
+        assertSql(false, "drop");
+        assertSql(true, "and age not in (1,2,3)");
+        assertSql(true, "and age <> 1");
+        assertSql(false,"ORDER BY field(status,'SUCCESS','FAILED','CLOSED')");
+        assertSql(true,"ORDER BY id,'SUCCESS',''-- FAILED','CLOSED'");
+        assertSql(true, "or 1 = 1");
     }
 
     private void assertSql(boolean injection, String sql) {

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/type/TypeRegistry.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/type/TypeRegistry.java
@@ -44,7 +44,7 @@ public class TypeRegistry {
         typeMap.put(Types.LONGVARBINARY, DbColumnType.BYTE_ARRAY);
         typeMap.put(Types.VARBINARY, DbColumnType.BYTE_ARRAY);
         //byte
-        typeMap.put(Types.TINYINT, DbColumnType.BYTE);
+        typeMap.put(Types.TINYINT, DbColumnType.INTEGER);
         //long
         typeMap.put(Types.BIGINT, DbColumnType.LONG);
         //boolean


### PR DESCRIPTION
### 该Pull Request关联的Issue
#5424 order by field 自定义排序中的列举值的单引号被错误的移除了


### 修改描述
根本原因是SqlInjectionUtils 错误地判断了order by的字符串有sql注释字符/*。
解决方法：修改正则表达式，添加转义符号

同时修改了原有的正则无法匹配insert语句省略into关键字的sql注入，添加了相关测试用例
原有的正则无法匹配如下的几种sql注入语句：
        assertSql(true, "insert user (id,age) values (1, 18)");
        assertSql(true, "and age not in (1,2,3)");
        assertSql(true, "and age <> 1");
        assertSql(false,"ORDER BY field(status,'SUCCESS','FAILED','CLOSED')");
        assertSql(true, "or 1 = 1");

### 测试用例
com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtilsTest


### 修复效果的截屏
![image](https://github.com/baomidou/mybatis-plus/assets/15938656/c57fc0d6-321d-41f8-8214-25cdbb4d205b)


