### PR TITLE
解决k8s集群下,进程号pid为1导致生成重复ID的可能性大大增加

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Sequence.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/Sequence.java
@@ -129,9 +129,10 @@ public class Sequence {
         String name = ManagementFactory.getRuntimeMXBean().getName();
         if (StringUtils.isNotBlank(name)) {
             /*
-             * GET jvmPid
+             * GET jvm 进程名 eg: 62061@macdeMacBook-Pro-2.local
+             * issue#6177 解决k8s集群下,进程号pid为1导致生成重复ID的可能性大大增加
              */
-            mpid.append(name.split(StringPool.AT)[0]);
+            mpid.append(name);
         }
         /*
          * MAC + PID 的 hashcode 获取16个低位


### PR DESCRIPTION
### 该Pull Request关联的Issue
issue#6177


### 修改描述
解决k8s集群下,进程号pid为1导致生成重复ID的可能性大大增加


### 测试用例



### 修复效果的截屏


