### PR TITLE
租户拦截器 添加表名作为别名

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/TenantLineInnerInterceptor.java
@@ -235,6 +235,9 @@ public class TenantLineInnerInterceptor extends BaseMultiTableInnerInterceptor i
         // todo 该起别名就要起别名,禁止修改此处逻辑
         if (table.getAlias() != null) {
             column.append(table.getAlias().getName()).append(StringPool.DOT);
+        } else {
+            // 没有别名就取表名
+            column.append(table.getName()).append(StringPool.DOT);
         }
         column.append(tenantLineHandler.getTenantIdColumn());
         return new Column(column.toString());


### PR DESCRIPTION
A表 id code name tenant_id 字段， B表 id ,a_id ,tenant_id, age 字段

sql = select A.id, A.name, b.age from A left join B b on A.id = b.a_id 
这样的sql租户拦截器缺少别名，导致字段重复