### PR TITLE
feat: 修改GlobalConfig的生成方法，由于目前无法在代码层面修改已加载后的GlobalConfig，所以做出这个修改

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/GlobalConfigUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/GlobalConfigUtils.java
@@ -45,6 +45,8 @@ public class GlobalConfigUtils {
      */
     private static final Map<String, GlobalConfig> GLOBAL_CONFIG = new ConcurrentHashMap<>();
 
+    private static final GlobalConfig GLOBAL = new GlobalConfig().setDbConfig(new GlobalConfig.DbConfig());
+
     /**
      * 获取当前的SqlSessionFactory
      *
@@ -63,7 +65,7 @@ public class GlobalConfigUtils {
      * 获取默认 MybatisGlobalConfig
      */
     public static GlobalConfig defaults() {
-        return new GlobalConfig().setDbConfig(new GlobalConfig.DbConfig());
+        return GLOBAL;
     }
 
     /**


### PR DESCRIPTION
这样就可以在ConfigurationCustomizer上去修改GlobalConfig，同时不会影响已加载的配置。
比如用到了mysql和oracle两种数据库，但是根据当前是有的数据库使用不同的字段包装符合，有一个 columnForamt的配置可以做到，但是由于这个配置在 `global-config` 中的 `db-config` 配置中，所以无法在代码中动态的根据当前的数据源进行修改。目前只能通过重新实例化 SqlSessionFacotry 的办法解决，但这样一来就会导致配置文件中的默认配置全部失效。
而 `SqlSessionFactoryBeanCustomizer` 虽然可以在原来已加载配置的基础上修改配置，但是由于设置 `globalConfig` 的方法在调用这个方法的后面，所以无法生效
![image](https://github.com/user-attachments/assets/02c13979-6b05-4787-ac71-f17ea37f52ba)

通过修改GlobalConfigUtils中的defaults方法可以让`global-config`对象全局唯一，这样在 `SqlSessionFactoryBeanCustomizer` 的修改的配置不会被后面的代码覆盖