### PR TITLE
BaseMultiTableInnerInterceptor【数据权限】 处理left join时，遇到join的表只会拼接到 on条件并不会拼接到where条件后 #5797

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BaseMultiTableInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BaseMultiTableInnerInterceptor.java
@@ -106,6 +106,12 @@ public abstract class BaseMultiTableInnerInterceptor extends JsqlParserSupport i
         List<Join> joins = plainSelect.getJoins();
         if (CollectionUtils.isNotEmpty(joins)) {
             mainTables = processJoins(mainTables, joins, whereSegment);
+            for (Join join : joins) {
+                FromItem rightItem = join.getRightItem();
+                if(rightItem instanceof Table){
+                    mainTables.add((Table) rightItem);
+                }
+            }
         }
 
         // 当有 mainTable 时，进行 where 条件追加

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/MultiDataPermissionInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/MultiDataPermissionInterceptorTest.java
@@ -105,7 +105,7 @@ public class MultiDataPermissionInterceptorTest {
     void test6() {
         // 显式指定 JOIN 类型时 JOIN 右侧表才能进行拼接条件
         assertSql(TEST_6, "select u.username from sys_user u LEFT join sys_user_role r on u.id=r.user_id",
-            "SELECT u.username FROM sys_user u LEFT JOIN sys_user_role r ON u.id = r.user_id AND r.role_id = 3 AND r.role_id IN (7, 9, 11) WHERE u.state = 1 AND u.amount > 1000");
+            "SELECT u.username FROM sys_user u LEFT JOIN sys_user_role r ON u.id = r.user_id AND r.role_id = 3 AND r.role_id IN (7, 9, 11) WHERE u.state = 1 AND u.amount > 1000 AND r.role_id = 3 AND r.role_id IN (7, 9, 11)");
     }
 
     @Test

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/MultiDataPermissionInterceptorTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/extension/plugins/inner/MultiDataPermissionInterceptorTest.java
@@ -111,7 +111,7 @@ public class MultiDataPermissionInterceptorTest {
     @Test
     void test7() {
         assertSql(TEST_7, "SELECT c.doc AS title, sum(c.total_paid_amount) AS total_paid_amount, sum(c.balance_amount) AS balance_amount FROM (SELECT `a`.`id`, `a`.`doc`, `b`.`month`, `b`.`total_paid_amount`, `b`.`balance_amount`, row_number() OVER (PARTITION BY `a`.`id` ORDER BY `b`.`month` DESC) AS `row_index` FROM `fund` `a` LEFT JOIN `fund_month` `b` ON `a`.`id` = `b`.`fund_id` AND `b`.`submit` = TRUE) c WHERE c.row_index = 1 GROUP BY title LIMIT 20",
-            "SELECT c.doc AS title, sum(c.total_paid_amount) AS total_paid_amount, sum(c.balance_amount) AS balance_amount FROM (SELECT `a`.`id`, `a`.`doc`, `b`.`month`, `b`.`total_paid_amount`, `b`.`balance_amount`, row_number() OVER (PARTITION BY `a`.`id` ORDER BY `b`.`month` DESC) AS `row_index` FROM `fund` `a` LEFT JOIN `fund_month` `b` ON `a`.`id` = `b`.`fund_id` AND `b`.`submit` = TRUE AND b.fund_id = 2 AND b.month <= '2022-05' WHERE a.id = 1 AND a.year = 2022 AND a.create_user_id = 1111) c WHERE c.row_index = 1 GROUP BY title LIMIT 20");
+            "SELECT c.doc AS title, sum(c.total_paid_amount) AS total_paid_amount, sum(c.balance_amount) AS balance_amount FROM (SELECT `a`.`id`, `a`.`doc`, `b`.`month`, `b`.`total_paid_amount`, `b`.`balance_amount`, row_number() OVER (PARTITION BY `a`.`id` ORDER BY `b`.`month` DESC) AS `row_index` FROM `fund` `a` LEFT JOIN `fund_month` `b` ON `a`.`id` = `b`.`fund_id` AND `b`.`submit` = TRUE AND b.fund_id = 2 AND b.month <= '2022-05' WHERE a.id = 1 AND a.year = 2022 AND a.create_user_id = 1111 AND b.fund_id = 2 AND b.month <= '2022-05') c WHERE c.row_index = 1 GROUP BY title LIMIT 20");
     }
 
     void assertSql(String mappedStatementId, String sql, String targetSql) {


### PR DESCRIPTION
### 该Pull Request关联的Issue
https://github.com/baomidou/mybatis-plus/issues/5797


### 修改描述
BaseMultiTableInnerInterceptor【数据权限】 处理left join时，遇到join的表只会拼接到 on条件并不会拼接到where条件后 #5797


### 测试用例
```java
   sqlSegmentMap.put(TEST_6, "sys_user", "u.state=1 and u.amount > 1000");
        sqlSegmentMap.put(TEST_6, "sys_user_role", "r.role_id=3 AND r.role_id IN (7,9,11)");

  assertSql(TEST_6, "select u.username from sys_user u LEFT join sys_user_role r on u.id=r.user_id",
            "SELECT u.username FROM sys_user u LEFT JOIN sys_user_role r ON u.id = r.user_id AND r.role_id = 3 AND r.role_id IN (7, 9, 11) WHERE u.state = 1 AND u.amount > 1000 AND r.role_id = 3 AND r.role_id IN (7, 9, 11)");
```
详细请看MultiDataPermissionInterceptorTest#test6


### 修复效果的截屏


