### PR TITLE
ServiceImpl反射获取当前映射(类,模型)的方法,增加null值判断

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/service/impl/ServiceImpl.java
@@ -115,13 +115,21 @@ public abstract class ServiceImpl<M extends BaseMapper<T>, T> implements IServic
     protected boolean retBool(Integer result) {
         return SqlHelper.retBool(result);
     }
-
+    /**
+     * 当前映射类
+     * {@code @update} 2024年4月15日17:47:37 增加null值判断
+     * @author chrelyonly
+     */
     protected Class<M> currentMapperClass() {
-        return (Class<M>) this.typeArguments[0];
+        return null == this.typeArguments ? null :(Class<M>) this.typeArguments[0];
     }
-
+    /**
+     * 当前模型类
+     * {@code @update} 2024年4月15日17:47:37 增加null值判断
+     * @author chrelyonly
+     */
     protected Class<T> currentModelClass() {
-        return (Class<T>) this.typeArguments[1];
+        return null == this.typeArguments ? null :(Class<T>) this.typeArguments[1];
     }
 
 


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述
版本3.5.6
1.在进行手动创建serviceBean的时候出现类映射获取失败,(这在早期的版本中(3.5.3.1)是有判断null值的情况,新版本中缺少了判断)
2.新增serviceImpl抽象类对获取反射值的方法进行null判断处理


### 测试用例
![251a2d5e7ebede920adfcefdc40a73a](https://github.com/baomidou/mybatis-plus/assets/62467038/14d2d41b-1393-4cb9-954e-3fdb1a588322)
![666b7675eca3605ec0c847971737d93](https://github.com/baomidou/mybatis-plus/assets/62467038/be7cb3df-beaa-4f00-a092-78cbea63901e)



### 修复效果的截屏
![image](https://github.com/baomidou/mybatis-plus/assets/62467038/1b863ed0-c0bb-4d38-904d-3ebef0a251da)


