### PR TITLE
fix: 修复SqlServerQuery查询表描述乱码，已在SqlServer2017和SqlServer2019版本上面验证通过.

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/SqlServerQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/SqlServerQuery.java
@@ -29,7 +29,7 @@ public class SqlServerQuery extends AbstractDbQuery {
     @Override
     public String tablesSql() {
         return "select * from (select cast(so.name as varchar(500)) as TABLE_NAME, " +
-            "cast(sep.value as varchar(500)) as COMMENTS from sysobjects so " +
+            "cast(sep.value as nvarchar(500)) as COMMENTS from sysobjects so " +
             "left JOIN sys.extended_properties sep on sep.major_id=so.id and sep.minor_id=0 " +
             "where (xtype='U' or xtype='v')) a where 1=1 ";
     }


### PR DESCRIPTION
https://github.com/baomidou/mybatis-plus/issues/6334