### PR TITLE
java实体类模版默认导入TableName类

### DIFF
--- a/mybatis-plus-generator/src/main/resources/templates/entity.java.ftl
+++ b/mybatis-plus-generator/src/main/resources/templates/entity.java.ftl
@@ -16,6 +16,9 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
     </#if>
 </#if>
+<#if table.convert>
+    import com.baomidou.mybatisplus.annotation.TableName;
+</#if>
 
 /**
  * <p>

--- a/mybatis-plus-generator/src/main/resources/templates/entity.java.vm
+++ b/mybatis-plus-generator/src/main/resources/templates/entity.java.vm
@@ -16,7 +16,9 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 #end
 #end
-
+#if(${table.convert})
+import com.baomidou.mybatisplus.annotation.TableName;
+#end
 /**
  * <p>
  * $!{table.comment}


### PR DESCRIPTION
### 实体生成的 vm 和 ftl 模板生成实体是没导入TableName类，修改后生成时默认导入，避免二次修改代码


### 修复效果的截屏<img width="457" alt="111" src="https://github.com/baomidou/mybatis-plus/assets/35858039/86853896-e90c-44e4-b18d-12b885791822">

