### PR TITLE
添加condition方法，简化手动指定condition的重复工作

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
@@ -15,6 +15,8 @@
  */
 package com.baomidou.mybatisplus.core.conditions.interfaces;
 
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
+
 import java.io.Serializable;
 import java.util.Map;
 import java.util.function.BiPredicate;
@@ -105,6 +107,18 @@ public interface Compare<Children, R> extends Serializable {
     }
 
     /**
+     * 条件eq，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionEq(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return eq(condition, column, val);
+    }
+
+    /**
      * 等于 =
      *
      * @param condition 执行条件
@@ -123,6 +137,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children ne(R column, Object val) {
         return ne(true, column, val);
+    }
+
+    /**
+     * 条件ne，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionNe(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return ne(condition, column, val);
     }
 
     /**
@@ -147,6 +173,18 @@ public interface Compare<Children, R> extends Serializable {
     }
 
     /**
+     * 条件gt，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionGt(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return gt(condition, column, val);
+    }
+
+    /**
      * 大于 &gt;
      *
      * @param condition 执行条件
@@ -167,6 +205,17 @@ public interface Compare<Children, R> extends Serializable {
         return ge(true, column, val);
     }
 
+    /**
+     * 条件ge，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionGe(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return ge(condition, column, val);
+    }
     /**
      * 大于等于 &gt;=
      *
@@ -189,6 +238,18 @@ public interface Compare<Children, R> extends Serializable {
     }
 
     /**
+     * 条件lt，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionLt(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return lt(condition, column, val);
+    }
+
+    /**
      * 小于 &lt;
      *
      * @param condition 执行条件
@@ -207,6 +268,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children le(R column, Object val) {
         return le(true, column, val);
+    }
+
+    /**
+     * 条件le，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionLe(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return le(condition, column, val);
     }
 
     /**
@@ -278,6 +351,18 @@ public interface Compare<Children, R> extends Serializable {
     }
 
     /**
+     * 条件like，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionLike(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return like(condition, column, val);
+    }
+
+    /**
      * LIKE '%值%'
      *
      * @param condition 执行条件
@@ -296,6 +381,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children notLike(R column, Object val) {
         return notLike(true, column, val);
+    }
+
+    /**
+     * 条件notLike，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionNotLike(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return notLike(condition, column, val);
     }
 
     /**
@@ -320,6 +417,18 @@ public interface Compare<Children, R> extends Serializable {
     }
 
     /**
+     * 条件notLikeLeft，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionNotLikeLeft(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return notLikeLeft(condition, column, val);
+    }
+
+    /**
      * NOT LIKE '%值'
      *
      * @param condition 执行条件
@@ -338,6 +447,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children notLikeRight(R column, Object val) {
         return notLikeRight(true, column, val);
+    }
+
+    /**
+     * 条件notLikeRight，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionNotLikeRight(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return notLikeRight(condition, column, val);
     }
 
     /**
@@ -362,6 +483,18 @@ public interface Compare<Children, R> extends Serializable {
     }
 
     /**
+     * 条件leftLike，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionLikeLeft(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return likeLeft(condition, column, val);
+    }
+
+    /**
      * LIKE '%值'
      *
      * @param condition 执行条件
@@ -380,6 +513,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children likeRight(R column, Object val) {
         return likeRight(true, column, val);
+    }
+
+    /**
+     * 条件leftRight，默认使用StringUtils.checkValNotNull(val)作为condition
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children conditionLikeRight(R column, Object val) {
+        boolean condition = StringUtils.checkValNotNull(val);
+        return likeRight(condition, column, val);
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Func.java
@@ -15,6 +15,7 @@
  */
 package com.baomidou.mybatisplus.core.conditions.interfaces;
 
+import com.baomidou.mybatisplus.core.toolkit.ArrayUtils;
 import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 
 import java.io.Serializable;
@@ -89,6 +90,18 @@ public interface Func<Children, R> extends Serializable {
     }
 
     /**
+     * 条件in，默认使用CollectionUtils.isNotEmpty(coll)作为condition
+     *
+     * @param column 字段
+     * @param coll   数据集合
+     * @return children
+     */
+    default Children conditionIn(R column, Collection<?> coll) {
+        boolean condition = CollectionUtils.isNotEmpty(coll);
+        return in(condition, column, coll);
+    }
+
+    /**
      * 字段 IN (value.get(0), value.get(1), ...)
      * <p>例: in(true, "id", Arrays.asList(1, 2, 3, 4, 5))</p>
      *
@@ -115,6 +128,18 @@ public interface Func<Children, R> extends Serializable {
      */
     default Children in(R column, Object... values) {
         return in(true, column, values);
+    }
+
+    /**
+     * 条件in，默认使用ArrayUtils.isNotEmpty(values)作为condition
+     *
+     * @param column 字段
+     * @param values 数据数组
+     * @return children
+     */
+    default Children conditionIn(R column, Object... values) {
+        boolean condition = ArrayUtils.isNotEmpty(values);
+        return in(condition, column, values);
     }
 
     /**
@@ -147,6 +172,17 @@ public interface Func<Children, R> extends Serializable {
     }
 
     /**
+     * 条件in，默认使用CollectionUtils.isNotEmpty(values)作为condition
+     *
+     * @param column 字段
+     * @param coll coll
+     * @return children
+     */
+    default Children conditionNotIn(R column, Collection<?> coll) {
+        boolean condition = CollectionUtils.isNotEmpty(coll);
+        return notIn(condition, column, coll);
+    }
+    /**
      * 字段 NOT IN (value.get(0), value.get(1), ...)
      * <p>例: notIn(true, "id", Arrays.asList(1, 2, 3, 4, 5))</p>
      *
@@ -173,6 +209,18 @@ public interface Func<Children, R> extends Serializable {
      */
     default Children notIn(R column, Object... values) {
         return notIn(true, column, values);
+    }
+
+    /**
+     * 条件notIn，默认使用ArrayUtils.isNotEmpty(values)作为condition
+     *
+     * @param column 字段
+     * @param values 数据数组
+     * @return children
+     */
+    default Children conditionNotIn(R column, Object... values) {
+        boolean condition = ArrayUtils.isNotEmpty(values);
+        return notIn(condition, column, values);
     }
 
     /**

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/QueryWrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/QueryWrapperTest.java
@@ -99,6 +99,104 @@ class QueryWrapperTest extends BaseWrapperTest {
     }
 
     @Test
+    void testConditionCompareWhenCheckValIsNull() {
+        QueryWrapper<Entity> queryWrapper1 = new QueryWrapper<Entity>()
+            .conditionEq("id", null)
+            .conditionNe("id", null)
+            .or()
+            .conditionGt("id", null)
+            .conditionGe("id", null)
+            .conditionLt("id", null)
+            .conditionLe("id", null)
+            .or()
+            .conditionLike("id", null)
+            .conditionNotLike("id", null)
+            .conditionNotLikeLeft("id", null)
+            .conditionNotLikeRight("id", null)
+            .or()
+            .conditionLikeLeft("id", null)
+            .conditionLikeRight("id", null);
+        logSqlWhere("测试 Compare 下非字符val checkValIsNull的方法", queryWrapper1, "");
+        logParams(queryWrapper1);
+        QueryWrapper<Entity> queryWrapper2 = new QueryWrapper<Entity>()
+            .conditionEq("name", null)
+            .conditionNe("name", null)
+            .or()
+            .conditionGt("name", null)
+            .conditionGe("name", null)
+            .conditionLt("name", null)
+            .conditionLe("name", null)
+            .or()
+            .conditionLike("name", null)
+            .conditionNotLike("name", null)
+            .conditionNotLikeLeft("name", null)
+            .conditionNotLikeRight("name", null)
+            .or()
+            .conditionLikeLeft("name", null)
+            .conditionLikeRight("name", null);
+        logSqlWhere("测试 Compare 下字符类型val checkValIsNull的方法", queryWrapper2, "");
+        logParams(queryWrapper2);
+        QueryWrapper<Entity> queryWrapper3 = new QueryWrapper<Entity>()
+            .conditionEq("name", "")
+            .conditionNe("name", "")
+            .or()
+            .conditionGt("name", "")
+            .conditionGe("name", "")
+            .conditionLt("name", "")
+            .conditionLe("name", "")
+            .or()
+            .conditionLike("name", "")
+            .conditionNotLike("name", "")
+            .conditionNotLikeLeft("name", "")
+            .conditionNotLikeRight("name", "")
+            .or()
+            .conditionLikeLeft("name", "")
+            .conditionLikeRight("name", "");
+        logSqlWhere("测试 Compare 下字符val为空字符串 condition的方法", queryWrapper3, "");
+        logParams(queryWrapper3);
+    }
+
+    @Test
+    void testConditionCompareWhenCheckValNotNull() {
+        QueryWrapper<Entity> queryWrapper1 = new QueryWrapper<Entity>()
+            .conditionEq("id", 1)
+            .conditionNe("id", 1)
+            .or()
+            .conditionGt("id", 1)
+            .conditionGe("id", 1)
+            .conditionLt("id", 1)
+            .conditionLe("id", 1)
+            .or()
+            .conditionLike("id", 1)
+            .conditionNotLike("id", 1)
+            .conditionNotLikeLeft("id", 1)
+            .conditionNotLikeRight("id", 1)
+            .or()
+            .conditionLikeLeft("id", 1)
+            .conditionLikeRight("id", 1);
+        logSqlWhere("测试 Compare 下非字符val CheckValNotNull的方法", queryWrapper1, "(id = ? AND id <> ? OR id > ? AND id >= ? AND id < ? AND id <= ? OR id LIKE ? AND id NOT LIKE ? AND id NOT LIKE ? AND id NOT LIKE ? OR id LIKE ? AND id LIKE ?)");
+        logParams(queryWrapper1);
+        QueryWrapper<Entity> queryWrapper2 = new QueryWrapper<Entity>()
+            .conditionEq("name", "我不是名字")
+            .conditionNe("name", "我不是名字")
+            .or()
+            .conditionGt("name", "我不是名字")
+            .conditionGe("name", "我不是名字")
+            .conditionLt("name", "我不是名字")
+            .conditionLe("name", "我不是名字")
+            .or()
+            .conditionLike("name", "我不是名字")
+            .conditionNotLike("name", "我不是名字")
+            .conditionNotLikeLeft("name", "我不是名字")
+            .conditionNotLikeRight("name", "我不是名字")
+            .or()
+            .conditionLikeLeft("name", "我不是名字")
+            .conditionLikeRight("name", "我不是名字");
+        logSqlWhere("测试 Compare 下字符类型val checkValNotNull的方法", queryWrapper2, "(name = ? AND name <> ? OR name > ? AND name >= ? AND name < ? AND name <= ? OR name LIKE ? AND name NOT LIKE ? AND name NOT LIKE ? AND name NOT LIKE ? OR name LIKE ? AND name LIKE ?)");
+        logParams(queryWrapper2);
+    }
+
+    @Test
     void testFunc() {
         Entity entity = new Entity();
         QueryWrapper<Entity> queryWrapper = new QueryWrapper<Entity>()
@@ -114,6 +212,31 @@ class QueryWrapperTest extends BaseWrapperTest {
             .having("sum(age) > {0}", 1).having("id is not null")
             .func(entity.getId() != null, j -> j.eq("id", entity.getId()));// 不会npe,也不会加入sql
         logSqlWhere("测试 Func 下的方法", queryWrapper, "(nullColumn IS NULL OR notNullColumn IS NOT NULL AND inColl IN (?,?) OR notInColl NOT IN (?,?) AND inArray IN () AND notInArray NOT IN (?,?,?) AND eqSql = (1) AND inSql IN (1,2,3,4,5) AND inSql NOT IN (1,2,3,4,5) AND gtSql > (1,2,3,4,5) AND ltSql < (1,2,3,4,5) AND geSql >= (1,2,3,4,5) AND leSql <= (1,2,3,4,5)) GROUP BY id,name,id2,name2 HAVING sum(age) > ? AND id is not null ORDER BY id ASC,name DESC,name2 DESC");
+        logParams(queryWrapper);
+    }
+
+    @Test
+    void testConditionFuncWhenInConditionIsEmpty() {
+        Object[] emptyObjects = new Object[0];
+        QueryWrapper<Entity> queryWrapper = new QueryWrapper<Entity>()
+            .conditionIn("inColl", Collections.emptyList())
+            .or()
+            .conditionNotIn("notInColl", Collections.emptyList())
+            .conditionIn("inArray", emptyObjects)
+            .conditionNotIn("notInArray", emptyObjects);
+        logSqlWhere("测试 Func 下in条件isEmpty的conditionIn方法", queryWrapper, "");
+        logParams(queryWrapper);
+    }
+
+    @Test
+    void testConditionFuncWhenInConditionIsNotEmpty() {
+        QueryWrapper<Entity> queryWrapper = new QueryWrapper<Entity>()
+            .conditionIn("inColl", getList())
+            .or()
+            .conditionNotIn("notInColl", getList())
+            .conditionIn("inArray", 1, 2, 3)
+            .conditionNotIn("notInArray", 1, 2, 3, 4);
+        logSqlWhere("测试 Func 下in条件isNotEmpty的conditionIn方法", queryWrapper, "(inColl IN (?,?) OR notInColl NOT IN (?,?) AND inArray IN (?,?,?) AND notInArray NOT IN (?,?,?,?))");
         logParams(queryWrapper);
     }
 


### PR DESCRIPTION
在构建动态条件时经常会遇到以下场景
`QueryWrapper<Entity> queryWrapper = new QueryWrapper<Entity>()
            .eq(Objects.nonNull(entity.getId()), "id", entity.getId())
            .eq(StringUtils.isBlank(entity.getName()), "name", entity.getName());`
手动指定condition会有点繁琐，提供默认的方法，简化此步骤