### PR TITLE
修正并补充注释

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
@@ -76,8 +76,8 @@ public interface Func<Children, R> extends Serializable {
      * 字段 IN (value.get(0), value.get(1), ...)
      * <p>例: in("id", Arrays.asList(1, 2, 3, 4, 5))</p>
      *
-     * <li> 注意！集合为空若存在逻辑错误，请在 condition 条件中判断 </li>
-     * <li> 如果集合为 empty 则不会进行 sql 拼接 </li>
+     * <li> 注意！当集合为 空或null 时, sql会拼接为：WHERE (字段名 IN ()), 执行时报错</li>
+     * <li> 若要在特定条件下不拼接, 可在 condition 条件中判断 </li>
      *
      * @param condition 执行条件
      * @param column    字段
@@ -97,8 +97,8 @@ public interface Func<Children, R> extends Serializable {
      * 字段 IN (v0, v1, ...)
      * <p>例: in("id", 1, 2, 3, 4, 5)</p>
      *
-     * <li> 注意！数组为空若存在逻辑错误，请在 condition 条件中判断 </li>
-     * <li> 如果动态数组为 empty 则不会进行 sql 拼接 </li>
+     * <li> 注意！当数组为 空或null 时, sql会拼接为：WHERE (字段名 IN ()), 执行时报错</li>
+     * <li> 若要在特定条件下不拼接, 可在 condition 条件中判断 </li>
      *
      * @param condition 执行条件
      * @param column    字段
@@ -118,6 +118,9 @@ public interface Func<Children, R> extends Serializable {
      * 字段 NOT IN (value.get(0), value.get(1), ...)
      * <p>例: notIn("id", Arrays.asList(1, 2, 3, 4, 5))</p>
      *
+     * <li> 注意！当集合为 空或null 时, sql会拼接为：WHERE (字段名 NOT IN ()), 执行时报错</li>
+     * <li> 若要在特定条件下不拼接, 可在 condition 条件中判断 </li>
+     *
      * @param condition 执行条件
      * @param column    字段
      * @param coll      数据集合
@@ -135,6 +138,9 @@ public interface Func<Children, R> extends Serializable {
     /**
      * 字段 NOT IN (v0, v1, ...)
      * <p>例: notIn("id", 1, 2, 3, 4, 5)</p>
+     *
+     * <li> 注意！当数组为 空或null 时, sql会拼接为：WHERE (字段名 NOT IN ()), 执行时报错</li>
+     * <li> 若要在特定条件下不拼接, 可在 condition 条件中判断 </li>
      *
      * @param condition 执行条件
      * @param column    字段


### PR DESCRIPTION
### 修改描述
Wrapper 接口中, in及notIn条件的拼接逻辑在历史版本中修改过, 但是注释未修改. 因此修正并补充注释, 以下单元测试用于佐证注释的正确性

### 测试用例
**空数组**
**in()**
![DD{}$}5J{OU2XPPL}~`7R(5](https://github.com/baomidou/mybatis-plus/assets/68154292/de107f7c-e87c-433b-a252-dccc623dcdf8)
**notIn()**
![Y{KTGE(2@AVKKO@1% U8M7H](https://github.com/baomidou/mybatis-plus/assets/68154292/72195fce-a1c6-4a82-8c9c-15fc376d0c6a)

**数组为null**
**in()**
![6$9%FMX(NT1Q)IMJQSA${XJ](https://github.com/baomidou/mybatis-plus/assets/68154292/0999d8fe-eccb-4629-ad9d-1bb0292fb3b0)
**notIn()**
![DRXZW@{K@B4PLI NBP8C)8J](https://github.com/baomidou/mybatis-plus/assets/68154292/565f4fa8-09cc-4785-8470-00a11d2ae847)

**空集合**
**in()**
![}8NJ) (OV58IJLED_J CIX7](https://github.com/baomidou/mybatis-plus/assets/68154292/f587c844-49c9-4efb-87c5-f09be3d33e35)
**notIn()**
![H68ZHE 1PCC`VPJ%%S{2KKY](https://github.com/baomidou/mybatis-plus/assets/68154292/16ce313b-3d06-4627-94d0-e5ba28fdbf3e)

**集合为null**
**in()**
![(6~X@{G)4~E@DUK`KF50SPW](https://github.com/baomidou/mybatis-plus/assets/68154292/2bf383a9-6c1d-4bda-b6b5-bb87ebb68eb6)
**notIn()**
![25BO2P0}72Z0XP5E8NL@D R](https://github.com/baomidou/mybatis-plus/assets/68154292/02717461-ebf1-47aa-a87e-0a96a44721b2)



