### PR TITLE
修正并补充注释

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
@@ -76,8 +76,8 @@ public interface Func<Children, R> extends Serializable {
      * 字段 IN (value.get(0), value.get(1), ...)
      * <p>例: in("id", Arrays.asList(1, 2, 3, 4, 5))</p>
      *
-     * <li> 注意！集合为空若存在逻辑错误，请在 condition 条件中判断 </li>
-     * <li> 如果集合为 empty 则不会进行 sql 拼接 </li>
+     * <li> 注意！当集合为 空或null 时, sql会拼接为：WHERE (字段名 IN ()), 执行时报错</li>
+     * <li> 若要在特定条件下不拼接, 可在 condition 条件中判断 </li>
      *
      * @param condition 执行条件
      * @param column    字段
@@ -97,8 +97,8 @@ public interface Func<Children, R> extends Serializable {
      * 字段 IN (v0, v1, ...)
      * <p>例: in("id", 1, 2, 3, 4, 5)</p>
      *
-     * <li> 注意！数组为空若存在逻辑错误，请在 condition 条件中判断 </li>
-     * <li> 如果动态数组为 empty 则不会进行 sql 拼接 </li>
+     * <li> 注意！当数组为 空 时, sql会拼接为：WHERE (字段名 IN ()), 执行时报错</li>
+     * <li> 若要在特定条件下不拼接, 可在 condition 条件中判断 </li>
      *
      * @param condition 执行条件
      * @param column    字段


### PR DESCRIPTION
### 修改描述
Wrapper 接口中, in条件的拼接逻辑在历史版本中修改过, 但是注释未修改. 因此修正并补充注释 


### 测试用例
空数组
![DD{}$}5J{OU2XPPL}~`7R(5](https://github.com/baomidou/mybatis-plus/assets/68154292/5624795f-506f-41cc-b68f-7f32806e5954)

空集合
![}8NJ) (OV58IJLED_J CIX7](https://github.com/baomidou/mybatis-plus/assets/68154292/62f81f41-0cbb-4126-b55a-ff831344ebae)

集合为null
![(6~X@{G)4~E@DUK`KF50SPW](https://github.com/baomidou/mybatis-plus/assets/68154292/57ee50c8-5a61-4034-93c7-887536596deb)





