### PR TITLE
修复脚本自动维护功能无法在sqlite数据库中正确创建ddl_history表

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/ddl/history/SQLiteDdlGenerator.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/ddl/history/SQLiteDdlGenerator.java
@@ -35,7 +35,7 @@ public class SQLiteDdlGenerator implements IDdlGenerator {
     @Override
     public boolean existTable(String databaseName, Function<String, Boolean> executeFunction) {
         StringBuffer sql = new StringBuffer();
-        sql.append("SELECT count(1) FROM sqlite_master WHERE name='");
+        sql.append("SELECT count(1) NUM FROM sqlite_master WHERE name='");
         sql.append(getDdlHistory()).append("' AND type='table'");
         return executeFunction.apply(sql.toString());
     }


### PR DESCRIPTION
example:
2024-05-11 12:00:41.301 ERROR 24112 --- [           main] c.b.mybatisplus.extension.ddl.DdlHelper  : run script sql:sql/master/datav_t_sys_user/0.sql , error: [SQLITE_ERROR] SQL error or missing database (no such table: ddl_history) , Please check if the table `ddl_history` exists

### 该Pull Request关联的Issue
 [BUG] 脚本自动维护功能无法在sqlite数据库中正确创建ddl_history表 #6152 



### 修改描述
增加`NUM`列名

修改前：
```java
sql.append("SELECT count(1) FROM sqlite_master WHERE name='");
```
修改后：
```java
sql.append("SELECT count(1) NUM FROM sqlite_master WHERE name='");
```


### 测试用例



### 修复效果的截屏


