### PR TITLE
数据库tinyint类型转为java Integer类型，与OscarTypeConvert中保持一致

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/type/TypeRegistry.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/type/TypeRegistry.java
@@ -44,7 +44,7 @@ public class TypeRegistry {
         typeMap.put(Types.LONGVARBINARY, DbColumnType.BYTE_ARRAY);
         typeMap.put(Types.VARBINARY, DbColumnType.BYTE_ARRAY);
         //byte
-        typeMap.put(Types.TINYINT, DbColumnType.BYTE);
+        typeMap.put(Types.TINYINT, DbColumnType.INTEGER);
         //long
         typeMap.put(Types.BIGINT, DbColumnType.LONG);
         //boolean


### PR DESCRIPTION
### 该Pull Request关联的Issue
#5432 代码生成器 .enableRemoveIsPrefix() // 开启 Boolean 类型字段移除 is 前缀 无效！


### 修改描述
解决方案：设置数据库字段类型为tinyint(1)即可
根本原因：mybatis-plus-generator底层是通过ResultSet获取mysql字段信息的，tinyint(1)类型的字段默认会当成bit(1)类型处理，而bit(1)类型就会转成Boolean类型，只要是Boolean 类型，字段就会移除 is 前缀

其它修改：将原有的tinyint类型转换为java Byte类型  改成 Integer类型，与OscarTypeConvert保持一致

### 测试用例
无


### 修复效果的截屏
![image](https://github.com/baomidou/mybatis-plus/assets/15938656/747e96bc-7d9c-41d9-af85-c0b1e37f516c)


