### PR TITLE
fix: 修复 DataChangeRecorderInnerInterceptor.java 在新旧数据进行比对时，强转类型产生的异常

### DIFF
--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
@@ -286,7 +286,7 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
             updateValueExpressions.addAll(updateSet.getValues());
         }
         int removeParamCount = 0;
-        for (Expression expression : updateValueExpressions) {
+        for (Expression expression : Expressions) {
             if (expression instanceof JdbcParameter) {
                 ++removeParamCount;
             }
@@ -870,8 +870,8 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
                 }
                 if (originalValue instanceof Comparable) {
                     Comparable original = (Comparable) originalValue;
-                    Comparable update = (Comparable) updateValue;
                     try {
+                        Comparable update = (Comparable) updateValue;
                         return update == null || original.compareTo(update) != 0;
                     } catch (Exception e) {
                         return true;

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
@@ -286,7 +286,7 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
             updateValueExpressions.addAll(updateSet.getValues());
         }
         int removeParamCount = 0;
-        for (Expression expression : Expressions) {
+        for (Expression expression : updateValueExpressions) {
             if (expression instanceof JdbcParameter) {
                 ++removeParamCount;
             }


### PR DESCRIPTION
现只是将会抛出 `ClassCastException` 的位置放在了 try catch 里面，详见 #6562 
妥否，望同意该次pull