### PR TITLE
@InterceptorIgnore不支持default修饰的方法(#6057)

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisMapperAnnotationBuilder.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisMapperAnnotationBuilder.java
@@ -128,7 +128,8 @@ public class MybatisMapperAnnotationBuilder extends MapperAnnotationBuilder {
 
     private static boolean canHaveStatement(Method method) {
         // issue #237
-        return !method.isBridge() && !method.isDefault();
+        // issue #6057 https://github.com/baomidou/mybatis-plus/issues/6057
+        return !method.isBridge();
     }
 
 


### PR DESCRIPTION
### 该Pull Request关联的Issue
https://github.com/baomidou/mybatis-plus/issues/6057


### 修改描述
使@InterceptorIgnore注解支持忽略default关键字修饰的方法


### 测试用例



### 修复效果的截屏


