### PR TITLE
分页插件支持GoldenDB数据库。

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -215,6 +215,10 @@ public enum DbType {
      */
     VASTBASE("vastbase", "Vastbase数据库"),
     /**
+     * goldendb
+     */
+    GOLDENDB("goldendb", "GoldenDB数据库"),
+    /**
      * UNKNOWN DB
      */
     OTHER("other", "其他数据库");

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/pagination/DialectFactory.java
@@ -73,6 +73,8 @@ public class DialectFactory {
             } else if (dbType == DbType.TRINO
                 || dbType == DbType.PRESTO) {
                 dialect = new TrinoDialect();
+            } else if (dbType == DbType.GOLDENDB) {
+                dialect = new MySqlDialect();
             }
             DIALECT_ENUM_MAP.put(dbType, dialect);
         }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/JdbcUtils.java
@@ -147,6 +147,8 @@ public class JdbcUtils {
             return DbType.DERBY;
         } else if (url.contains(":vastbase:")) {
             return DbType.VASTBASE;
+        } else if (url.contains(":goldendb:")) {
+            return DbType.GOLDENDB;
         } else {
             logger.warn("The jdbcUrl is " + jdbcUrl + ", Mybatis Plus Cannot Read Database type or The Database's Not Supported!");
             return DbType.OTHER;


### PR DESCRIPTION
# 需求描述
为分页插件支持[GoldenDB数据库](https://www.zte.com.cn/china/solutions_latest/goldendb.html)。

# 实现说明
- GoldenDB数据库SQL分页语法完全兼容MySQL语法([参考](https://www.goldendb.com/#/docsIndex/docs/GoldenDB_MySQLCompatibility))，因此直接使用了`com.baomidou.mybatisplus.extension.plugins.pagination.dialects.MySqlDialect`作为分页方言实现类
- 因GoldenDB数据库的DDL相比MySQL有额外的声明，因此不适用于`com.baomidou.mybatisplus.extension.ddl.history.MysqlDdlGenerator`的场景，未加入到`com.baomidou.mybatisplus.annotation.DbType#mysqlSameType`方法的判断逻辑中

请审阅，谢谢！