### PR TITLE
移除ddlApplicationRunner方法返回null

### DIFF
--- a/spring-boot-starter/mybatis-plus-spring-boot-autoconfigure/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
+++ b/spring-boot-starter/mybatis-plus-spring-boot-autoconfigure/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusAutoConfiguration.java
@@ -404,9 +404,6 @@ public class MybatisPlusAutoConfiguration implements InitializingBean {
     @Bean
     @ConditionalOnMissingBean
     public DdlApplicationRunner ddlApplicationRunner(@Autowired(required = false) List<IDdl> ddlList) {
-        if (ObjectUtils.isEmpty(ddlList)) {
-            return null;
-        }
         return new DdlApplicationRunner(ddlList);
     }
 }


### PR DESCRIPTION
### 该Pull Request关联的Issue

Fix issue [5867](https://github.com/baomidou/mybatis-plus/issues/5867)

### 修改描述
1. 官方在Spring5+已经对返回null的bean做了很多变化，如若有返回null的需求也建议使用ObjectProvider或Optional
2. DdlApplicationRunner在run时已经判断了传入ddlList是否为空


### 测试用例



### 修复效果的截屏


