### PR TITLE
ActiveRecord模式下逻辑删除,deleteById方法支持自动填充功能

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/activerecord/Model.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/activerecord/Model.java
@@ -87,7 +87,13 @@ public abstract class Model<T extends Model<?>> implements Serializable {
      */
     public boolean deleteById() {
         Assert.isFalse(StringUtils.checkValNull(pkVal()), "deleteById primaryKey is null.");
-        return deleteById(pkVal());
+
+        SqlSession sqlSession = sqlSession();
+        try {
+            return SqlHelper.retBool(sqlSession.delete(sqlStatement(SqlMethod.DELETE_BY_ID), this));
+        } finally {
+            closeSqlSession(sqlSession);
+        }
     }
 
     /**


### PR DESCRIPTION
### 修改描述
自动填充是针对实体对象的,现有的版本已经解决了BaseMapper接口中deleteById方法在逻辑删除的情况下, 自动填充功能失效的问题
int deleteById(Serializable id);  传入的是id, 不会进行填充
int deleteById(T entity);            传入的是et, 逻辑删除情况下会进行自动填充

但是ActiveRecord模式的Model类中的deleteById()方法却依然不会自动填充
修改Model类的deleteById(), 内部调用当前this对象使其在逻辑删除的情况下可以自动填充
修改后的逻辑在使用的直觉上与mapper提供的deleteById方法也更契合

### 测试用例
![image](https://github.com/baomidou/mybatis-plus/assets/68154292/62ef05d4-60c2-4997-b0a1-cc17bef16d88)

### 修复效果的截屏
![image](https://github.com/baomidou/mybatis-plus/assets/68154292/a013d3c0-31b5-4a73-bfe5-e5b0de66078c)


