### PR TITLE
Add column reference for LambdaWrapper

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractLambdaWrapper.java
@@ -15,6 +15,8 @@
  */
 package com.baomidou.mybatisplus.core.conditions;
 
+import com.baomidou.mybatisplus.core.conditions.segments.ColumnSegment;
+import com.baomidou.mybatisplus.core.enums.SqlKeyword;
 import com.baomidou.mybatisplus.core.toolkit.Assert;
 import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 import com.baomidou.mybatisplus.core.toolkit.LambdaUtils;
@@ -149,5 +151,19 @@ public abstract class AbstractLambdaWrapper<T, Children extends AbstractLambdaWr
         Assert.notNull(columnCache, "can not find lambda cache for this property [%s] of entity [%s]",
             fieldName, lambdaClass.getName());
         return columnCache;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected ColumnSegment referColumn(SFunction<?,?> func) {
+        return () -> columnToString((SFunction<T, ?>) func);
+    }
+
+    @Override
+    protected Children addCondition(boolean condition, SFunction<T, ?> column, SqlKeyword sqlKeyword, Object val) {
+        if (val instanceof SFunction) {
+            // Lambda refers a column, convert it to a ColumnSegment
+            return super.addCondition(condition, column, sqlKeyword, referColumn((SFunction<?, ?>) val));
+        }
+        return super.addCondition(condition, column, sqlKeyword, val);
     }
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
@@ -528,6 +528,9 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
      * @return value
      */
     protected final String formatParam(String mapping, Object param) {
+        if (param instanceof ColumnSegment) {
+            return ((ColumnSegment) param).getSqlSegment();
+        }
         final String genParamName = Constants.WRAPPER_PARAM + paramNameSeq.incrementAndGet();
         final String paramStr = getParamAlias() + Constants.WRAPPER_PARAM_MIDDLE + genParamName;
         paramNameValuePairs.put(genParamName, param);

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/LambdaUpdateWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/update/LambdaUpdateWrapper.java
@@ -78,7 +78,12 @@ public class LambdaUpdateWrapper<T> extends AbstractLambdaWrapper<T, LambdaUpdat
     @Override
     public LambdaUpdateWrapper<T> set(boolean condition, SFunction<T, ?> column, Object val, String mapping) {
         return maybeDo(condition, () -> {
-            String sql = formatParam(mapping, val);
+            Object actualVal = val;
+            // value is a lambda, that refers to a column.
+            if (val instanceof SFunction) {
+                actualVal = referColumn((SFunction<?, ?>) val);
+            }
+            String sql = formatParam(mapping, actualVal);
             sqlSet.add(columnToString(column) + Constants.EQUALS + sql);
         });
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/LambdaUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/LambdaUtils.java
@@ -122,4 +122,7 @@ public final class LambdaUtils {
         });
     }
 
+    public static <T> SFunction<T, ?> getColumnRef(SFunction<T, ?> func) {
+        return func;
+    }
 }

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/LambdaQueryWrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/LambdaQueryWrapperTest.java
@@ -7,6 +7,7 @@ import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.TableInfo;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.core.toolkit.LambdaUtils;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.Data;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
@@ -38,6 +39,13 @@ class LambdaQueryWrapperTest extends BaseWrapperTest {
         Assertions.assertEquals(lqw.getSqlSegment(), "(`id` = #{ew.paramNameValuePairs.MPGENVAL1})");
     }
 
+    @Test
+    void testLambdaQueryByColumn() {
+        LambdaQueryWrapper lqw = Wrappers.<Table>lambdaQuery()
+            .eq(Table::getId, LambdaUtils.getColumnRef(Table::getRefId));
+        Assertions.assertEquals("(`id` = ref_id)", lqw.getSqlSegment());
+    }
+
 
     @Data
     @TableName("xxx")
@@ -48,5 +56,7 @@ class LambdaQueryWrapperTest extends BaseWrapperTest {
 
         @TableField("`name`")
         private Long name;
+
+        private Long refId;
     }
 }

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/LambdaUpdateWrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/LambdaUpdateWrapperTest.java
@@ -4,6 +4,7 @@ import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.baomidou.mybatisplus.core.metadata.TableInfo;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.core.toolkit.LambdaUtils;
 import com.baomidou.mybatisplus.test.User;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.junit.jupiter.api.Assertions;
@@ -117,4 +118,10 @@ class LambdaUpdateWrapperTest extends BaseWrapperTest {
         Assertions.assertEquals("role_id=role_id+2340", wrapper.getSqlSet());
     }
 
+    @Test
+    void testSetByAnotherColumn() {
+        LambdaUpdateWrapper<User> wrapper = new LambdaUpdateWrapper<>();
+        wrapper.set(User::getRoleId, LambdaUtils.getColumnRef(User::getId));
+        Assertions.assertEquals("role_id=id", wrapper.getSqlSet());
+    }
 }


### PR DESCRIPTION
## Add column reference for LambdaWrapper

We can use Lambda to refer a column in update and query.

- LambdaQueryWrapper condition with another column

```java
    @Test
    void testLambdaQueryByColumn() {
        // Query data that refers to itself.
        LambdaQueryWrapper lqw = Wrappers.<Table>lambdaQuery()
            .eq(Table::getId, LambdaUtils.getColumnRef(Table::getRefId));
        Assertions.assertEquals("(`id` = ref_id)", lqw.getSqlSegment());
    }
```

- LambdaUpdateWrapper set by another column

```java
    @Test
    void testSetByAnotherColumn() {
        LambdaUpdateWrapper<User> wrapper = new LambdaUpdateWrapper<>();
        // Logical delete flag by primary key to avoid unique key conflict.
        wrapper.set(User::getIsDelete, LambdaUtils.getColumnRef(User::getId));
        Assertions.assertEquals("is_delete=id", wrapper.getSqlSet());
    }
``` 