### PR TITLE
修复SqlRunner.db().insert 或者 update 的value中含有单引号会报错

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/StringEscape.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/sql/StringEscape.java
@@ -147,10 +147,21 @@ public class StringEscape {
      * @return 转义后的字符串
      */
     public static String escapeString(String escapeStr) {
+        // 处理空字符串
+        if (escapeStr == null || escapeStr.isEmpty()) {
+            return "''";
+        }
+
+        // 先移除开头和结尾的单引号（如果有）
         if (escapeStr.matches("\'(.+)\'")) {
             escapeStr = escapeStr.substring(1, escapeStr.length() - 1);
         }
-        return "\'" + escapeRawString(escapeStr) + "\'";
+
+        // 使用更安全的转义处理，确保反斜杠和单引号被正确处理
+        String escaped = escapeRawString(escapeStr);
+
+        // 返回带单引号的结果
+        return "\'" + escaped + "\'";
     }
 
 }


### PR DESCRIPTION
修复  #6666 
问题描述
使用SqlRunner.db().insert 或者 update 的value中含有单引号会报错；如果使用BaseMapper中的insert 和update 则正常。
报错原因：没有转义。
程序没有硬拼Sql，而是使用的{0},{1}这种占位符，期望-使用占位符传参应该与Xml中使用#{var}这种逻辑一致；
