### PR TITLE
修复因 https://github.com/baomidou/mybatis-plus/issues/5454 的提交引起的使用 set 更新时，数据库实体类的字段没法使用 val 修饰，也没法使用基类

### DIFF
--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/AbstractKtWrapper.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/AbstractKtWrapper.kt
@@ -20,7 +20,7 @@ import com.baomidou.mybatisplus.core.toolkit.LambdaUtils
 import com.baomidou.mybatisplus.core.toolkit.StringPool
 import com.baomidou.mybatisplus.core.toolkit.support.ColumnCache
 import java.util.stream.Collectors.joining
-import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.KProperty1
 
 /**
  * Lambda 语法使用 Wrapper
@@ -31,7 +31,7 @@ import kotlin.reflect.KMutableProperty1
  * @since 2018-11-07
  */
 @Suppress("serial")
-abstract class AbstractKtWrapper<T, Children : AbstractKtWrapper<T, Children>> : AbstractWrapper<T, KMutableProperty1<T, *>, Children>() {
+abstract class AbstractKtWrapper<T, Children : AbstractKtWrapper<T, Children>> : AbstractWrapper<T, KProperty1<in T, *>, Children>() {
 
     /**
      * 列 Map
@@ -41,12 +41,12 @@ abstract class AbstractKtWrapper<T, Children : AbstractKtWrapper<T, Children>> :
     /**
      * 重载方法，默认 onlyColumn = true
      */
-    override fun columnToString(kProperty: KMutableProperty1<T, *>): String? = columnToString(kProperty, true)
+    override fun columnToString(kProperty: KProperty1<in T, *>): String? = columnToString(kProperty, true)
 
     /**
      * 核心实现方法，供重载使用
      */
-    private fun columnToString(kProperty: KMutableProperty1<T, *>, onlyColumn: Boolean): String? {
+    private fun columnToString(kProperty: KProperty1<in T, *>, onlyColumn: Boolean): String? {
         return columnMap[LambdaUtils.formatKey(kProperty.name)]?.let { if (onlyColumn) it.column else it.columnSelect }
     }
 
@@ -55,7 +55,7 @@ abstract class AbstractKtWrapper<T, Children : AbstractKtWrapper<T, Children>> :
      *
      * "user_id" AS "userId" , "user_name" AS "userName"
      */
-    fun columnsToString(onlyColumn: Boolean, vararg columns: KMutableProperty1<T, *>): String =
+    fun columnsToString(onlyColumn: Boolean, vararg columns: KProperty1<in T, *>): String =
         columns.mapNotNull { columnToString(it, onlyColumn) }.joinToString(separator = StringPool.COMMA)
 
     /**
@@ -63,8 +63,8 @@ abstract class AbstractKtWrapper<T, Children : AbstractKtWrapper<T, Children>> :
      *
      * "user_id" AS "userId" , "user_name" AS "userName"
      */
-    fun columnsToString(onlyColumn: Boolean, columns: MutableList<KMutableProperty1<T, *>>): String =
-        columns.stream().map { columnToString(it, onlyColumn) }.collect(joining(StringPool.COMMA));
+    fun columnsToString(onlyColumn: Boolean, columns: MutableList<KProperty1<in T, *>>): String =
+        columns.stream().map { columnToString(it, onlyColumn) }.collect(joining(StringPool.COMMA))
 
     override fun initNeed() {
         super.initNeed()

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtQueryChainWrapper.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtQueryChainWrapper.kt
@@ -21,7 +21,7 @@ import com.baomidou.mybatisplus.core.metadata.TableFieldInfo
 import com.baomidou.mybatisplus.extension.conditions.AbstractChainWrapper
 import com.baomidou.mybatisplus.extension.conditions.query.ChainQuery
 import java.util.function.Predicate
-import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.KProperty1
 
 /**
  * @author FlyInWind
@@ -30,8 +30,8 @@ import kotlin.reflect.KMutableProperty1
 @Suppress("serial")
 open class KtQueryChainWrapper<T : Any>(
     internal val baseMapper: BaseMapper<T>?
-) : AbstractChainWrapper<T, KMutableProperty1<T, *>, KtQueryChainWrapper<T>, KtQueryWrapper<T>>(),
-    ChainQuery<T>, Query<KtQueryChainWrapper<T>, T, KMutableProperty1<T, *>> {
+) : AbstractChainWrapper<T, KProperty1<in T, *>, KtQueryChainWrapper<T>, KtQueryWrapper<T>>(),
+    ChainQuery<T>, Query<KtQueryChainWrapper<T>, T, KProperty1<in T, *>> {
 
     constructor(baseMapper: BaseMapper<T>, entityClass: Class<T>) : this(baseMapper) {
         super.wrapperChildren = KtQueryWrapper(entityClass)
@@ -50,7 +50,7 @@ open class KtQueryChainWrapper<T : Any>(
         super.setEntityClass(entity.javaClass)
     }
 
-    override fun select(condition: Boolean, columns: MutableList<KMutableProperty1<T, *>>): KtQueryChainWrapper<T> {
+    override fun select(condition: Boolean, columns: MutableList<KProperty1<in T, *>>): KtQueryChainWrapper<T> {
         wrapperChildren.select(condition, columns)
         return typedThis
     }

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtQueryWrapper.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtQueryWrapper.kt
@@ -24,7 +24,7 @@ import com.baomidou.mybatisplus.core.toolkit.CollectionUtils
 import com.baomidou.mybatisplus.core.toolkit.support.ColumnCache
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Predicate
-import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.KProperty1
 
 /**
  * Kotlin Lambda 语法使用 Wrapper
@@ -33,7 +33,7 @@ import kotlin.reflect.KMutableProperty1
  * @since 2018-11-02
  */
 @Suppress("serial")
-open class KtQueryWrapper<T : Any> : AbstractKtWrapper<T, KtQueryWrapper<T>>, Query<KtQueryWrapper<T>, T, KMutableProperty1<T, *>> {
+open class KtQueryWrapper<T : Any> : AbstractKtWrapper<T, KtQueryWrapper<T>>, Query<KtQueryWrapper<T>, T, KProperty1<in T, *>> {
 
     /**
      * 查询字段
@@ -65,7 +65,7 @@ open class KtQueryWrapper<T : Any> : AbstractKtWrapper<T, KtQueryWrapper<T>>, Qu
         this.sqlFirst = sqlFirst
     }
 
-    override fun select(condition: Boolean, columns: MutableList<KMutableProperty1<T, *>>): KtQueryWrapper<T> {
+    override fun select(condition: Boolean, columns: MutableList<KProperty1<in T, *>>): KtQueryWrapper<T> {
         if (condition && CollectionUtils.isNotEmpty(columns)) {
             this.sqlSelect.stringValue = columnsToString(false, columns)
         }

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtUpdateChainWrapper.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtUpdateChainWrapper.kt
@@ -19,7 +19,7 @@ import com.baomidou.mybatisplus.core.conditions.update.Update
 import com.baomidou.mybatisplus.core.mapper.BaseMapper
 import com.baomidou.mybatisplus.extension.conditions.AbstractChainWrapper
 import com.baomidou.mybatisplus.extension.conditions.update.ChainUpdate
-import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.KProperty1
 
 /**
  * @author FlyInWind
@@ -28,8 +28,8 @@ import kotlin.reflect.KMutableProperty1
 @Suppress("serial")
 open class KtUpdateChainWrapper<T : Any>(
     internal val baseMapper: BaseMapper<T>?
-) : AbstractChainWrapper<T, KMutableProperty1<T, *>, KtUpdateChainWrapper<T>, KtUpdateWrapper<T>>(),
-    ChainUpdate<T>, Update<KtUpdateChainWrapper<T>, KMutableProperty1<T, *>> {
+) : AbstractChainWrapper<T, KProperty1<in T, *>, KtUpdateChainWrapper<T>, KtUpdateWrapper<T>>(),
+    ChainUpdate<T>, Update<KtUpdateChainWrapper<T>, KProperty1<in T, *>> {
 
     constructor(baseMapper: BaseMapper<T>, entityClass: Class<T>) : this(baseMapper) {
         super.wrapperChildren = KtUpdateWrapper(entityClass)
@@ -48,7 +48,7 @@ open class KtUpdateChainWrapper<T : Any>(
         super.setEntityClass(entity.javaClass)
     }
 
-    override fun set(condition: Boolean, column: KMutableProperty1<T, *>, value: Any?, mapping: String?): KtUpdateChainWrapper<T> {
+    override fun set(condition: Boolean, column: KProperty1<in T, *>, value: Any?, mapping: String?): KtUpdateChainWrapper<T> {
         wrapperChildren.set(condition, column, value, mapping)
         return typedThis
     }

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtUpdateWrapper.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtUpdateWrapper.kt
@@ -25,7 +25,7 @@ import com.baomidou.mybatisplus.core.toolkit.StringUtils
 import com.baomidou.mybatisplus.core.toolkit.support.ColumnCache
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.stream.Collectors.joining
-import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.KProperty1
 
 /**
  * Kotlin Lambda 更新封装
@@ -34,7 +34,7 @@ import kotlin.reflect.KMutableProperty1
  * @since 2018-11-02
  */
 @Suppress("serial")
-open class KtUpdateWrapper<T : Any> : AbstractKtWrapper<T, KtUpdateWrapper<T>>, Update<KtUpdateWrapper<T>, KMutableProperty1<T, *>> {
+open class KtUpdateWrapper<T : Any> : AbstractKtWrapper<T, KtUpdateWrapper<T>>, Update<KtUpdateWrapper<T>, KProperty1<in T, *>> {
 
     /**
      * SQL 更新字段内容，例如：name='1', age=2
@@ -76,7 +76,7 @@ open class KtUpdateWrapper<T : Any> : AbstractKtWrapper<T, KtUpdateWrapper<T>>, 
         return typedThis
     }
 
-    override fun set(condition: Boolean, column: KMutableProperty1<T, *>, value: Any?, mapping: String?): KtUpdateWrapper<T> {
+    override fun set(condition: Boolean, column: KProperty1<in T, *>, value: Any?, mapping: String?): KtUpdateWrapper<T> {
         return maybeDo(condition) {
             val sql = formatParam(mapping, value)
             sqlSet.add(columnsToString(column) + Constants.EQUALS + sql)


### PR DESCRIPTION
### 该Pull Request关联的Issue
https://github.com/baomidou/mybatis-plus/issues/5824


### 修改描述
修复因 https://github.com/baomidou/mybatis-plus/issues/5454 的提交引起的使用 set 更新时，数据库实体类的字段没法使用 val 修饰，也没法使用基类

### 测试用例
```kotlin
interface IUpdateTime {

    var updateTime: Instant?

}

interface IUpdater : IUpdateTime {

    var updater: Long?

}

data class User(

    var id: Long? = null,

    override var updater: Long? = null,
    override var updateTime: Instant? = null,

    ): IUpdater

interface ICService<T : Any> : IService<T> {

    fun update(whereChain: (KtUpdateChainWrapper<T>) -> KtUpdateChainWrapper<T>): Boolean {

        val wrapper = whereChain.invoke(ktUpdate())

        val now = Instant.now()

        if (IUpdater::class.java.isAssignableFrom(entityClass)) {
            wrapper.set(IUpdater::updater, 1L)
            wrapper.set(IUpdateTime::updateTime, now)
        } else if (IUpdateTime::class.java.isAssignableFrom(entityClass)) {
            wrapper.set(IUpdateTime::updateTime, now)
        }

        return wrapper.update()
    }

}

interface ICUpdaterService<T: IUpdater> : ICService<T> {

    override fun update(whereChain: (KtUpdateChainWrapper<T>) -> KtUpdateChainWrapper<T>): Boolean {
        return super.update{
            it.set(IUpdater::updater, 1L)
        }
    }

}
```


### 修复效果的截屏
![image](https://github.com/baomidou/mybatis-plus/assets/15310784/9defd014-f655-4466-8037-1c0db859e388)
