### PR TITLE
fix(extension): 修复 Db 类 count 方法返回值为空时的异常

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/Db.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/toolkit/Db.java
@@ -346,7 +346,8 @@ public class Db {
      * @param queryWrapper 实体对象封装操作类 {@link com.baomidou.mybatisplus.core.conditions.query.QueryWrapper}
      */
     public static <T> long count(AbstractWrapper<T, ?, ?> queryWrapper) {
-        return SqlHelper.execute(getEntityClass(queryWrapper), baseMapper -> baseMapper.selectCount(queryWrapper));
+         Long count = SqlHelper.execute(getEntityClass(queryWrapper), baseMapper -> baseMapper.selectCount(queryWrapper));
+         return count == null ? 0L : count;
     }
 
     /**

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/toolkit/DbTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/toolkit/DbTest.java
@@ -280,6 +280,12 @@ class DbTest extends BaseDbTest<EntityMapper> {
         Assertions.assertEquals("ruben", name);
     }
 
+    @Test
+    void count() {
+        long count = Db.count(Wrappers.lambdaQuery(Entity.class).eq(Entity::getName, UUID.randomUUID().toString()));
+        Assertions.assertSame(0L, count);
+    }
+
 
     @Override
     protected String tableDataSql() {


### PR DESCRIPTION
fix: Db.count in extension module produce NullPointerException when query wrapper hit no rows