### PR TITLE
security: remove sensitive credentials

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,2 @@
 APP_VERSION=3.5.13-SNAPSHOT
 APP_GROUP=com.baomidou
-signing.keyId=1FD337F9
-signing.password=243194995
-signing.secretKeyRingFile=/home/nieqiurong/signing.gpg
-#signing.secretKeyRingFile=/Users/ming/Documents/signing.gpg


### PR DESCRIPTION
`signing` configurations should not be pushed to public. And we have already set `key` and `password` in GitHub actions secrets. 
```
      - name: Publish
        run: ./gradlew publish -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
```
So it's safe to remove

### don't forget to change password as it already exposed a long time.