### PR TITLE
fix: 修改lambdaUpdate().remove()更新时自动填充失效问题

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
@@ -35,6 +35,7 @@ public enum SqlMethod {
     @Deprecated
     DELETE_BY_MAP("deleteByMap", "根据columnMap 条件删除记录", "<script>\nDELETE FROM %s %s\n</script>"),
     DELETE("delete", "根据 entity 条件删除记录", "<script>\nDELETE FROM %s %s %s\n</script>"),
+    DELETE_BATCH("deleteBatch", "根据条件删除记录", "<script>\nDELETE FROM %s %s %s\n</script>"),
     DELETE_BATCH_BY_IDS("deleteBatchIds", "根据ID集合，批量删除数据", "<script>\nDELETE FROM %s WHERE %s IN (%s)\n</script>"),
 
     /**
@@ -43,6 +44,7 @@ public enum SqlMethod {
     LOGIC_DELETE_BY_ID("deleteById", "根据ID 逻辑删除一条数据", "<script>\nUPDATE %s %s WHERE %s=#{%s} %s\n</script>"),
     LOGIC_DELETE_BY_MAP("deleteByMap", "根据columnMap 条件逻辑删除记录", "<script>\nUPDATE %s %s %s\n</script>"),
     LOGIC_DELETE("delete", "根据 entity 条件逻辑删除记录", "<script>\nUPDATE %s %s %s %s\n</script>"),
+    LOGIC_DELETE_BATCH("deleteBatch", "根据条件逻辑删除记录", "<script>\nUPDATE %s %s %s %s\n</script>"),
     LOGIC_DELETE_BATCH_BY_IDS("deleteBatchIds", "根据ID集合，批量逻辑删除数据", "<script>\nUPDATE %s %s WHERE %s IN (%s) %s\n</script>"),
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
@@ -22,6 +22,7 @@ import com.baomidou.mybatisplus.core.toolkit.Assert;
 import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 import com.baomidou.mybatisplus.core.toolkit.Constants;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.core.toolkit.sql.SqlScriptUtils;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.apache.ibatis.builder.SqlSourceBuilder;
@@ -105,6 +106,20 @@ public abstract class AbstractMethod implements Constants {
      */
     protected String sqlLogicSet(TableInfo table) {
         return "SET " + table.getLogicDeleteSql(false, false);
+    }
+
+    /**
+     * SQL 更新 set 语句
+     *
+     * @param table 表信息
+     * @param prefix 前缀
+     * @return sql set 片段
+     */
+    protected String sqlLogicAndFillSet(TableInfo table, String prefix) {
+        String setSql = "SET ";
+        String updateFillSql = table.getUpdateFillSqlSet(true, prefix);
+        String sql = table.getLogicDeleteSql(false, false);
+        return StringUtils.isEmpty(updateFillSql) ? setSql + sql : setSql + updateFillSql + sql;
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/DefaultSqlInjector.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/DefaultSqlInjector.java
@@ -37,6 +37,7 @@ public class DefaultSqlInjector extends AbstractSqlInjector {
         Stream.Builder<AbstractMethod> builder = Stream.<AbstractMethod>builder()
             .add(new Insert())
             .add(new Delete())
+            .add(new DeleteBatch())
             .add(new Update())
             .add(new SelectCount())
             .add(new SelectMaps())

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/DeleteBatch.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/DeleteBatch.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011-2023, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.injector.methods;
+
+import com.baomidou.mybatisplus.core.enums.SqlMethod;
+import com.baomidou.mybatisplus.core.injector.AbstractMethod;
+import com.baomidou.mybatisplus.core.metadata.TableInfo;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.SqlSource;
+
+/**
+ * 根据条件删除记录
+ *
+ * @author yuge
+ * @since 2023-11-24
+ */
+public class DeleteBatch extends AbstractMethod {
+
+    public DeleteBatch() {
+        this(SqlMethod.DELETE_BATCH.getMethod());
+    }
+
+    /**
+     * @param name 方法名
+     * @since 3.5.0
+     */
+    public DeleteBatch(String name) {
+        super(name);
+    }
+
+    @Override
+    public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
+        String sql;
+        SqlMethod sqlMethod = SqlMethod.LOGIC_DELETE_BATCH;
+        if (tableInfo.isWithLogicDelete()) {
+            sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(), sqlLogicAndFillSet(tableInfo, ENTITY_DOT),
+                sqlWhereEntityWrapper(true, tableInfo),
+                sqlComment());
+            SqlSource sqlSource = super.createSqlSource(configuration, sql, modelClass);
+            return addUpdateMappedStatement(mapperClass, modelClass, methodName, sqlSource);
+        } else {
+            sqlMethod = SqlMethod.DELETE_BATCH;
+            sql = String.format(sqlMethod.getSql(), tableInfo.getTableName(),
+                sqlWhereEntityWrapper(true, tableInfo),
+                sqlComment());
+            SqlSource sqlSource = super.createSqlSource(configuration, sql, modelClass);
+            return this.addDeleteMappedStatement(mapperClass, methodName, sqlSource);
+        }
+    }
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
@@ -129,6 +129,14 @@ public interface BaseMapper<T> extends Mapper<T> {
     int delete(@Param(Constants.WRAPPER) Wrapper<T> queryWrapper);
 
     /**
+     * 根据条件，删除记录
+     *
+     * @param entity       实体对象 (set 条件值,可以为 null, 支持逻辑删除时update fill)
+     * @param queryWrapper 实体对象封装操作类（可以为 null,里面的 entity 用于生成 where 语句）
+     */
+    int deleteBatch(@Param(Constants.ENTITY) T entity, @Param(Constants.WRAPPER) Wrapper<T> queryWrapper);
+
+    /**
      * 删除（根据ID或实体 批量删除）
      *
      * @param idList 主键ID列表或实体列表(不能为 null 以及 empty)

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
@@ -428,6 +428,26 @@ public class TableInfo implements Constants {
     }
 
     /**
+     * 获取更新填充字段的 sql set 片段
+     *
+     * @param ignoreLogicDelFiled 是否过滤掉逻辑删除字段
+     * @param prefix              前缀
+     * @return sql 脚本片段
+     */
+    public String getUpdateFillSqlSet(boolean ignoreLogicDelFiled, final String prefix) {
+        final String newPrefix = prefix == null ? EMPTY : prefix;
+        return fieldList.stream()
+            .filter(i -> {
+                if (ignoreLogicDelFiled) {
+                    return !(isWithLogicDelete() && i.isLogicDelete());
+                }
+                return true;
+            })
+            .filter(i -> i.isWithUpdateFill())
+            .map(i -> i.getSqlSet(newPrefix)).filter(Objects::nonNull).collect(joining(NEWLINE));
+    }
+
+    /**
      * 获取逻辑删除字段的 sql 脚本
      *
      * @param startWithAnd 是否以 and 开头

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/update/ChainUpdate.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/update/ChainUpdate.java
@@ -15,6 +15,7 @@
  */
 package com.baomidou.mybatisplus.extension.conditions.update;
 
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.extension.conditions.ChainWrapper;
 import com.baomidou.mybatisplus.extension.toolkit.SqlHelper;
 
@@ -51,6 +52,17 @@ public interface ChainUpdate<T> extends ChainWrapper<T> {
      * @return 是否成功
      */
     default boolean remove() {
-        return execute(mapper -> SqlHelper.retBool(mapper.delete(getWrapper())));
+        Class<T> entityClass = getEntityClass();
+        if (entityClass == null) {
+            return execute(mapper -> SqlHelper.retBool(mapper.delete(getWrapper())));
+        } else {
+            T entity = null;
+            try {
+                entity = TableInfoHelper.getTableInfo(entityClass).newInstance();
+            } catch (Exception e) {
+            }
+            T finalEntity = entity;
+            return execute(mapper -> SqlHelper.retBool(mapper.deleteBatch(finalEntity, getWrapper())));
+        }
     }
 }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/IService.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/IService.java
@@ -652,7 +652,7 @@ public interface IService<T> {
      * @return LambdaUpdateWrapper 的包装类
      */
     default LambdaUpdateChainWrapper<T> lambdaUpdate() {
-        return ChainWrappers.lambdaUpdateChain(getBaseMapper());
+        return ChainWrappers.lambdaUpdateChain(getEntityClass());
     }
 
     /**

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserMapperTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserMapperTest.java
@@ -408,6 +408,24 @@ class H2UserMapperTest extends BaseTest {
     }
 
     @Test
+    void deleteBatch() {
+        userMapper.insert(new H2User().setAge(AgeEnum.ONE));
+        userMapper.insert(new H2User().setAge(AgeEnum.TWO));
+        Long beforeCount1 = userMapper.selectCount(new QueryWrapper<>(H2User.class).eq("age", AgeEnum.ONE));
+        Long beforeCount2 = userMapper.selectCount(new QueryWrapper<>(H2User.class).eq("age", AgeEnum.TWO));
+        Assertions.assertTrue(beforeCount1.intValue() > 0);
+        Assertions.assertTrue(beforeCount2.intValue() > 0);
+        userMapper.deleteBatch(null,
+            new QueryWrapper<>(H2User.class).eq("age", AgeEnum.ONE));
+        userMapper.deleteBatch(new H2User(),
+            new QueryWrapper<>(H2User.class).eq("age", AgeEnum.TWO));
+        Long afterCount1 = userMapper.selectCount(new QueryWrapper<>(H2User.class).eq("age", AgeEnum.ONE));
+        Long afterCount2 = userMapper.selectCount(new QueryWrapper<>(H2User.class).eq("age", AgeEnum.TWO));
+        Assertions.assertTrue(afterCount1.intValue() == 0);
+        Assertions.assertTrue(afterCount2.intValue() == 0);
+    }
+
+    @Test
     @Order(Integer.MAX_VALUE)
     void sqlCommentTest() {
         userMapper.delete(new QueryWrapper<H2User>().comment("deleteAllUsers"));

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
@@ -656,6 +656,17 @@ class H2UserTest extends BaseTest {
     }
 
     @Test
+    void testLamdaDeleteByFill() {
+        H2User user = new H2User("yuge", AgeEnum.TWO);
+        userService.save(user);
+        Long beforeCount = userService.count(userService.lambdaQuery().eq(H2User::getName, "yuge").getWrapper());
+        Assertions.assertTrue(beforeCount.intValue() > 0);
+        userService.lambdaUpdate().eq(H2User::getName, "yuge").remove();
+        Long afterCount = userService.count(userService.lambdaQuery().eq(H2User::getName, "yuge").getWrapper());
+        Assertions.assertTrue(afterCount.intValue() == 0);
+    }
+
+    @Test
     @Order(25)
     void testServiceImplInnerLambdaQueryConstructorSetEntity() {
         H2User condition = new H2User();


### PR DESCRIPTION
### 该Pull Request关联的Issue
https://github.com/baomidou/mybatis-plus/issues/5785


### 修改描述
使用lambdaUpdate().remove()时，自动填充失效；
BaseMapper增加deleteBatch方法，带实体类对象entity参数；
![image](https://github.com/baomidou/mybatis-plus/assets/45219837/1edb9da9-69e8-49e3-833c-0765b443e218)
remove时，判断entityClass是否存在，存在则创建空对象，调用deleteBatch方法；
![image](https://github.com/baomidou/mybatis-plus/assets/45219837/abc23156-60be-4d58-8e2a-3e3e8e53a805)


### 测试用例
![image](https://github.com/baomidou/mybatis-plus/assets/45219837/5730de07-0b45-41c2-b1a3-09405eba0068)
![image](https://github.com/baomidou/mybatis-plus/assets/45219837/c47253d1-d68e-434f-b208-4abfacf3a55b)



### 修复效果的截屏
![image](https://github.com/baomidou/mybatis-plus/assets/45219837/0473b06d-43a4-434a-b96b-9a0c77f3cdf6)
![image](https://github.com/baomidou/mybatis-plus/assets/45219837/eee66442-e0f3-4345-840d-0055aa9235ca)


