### PR TITLE
fix sqlserver distinct与orderby 一起用报错问题

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -272,7 +272,7 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
             GroupByElement groupBy = plainSelect.getGroupBy();
 
             // 包含 distinct、groupBy 不优化
-            if (null != distinct || null != groupBy) {
+            if (null != groupBy) {
                 return lowLevelCountSql(select.toString());
             }
 

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -271,7 +271,7 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
             Distinct distinct = plainSelect.getDistinct();
             GroupByElement groupBy = plainSelect.getGroupBy();
 
-            // 包含 distinct、groupBy 不优化
+            // 包含 groupBy 不优化
             if (null != groupBy) {
                 return lowLevelCountSql(select.toString());
             }


### PR DESCRIPTION


### 该Pull Request关联的Issue



### 修改描述
sqlserver的count内不允许出现orderby语句
另外orderby对count distinct也没有什么影响

```
SELECT COUNT(*) FROM (SELECT DISTINCT r.role_id, r.role_name, r.role_key, r.role_sort, r.data_scope, r.menu_check_strictly, r.dept_check_strictly, r.status, r.del_flag, r.create_time, r.remark FROM sys_role r LEFT JOIN sys_user_role sur ON sur.role_id = r.role_id LEFT JOIN sys_user u ON u.user_id = sur.user_id AND u.tenant_id = '000000' LEFT JOIN sys_dept d ON u.dept_id = d.dept_id AND d.tenant_id = '000000' WHERE (r.del_flag = ?) AND r.tenant_id = '000000' ORDER BY r.role_sort ASC, r.create_time ASC) TOTAL

Cause: com.microsoft.sqlserver.jdbc.SQLServerException: The ORDER BY clause is invalid in views, inline functions, derived tables, subqueries, and common table expressions, unless TOP, OFFSET or FOR XML is also specified.
```

### 测试用例



### 修复效果的截屏


