### PR TITLE
updateById Support Dynamic Field Strategy

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/enums/SqlMethod.java
@@ -49,6 +49,7 @@ public enum SqlMethod {
      * 修改
      */
     UPDATE_BY_ID("updateById", "根据ID 选择修改数据", "<script>\nUPDATE %s %s WHERE %s=#{%s} %s\n</script>"),
+    STRATEGY_UPDATE_BY_ID("strategyUpdateById", "根据ID 选择动态字段策略修改数据","<script>\n%s\nUPDATE %s %s WHERE %s=#{%s} %s\n</script>"),
     UPDATE("update", "根据 whereEntity 条件，更新记录", "<script>\nUPDATE %s %s %s %s\n</script>"),
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/AbstractMethod.java
@@ -119,7 +119,7 @@ public abstract class AbstractMethod implements Constants {
      */
     protected String sqlSet(boolean logic, boolean ew, TableInfo table, boolean judgeAliasNull, final String alias,
                             final String prefix) {
-        String sqlScript = table.getAllSqlSet(logic, prefix);
+        String sqlScript = getTableAllSqlSet(table, logic, prefix);
         if (judgeAliasNull) {
             sqlScript = SqlScriptUtils.convertIf(sqlScript, String.format("%s != null", alias), true);
         }
@@ -129,6 +129,17 @@ public abstract class AbstractMethod implements Constants {
         }
         sqlScript = SqlScriptUtils.convertSet(sqlScript);
         return sqlScript;
+    }
+
+    /**
+     * table所有的 sql set 片段
+     * @param table table 信息
+     * @param logic 是否逻辑删除注入器
+     * @param prefix 前缀
+     * @return table所有的 sql set 片段
+     */
+    protected String getTableAllSqlSet(TableInfo table,final boolean logic,final String prefix){
+        return table.getAllSqlSet(logic, prefix, false);
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/DefaultSqlInjector.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/DefaultSqlInjector.java
@@ -46,6 +46,7 @@ public class DefaultSqlInjector extends AbstractSqlInjector {
             builder.add(new DeleteById())
                 .add(new DeleteBatchByIds())
                 .add(new UpdateById())
+                .add(new StrategyUpdateById())
                 .add(new SelectById())
                 .add(new SelectBatchByIds());
         } else {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/StrategyUpdateById.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/StrategyUpdateById.java
@@ -1,0 +1,64 @@
+package com.baomidou.mybatisplus.core.injector.methods;
+
+import com.baomidou.mybatisplus.core.enums.SqlMethod;
+import com.baomidou.mybatisplus.core.injector.AbstractMethod;
+import com.baomidou.mybatisplus.core.metadata.TableInfo;
+import com.baomidou.mybatisplus.core.toolkit.sql.SqlScriptUtils;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.SqlSource;
+
+import java.util.HashMap;
+
+/**
+ * @author 张治保
+ * @since 2023/12/29
+ */
+public class StrategyUpdateById extends AbstractMethod {
+
+    private static final String ALWAYS_EXPRESSION =String.format("%s == null or %s == @com.baomidou.mybatisplus.annotation.FieldStrategy@IGNORED  or %s == @com.baomidou.mybatisplus.annotation.FieldStrategy@ALWAYS",STRATEGY,STRATEGY,STRATEGY);
+    private static final String NOT_NULL_EXPRESSION =String.format("%s == @com.baomidou.mybatisplus.annotation.FieldStrategy@NOT_NULL",STRATEGY);
+    private static final String NOT_EMPTY_EXPRESSION =String.format("%s == @com.baomidou.mybatisplus.annotation.FieldStrategy@NOT_EMPTY",STRATEGY);
+
+    private static final String ALL_BIND;
+
+    static {
+        ALL_BIND = SqlScriptUtils.convertBinds(
+            new HashMap<String,String>(){
+                {
+                    put(ALWAYS_STRATEGY_BINDER,ALWAYS_EXPRESSION);
+                    put(NOT_NULL_STRATEGY_BINDER,NOT_NULL_EXPRESSION);
+                    put(NOT_EMPTY_STRATEGY_BINDER,NOT_EMPTY_EXPRESSION);
+                }
+            }
+        );
+    }
+    public StrategyUpdateById(){
+        this(SqlMethod.STRATEGY_UPDATE_BY_ID.getMethod());
+    }
+
+    public StrategyUpdateById(String methodName) {
+        super(methodName);
+    }
+
+    @Override
+    public MappedStatement injectMappedStatement(Class<?> mapperClass, Class<?> modelClass, TableInfo tableInfo) {
+        SqlMethod sqlMethod = SqlMethod.STRATEGY_UPDATE_BY_ID;
+        final String additional = optlockVersion(tableInfo) + tableInfo.getLogicDeleteSql(true, true);
+        String sql = String.format(
+            sqlMethod.getSql(),
+            ALL_BIND,
+            tableInfo.getTableName(),
+            sqlSet(tableInfo.isWithLogicDelete(), false, tableInfo, false, ENTITY, ENTITY_DOT),
+            tableInfo.getKeyColumn(), ENTITY_DOT + tableInfo.getKeyProperty(), additional);
+        SqlSource sqlSource = super.createSqlSource(configuration, sql, modelClass);
+        return addUpdateMappedStatement(mapperClass, modelClass, methodName, sqlSource);
+    }
+
+
+    @Override
+    protected String getTableAllSqlSet(TableInfo table, boolean logic, String prefix) {
+        return table.getAllSqlSet(logic, prefix,true);
+    }
+
+
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
@@ -15,8 +15,8 @@
  */
 package com.baomidou.mybatisplus.core.mapper;
 
+import com.baomidou.mybatisplus.annotation.FieldStrategy;
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
@@ -139,6 +139,15 @@ public interface BaseMapper<T> extends Mapper<T> {
      * @param entity 实体对象
      */
     int updateById(@Param(Constants.ENTITY) T entity);
+
+    /**
+     * 使用指定的字段策略 根据  ID修改  update
+     *
+     * @param strategy 字段策略
+     * @param entity   实体对象
+     * @return int 返回影响行数
+     */
+    int strategyUpdateById(@Param(Constants.STRATEGY) FieldStrategy strategy, @Param(Constants.ENTITY) T entity);
 
     /**
      * 根据 whereEntity 条件，更新记录

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
@@ -416,7 +416,18 @@ public class TableInfo implements Constants {
      * @param prefix              前缀
      * @return sql 脚本片段
      */
-    public String getAllSqlSet(boolean ignoreLogicDelFiled, final String prefix) {
+    public String getAllSqlSet(boolean ignoreLogicDelFiled, final String prefix){
+        return getAllSqlSet(ignoreLogicDelFiled,prefix,false);
+    }
+    /**
+     * 获取所有的 sql set 片段
+     *
+     * @param ignoreLogicDelFiled 是否过滤掉逻辑删除字段
+     * @param prefix              前缀
+     * @param dynamicStrategy     是否是动态字段策略
+     * @return sql 脚本片段
+     */
+    public String getAllSqlSet(boolean ignoreLogicDelFiled, final String prefix,boolean dynamicStrategy) {
         final String newPrefix = prefix == null ? EMPTY : prefix;
         return fieldList.stream()
             .filter(i -> {
@@ -424,7 +435,7 @@ public class TableInfo implements Constants {
                     return !(isWithLogicDelete() && i.isLogicDelete());
                 }
                 return true;
-            }).map(i -> i.getSqlSet(newPrefix)).filter(Objects::nonNull).collect(joining(NEWLINE));
+            }).map(i -> i.getSqlSet(newPrefix,dynamicStrategy)).filter(Objects::nonNull).collect(joining(NEWLINE));
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Constants.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Constants.java
@@ -179,4 +179,24 @@ public interface Constants extends StringPool, Serializable {
      */
     String WRAPPER_PARAM = "MPGENVAL";
     String WRAPPER_PARAM_MIDDLE = ".paramNameValuePairs" + DOT;
+
+    /**
+     * 动态 字段策略参数名
+     */
+    String STRATEGY = "st";
+
+    /**
+     *  字段策略忽略判断 bind name
+     */
+    String ALWAYS_STRATEGY_BINDER = "always";
+
+    /**
+     *  字段策略非空判断 bind name
+     */
+    String NOT_NULL_STRATEGY_BINDER = "notNull";
+
+    /**
+     *  字段策略非空白判断 bind name
+     */
+    String NOT_EMPTY_STRATEGY_BINDER = "notEmpty";
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlScriptUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlScriptUtils.java
@@ -20,6 +20,9 @@ import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 /**
  * <p>
  * sql 脚本工具类
@@ -145,6 +148,34 @@ public abstract class SqlScriptUtils implements Constants {
      */
     public static String convertSet(final String sqlScript) {
         return "<set>" + NEWLINE + sqlScript + NEWLINE + "</set>";
+    }
+
+    /**
+     * <p>
+     * 生成 bind 标签的脚本
+     * <a href="https://mybatis.org/mybatis-3/zh_CN/dynamic-sql.html#bind">bind</a>
+     * </p>
+     * @param name 变量名
+     * @param expression 变量值计算表达式
+     * @return bind 脚本
+     */
+    public static String convertBind(final String name,String expression){
+        return "<bind name=\""+name+"\" value=\""+expression+"\"/>";
+    }
+
+    /**
+     * <p>
+     *  批量生成 bind 标签的脚本
+     *  <p>
+     * @see SqlScriptUtils#convertBind
+     * @param bindMap 变量名与变量值计算表达式的映射 key 为变量名 value 为变量值计算表达式
+     * @return bind 脚本
+     */
+    public static String convertBinds(final Map<String,String> bindMap){
+        return bindMap.entrySet()
+            .stream()
+            .map(entry -> convertBind(entry.getKey(),entry.getValue()))
+            .collect(Collectors.joining(NEWLINE));
     }
 
     /**

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlScriptUtilsTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/toolkit/sql/SqlScriptUtilsTest.java
@@ -4,6 +4,8 @@ import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.LocalDateTypeHandler;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -16,5 +18,19 @@ class SqlScriptUtilsTest {
     void convertParamMapping() {
         assertThat(SqlScriptUtils.convertParamMapping(LocalDateTypeHandler.class, JdbcType.DATE,2))
             .isEqualTo("typeHandler=org.apache.ibatis.type.LocalDateTypeHandler,jdbcType=DATE,numericScale=2");
+    }
+
+    @Test
+    void convertBind(){
+        assertThat(SqlScriptUtils.convertBind("hello", "'world'"))
+            .isEqualTo("<bind name=\"hello\" value=\"'world'\"/>");
+    }
+
+    @Test
+    void convertBinds(){
+        assertThat(SqlScriptUtils.convertBinds(Map.of("hello", "'world'")))
+            .isEqualTo("<bind name=\"hello\" value=\"'world'\"/>");
+        assertThat(SqlScriptUtils.convertBinds(Map.of("hello", "'world'","hello2","'world2'")))
+            .contains("<bind name=\"hello\" value=\"'world'\"/>","<bind name=\"hello2\" value=\"'world2'\"/>");
     }
 }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/IService.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/IService.java
@@ -15,6 +15,7 @@
  */
 package com.baomidou.mybatisplus.extension.service;
 
+import com.baomidou.mybatisplus.annotation.FieldStrategy;
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
@@ -272,6 +273,39 @@ public interface IService<T> {
      * @param batchSize  更新批次数量
      */
     boolean updateBatchById(Collection<T> entityList, int batchSize);
+
+    /**
+     * 根据ID 动态字段策略 更新
+     * @param strategy 字段策略
+     * @param entity 实体对象
+     * @return boolean true 操作成功 false 操作失败
+     */
+    default boolean strategyUpdateById(FieldStrategy strategy,T entity){
+        if (FieldStrategy.DEFAULT == strategy){
+            return updateById(entity);
+        }
+        return SqlHelper.retBool(getBaseMapper().strategyUpdateById(strategy,entity));
+    }
+    /**
+     * 根据ID 动态字段策略 批量更新
+     *
+     * @param strategy 字段策略
+     * @param entityList 实体对象集合
+     * @return boolean true 操作成功 false 操作失败
+     */
+    @Transactional(rollbackFor = Exception.class)
+    default boolean strategyUpdateBatchById(FieldStrategy strategy,Collection<T> entityList){
+        return strategyUpdateBatchById(strategy,entityList,DEFAULT_BATCH_SIZE);
+    }
+    /**
+     * 根据ID 动态字段策略 批量更新
+     *
+     * @param strategy   字段策略
+     * @param entityList 实体对象集合
+     * @param batchSize  更新批次数量
+     * @return boolean true 操作成功 false 操作失败
+     */
+    boolean strategyUpdateBatchById(FieldStrategy strategy,Collection<T> entityList,int batchSize);
 
     /**
      * TableId 注解存在更新记录，否插入一条记录

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package com.baomidou.mybatisplus.extension.service.impl;
 
+import com.baomidou.mybatisplus.annotation.FieldStrategy;
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.enums.SqlMethod;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
@@ -233,6 +234,22 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
         return executeBatch(entityList, batchSize, (sqlSession, entity) -> {
             MapperMethod.ParamMap<T> param = new MapperMethod.ParamMap<>();
             param.put(Constants.ENTITY, entity);
+            sqlSession.update(sqlStatement, param);
+        });
+    }
+
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public boolean strategyUpdateBatchById(FieldStrategy strategy, Collection<T> entityList, int batchSize) {
+        if (strategy == FieldStrategy.DEFAULT){
+            return updateBatchById(entityList, batchSize);
+        }
+        String sqlStatement = getSqlStatement(SqlMethod.STRATEGY_UPDATE_BY_ID);
+        return executeBatch(entityList, batchSize, (sqlSession, entity) -> {
+            MapperMethod.ParamMap<Object> param = new MapperMethod.ParamMap<>();
+            param.put(Constants.ENTITY, entity);
+            param.put(Constants.STRATEGY, strategy);
             sqlSession.update(sqlStatement, param);
         });
     }

--- a/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/DynamicStrategySampleTest.java
+++ b/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/DynamicStrategySampleTest.java
@@ -1,0 +1,79 @@
+package com.baomidou.mybatisplus.test.autoconfigure.dynamic_strategy;
+
+import com.baomidou.mybatisplus.annotation.FieldStrategy;
+import com.baomidou.mybatisplus.test.autoconfigure.MybatisPlusTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author 张治保
+ * @since 2023/12/29
+ */
+@Import(SampleUserServiceImpl.class)
+@MybatisPlusTest
+public class DynamicStrategySampleTest {
+
+    @Autowired
+    private SampleUserMapper sampleUserMapper;
+    @Autowired
+    private SampleUserService sampleUserService;
+
+
+    @Test
+    void testStrategyUpdate() {
+        String username = "rowstop";
+        LocalDateTime createTime = LocalDateTime.now();
+        SampleUser sampleUser = new SampleUser()
+            .setId(1)
+            .setUsername(username)
+            .setPassword(UUID.randomUUID().toString())
+            .setCreateTime(createTime);
+        //mapper test
+        sampleUserMapper.insert(sampleUser);
+        SampleUser user = sampleUserMapper.selectById(1);
+        assertThat(user).isNotNull();
+        int count = sampleUserMapper.strategyUpdateById(
+            FieldStrategy.ALWAYS,
+            new SampleUser().setId(1).setUsername("rowstart")
+        );
+        assertThat(count).isEqualTo(1);
+        user = sampleUserMapper.selectById(1);
+        //should be rowstart
+        assertThat(user.getUsername()).isEqualTo("rowstart");
+        //should be null
+        assertThat(user.getPassword()).isNull();
+        //FieldStrategy.NEVER should never update
+        assertThat(user.getCreateTime()).isEqualTo(createTime);
+        //service test
+        String newPassword = UUID.randomUUID().toString();
+        sampleUserService.strategyUpdateById(
+            FieldStrategy.ALWAYS,
+            new SampleUser().setId(1).setPassword(newPassword)
+        );
+        user = sampleUserService.getById(1);
+        assertThat(user).isNotNull();
+        assertThat(user.getUsername()).isNull();
+        assertThat(user.getPassword()).isEqualTo(newPassword);
+        assertThat(user.getCreateTime()).isEqualTo(createTime);
+
+        sampleUserService.updateById(
+            new SampleUser().setId(1).setUsername(username)
+        );
+        user = sampleUserService.getById(1);
+        assertThat(user).isNotNull();
+        assertThat(user.getUsername()).isEqualTo(username);
+        assertThat(user.getPassword()).isEqualTo(newPassword);
+        assertThat(user.getCreateTime()).isEqualTo(createTime);
+
+    }
+
+
+
+
+}

--- a/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/SampleUser.java
+++ b/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/SampleUser.java
@@ -1,0 +1,33 @@
+package com.baomidou.mybatisplus.test.autoconfigure.dynamic_strategy;
+
+import com.baomidou.mybatisplus.annotation.FieldStrategy;
+import com.baomidou.mybatisplus.annotation.TableField;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author 张治保
+ * @since 2023/12/29
+ */
+@Getter
+@Setter
+@ToString
+@Accessors(chain = true)
+public class SampleUser {
+
+    private Integer id;
+
+    @TableField(updateStrategy = FieldStrategy.NOT_NULL)
+    private String username;
+
+    @TableField(updateStrategy = FieldStrategy.NOT_EMPTY)
+    private String password;
+
+    @TableField(updateStrategy = FieldStrategy.NEVER)
+    private LocalDateTime createTime;
+
+}

--- a/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/SampleUserMapper.java
+++ b/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/SampleUserMapper.java
@@ -1,0 +1,12 @@
+package com.baomidou.mybatisplus.test.autoconfigure.dynamic_strategy;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * @author 张治保
+ * @since 2023/12/29
+ */
+@Mapper
+public interface SampleUserMapper extends BaseMapper<SampleUser> {
+}

--- a/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/SampleUserService.java
+++ b/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/SampleUserService.java
@@ -1,0 +1,10 @@
+package com.baomidou.mybatisplus.test.autoconfigure.dynamic_strategy;
+
+import com.baomidou.mybatisplus.extension.service.IService;
+
+/**
+ * @author 张治保
+ * @since 2023/12/29
+ */
+public interface SampleUserService extends IService<SampleUser> {
+}

--- a/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/SampleUserServiceImpl.java
+++ b/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/java/com/baomidou/mybatisplus/test/autoconfigure/dynamic_strategy/SampleUserServiceImpl.java
@@ -1,0 +1,12 @@
+package com.baomidou.mybatisplus.test.autoconfigure.dynamic_strategy;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author 张治保
+ * @since 2023/12/29
+ */
+@Service
+public class SampleUserServiceImpl extends ServiceImpl<SampleUserMapper, SampleUser> implements SampleUserService{
+}

--- a/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/resources/schema.sql
+++ b/spring-boot-starter/mybatis-plus-boot-starter-test/src/test/resources/schema.sql
@@ -4,3 +4,12 @@ create table if not exists sample
     id   bigint,
     name varchar
 );
+
+drop table if exists sample_user;
+create table if not exists sample_user
+(
+    id   int,
+    username varchar,
+    password varchar,
+    create_time timestamp
+);


### PR DESCRIPTION
These methods have been supported
![image](https://github.com/baomidou/mybatis-plus/assets/100893704/75e572cf-ffc6-4f97-ae68-37e63048db91)

sql script
```script
<script>
<bind name="always" value="st == null or st == @com.baomidou.mybatisplus.annotation.FieldStrategy@IGNORED  or st == @com.baomidou.mybatisplus.annotation.FieldStrategy@ALWAYS"/>
<bind name="notNull" value="st == @com.baomidou.mybatisplus.annotation.FieldStrategy@NOT_NULL"/>
<bind name="notEmpty" value="st == @com.baomidou.mybatisplus.annotation.FieldStrategy@NOT_EMPTY"/>
UPDATE sample_user <set>
<if test="always or (notNull and et['username'] != null) or (notEmpty and et['username'] != null and et['username'] != '')">username=#{et.username},</if>
<if test="always or (notNull and et['password'] != null) or (notEmpty and et['password'] != null and et['password'] != '')">password=#{et.password},</if>
</set> WHERE id=#{et.id} 
</script>
```