### PR TITLE
feat：增强kotlin的BaseMapper语法糖以及dsl写法

### DIFF
--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/AbstractKtWrapper.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/AbstractKtWrapper.kt
@@ -31,7 +31,10 @@ import kotlin.reflect.KProperty1
  * @since 2018-11-07
  */
 @Suppress("serial")
-abstract class AbstractKtWrapper<T, Children : AbstractKtWrapper<T, Children>> : AbstractWrapper<T, KProperty1<in T, *>, Children>() {
+abstract class AbstractKtWrapper<T, Children : AbstractKtWrapper<T, Children>> :
+    AbstractWrapper<T, KProperty1<in T, *>, Children>(),
+    CompareDsl<Children, T>,
+    FuncDsl<Children, T> {
 
     /**
      * 列 Map

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/BaseMapperExt.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/BaseMapperExt.kt
@@ -1,0 +1,93 @@
+package com.baomidou.mybatisplus.extension.kotlin
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper
+import com.baomidou.mybatisplus.core.metadata.IPage
+import org.apache.ibatis.session.ResultHandler
+import kotlin.apply
+
+/**
+ * @Author lidiwei
+ * @CreateTime 2025/7/31 10:13
+ */
+
+inline fun <reified T : Any> BaseMapper<T>.delete(noinline build: (KtQueryWrapper<T>.() -> Unit)? = null): Int =
+    this.delete(build.toKtQueryWrapper())
+
+inline fun <reified T : Any> BaseMapper<T>.update(
+    entity: T? = null,
+    noinline build: (KtUpdateWrapper<T>.() -> Unit)? = null
+): Int =
+    this.update(entity, build.toKtUpdateWrapper())
+
+inline fun <reified T : Any> BaseMapper<T>.update(noinline build: (KtUpdateWrapper<T>.() -> Unit)? = null): Int =
+    this.update(build.toKtUpdateWrapper())
+
+inline fun <reified T : Any> BaseMapper<T>.selectOne(
+    throwEx: Boolean = true,
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+): T? =
+    this.selectOne(build.toKtQueryWrapper(), throwEx)
+
+inline fun <reified T : Any> BaseMapper<T>.exists(noinline build: (KtQueryWrapper<T>.() -> Unit)? = null): Boolean =
+    this.exists(build.toKtQueryWrapper())
+
+inline fun <reified T : Any> BaseMapper<T>.selectCount(noinline build: (KtQueryWrapper<T>.() -> Unit)? = null): Long =
+    this.selectCount(build.toKtQueryWrapper())
+
+inline fun <reified T : Any> BaseMapper<T>.selectList(noinline build: (KtQueryWrapper<T>.() -> Unit)? = null): List<T> =
+    this.selectList(build.toKtQueryWrapper())
+
+
+inline fun <reified T : Any> BaseMapper<T>.selectList(
+    page: IPage<T>,
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+): List<T> =
+    this.selectList(page, build.toKtQueryWrapper())
+
+inline fun <reified T : Any> BaseMapper<T>.selectList(
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+    resultHandler: ResultHandler<T>
+) = this.selectList(build.toKtQueryWrapper(), resultHandler)
+
+inline fun <reified T : Any> BaseMapper<T>.selectList(
+    page: IPage<T>,
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+    resultHandler: ResultHandler<T>
+) = this.selectList(page, build.toKtQueryWrapper(), resultHandler)
+
+inline fun <reified T : Any> BaseMapper<T>.selectMaps(
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+): List<Map<String, Any>> = this.selectMaps(build.toKtQueryWrapper())
+
+inline fun <reified T : Any> BaseMapper<T>.selectMaps(
+    page: IPage<Map<String, Any>>? = null,
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+): List<Map<String, Any>> = this.selectMaps(page, build.toKtQueryWrapper())
+
+inline fun <reified T : Any> BaseMapper<T>.selectMaps(
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+    resultHandler: ResultHandler<Map<String, Any>>
+) = this.selectMaps(build.toKtQueryWrapper(), resultHandler)
+
+inline fun <reified T : Any> BaseMapper<T>.selectMaps(
+    page: IPage<Map<String, Any>>? = null,
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+    resultHandler: ResultHandler<Map<String, Any>>
+) = this.selectMaps(page, build.toKtQueryWrapper(), resultHandler)
+
+inline fun <reified T : Any, P : IPage<Map<String, Any>>> BaseMapper<T>.selectMapsPage(
+    page: P? = null,
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+) = this.selectMapsPage(page, build.toKtQueryWrapper())
+
+inline fun <reified T : Any> BaseMapper<T>.selectPage(
+    page: IPage<T>,
+    noinline build: (KtQueryWrapper<T>.() -> Unit)? = null,
+): IPage<T> =
+    this.selectPage(page, build.toKtQueryWrapper())
+
+inline fun <reified T : Any> (KtQueryWrapper<T>.() -> Unit)?.toKtQueryWrapper() =
+    this?.let { buildKtQueryWrapper<T>().apply(it) }
+
+inline fun <reified T : Any> (KtUpdateWrapper<T>.() -> Unit)?.toKtUpdateWrapper() =
+    this?.let { buildKtUpdateWrapper<T>().apply(it) }

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/CompareDsl.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/CompareDsl.kt
@@ -1,0 +1,30 @@
+package com.baomidou.mybatisplus.extension.kotlin
+
+import com.baomidou.mybatisplus.core.conditions.interfaces.Compare
+import kotlin.reflect.KProperty1
+
+/**
+ * @Author lidiwei
+ * @CreateTime 2025/7/31 16:18
+ */
+interface CompareDsl<Children, T> : Compare<Children, KProperty1<in T, *>> {
+
+    infix fun <V> KProperty1<in T, V>.eq(value: V?) = this@CompareDsl.eq(this, value)
+    infix fun <V> KProperty1<in T, V>.ne(value: V?) = this@CompareDsl.ne(this, value)
+    infix fun <V> KProperty1<in T, V>.gt(value: V?) = this@CompareDsl.gt(this, value)
+    infix fun <V> KProperty1<in T, V>.ge(value: V?) = this@CompareDsl.ge(this, value)
+    infix fun <V> KProperty1<in T, V>.lt(value: V?) = this@CompareDsl.lt(this, value)
+    infix fun <V> KProperty1<in T, V>.le(value: V?) = this@CompareDsl.le(this, value)
+    infix fun <A, B> KProperty1<in T, *>.between(value: Pair<A, B>) =
+        this@CompareDsl.between(this, value.first, value.second)
+
+    infix fun <A, B> KProperty1<in T, *>.notBetween(value: Pair<A, B>) =
+        this@CompareDsl.notBetween(this, value.first, value.second)
+
+    infix fun <V> KProperty1<in T, V>.like(value: V?) = this@CompareDsl.like(this, value)
+    infix fun <V> KProperty1<in T, V>.notLike(value: V?) = this@CompareDsl.notLike(this, value)
+    infix fun <V> KProperty1<in T, V>.likeLeft(value: V?) = this@CompareDsl.likeLeft(this, value)
+    infix fun <V> KProperty1<in T, V>.notLikeLeft(value: V?) = this@CompareDsl.notLikeLeft(this, value)
+    infix fun <V> KProperty1<in T, V>.likeRight(value: V?) = this@CompareDsl.likeRight(this, value)
+    infix fun <V> KProperty1<in T, V>.notLikeRight(value: V?) = this@CompareDsl.notLikeRight(this, value)
+}

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/DbExt.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/DbExt.kt
@@ -1,0 +1,15 @@
+package com.baomidou.mybatisplus.extension.kotlin
+
+import com.baomidou.mybatisplus.extension.toolkit.Db
+import kotlin.reflect.KClass
+
+/**
+ * @Author lidiwei
+ * @CreateTime 2025/7/31 16:15
+ */
+
+inline fun <reified T : Any> ktQuery(query: KtQueryChainWrapper<T>.() -> Unit): KtQueryChainWrapper<T> =
+    Db.ktQuery<T>(T::class.java).apply(query)
+
+inline fun <reified T : KClass<*>> T.ktQuery(query: KtQueryChainWrapper<T>.() -> Unit): KtQueryChainWrapper<T> =
+    Db.ktQuery<T>(T::class.java).apply(query)

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/DbExt.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/DbExt.kt
@@ -11,5 +11,5 @@ import kotlin.reflect.KClass
 inline fun <reified T : Any> ktQuery(query: KtQueryChainWrapper<T>.() -> Unit): KtQueryChainWrapper<T> =
     Db.ktQuery<T>(T::class.java).apply(query)
 
-inline fun <reified T : KClass<*>> T.ktQuery(query: KtQueryChainWrapper<T>.() -> Unit): KtQueryChainWrapper<T> =
+inline fun <reified T : Any, C : KClass<T>> C.ktQuery(query: KtQueryChainWrapper<T>.() -> Unit): KtQueryChainWrapper<T> =
     Db.ktQuery<T>(T::class.java).apply(query)

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/DbExt.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/DbExt.kt
@@ -8,8 +8,8 @@ import kotlin.reflect.KClass
  * @CreateTime 2025/7/31 16:15
  */
 
-inline fun <reified T : Any> ktQuery(query: KtQueryChainWrapper<T>.() -> Unit): KtQueryChainWrapper<T> =
-    Db.ktQuery<T>(T::class.java).apply(query)
+inline fun <reified T : Any> ktQuery(noinline query: (KtQueryChainWrapper<T>.() -> Unit)? = null): KtQueryChainWrapper<T> =
+    Db.ktQuery<T>(T::class.java).also { query?.invoke(it) }
 
-inline fun <reified T : Any, C : KClass<T>> C.ktQuery(query: KtQueryChainWrapper<T>.() -> Unit): KtQueryChainWrapper<T> =
-    Db.ktQuery<T>(T::class.java).apply(query)
+inline fun <reified T : Any, C : KClass<T>> C.ktQuery(noinline query: (KtQueryChainWrapper<T>.() -> Unit)? = null): KtQueryChainWrapper<T> =
+    Db.ktQuery<T>(T::class.java).also { query?.invoke(it) }

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/FuncDsl.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/FuncDsl.kt
@@ -1,0 +1,23 @@
+package com.baomidou.mybatisplus.extension.kotlin
+
+import com.baomidou.mybatisplus.core.conditions.interfaces.Func
+import kotlin.reflect.KProperty1
+
+/**
+ * @Author lidiwei
+ * @CreateTime 2025/7/31 16:20
+ */
+interface FuncDsl<Children, T> : Func<Children, KProperty1<in T, *>> {
+    val KProperty1<in T, *>.isNull: Children?
+        get() = this@FuncDsl.isNull(this)
+
+    val KProperty1<in T, *>.isNotNull: Children?
+        get() = this@FuncDsl.isNotNull(this)
+
+    infix fun KProperty1<in T, *>.isIn(coll: Collection<*>?) = this@FuncDsl.`in`(this, coll)
+    infix fun KProperty1<in T, *>.isIn(array: Array<*>) = this@FuncDsl.`in`(this, array)
+
+    infix fun KProperty1<in T, *>.isNotIn(coll: Collection<*>?) = this@FuncDsl.notIn(this, coll)
+    infix fun KProperty1<in T, *>.isNotIn(array: Array<*>) = this@FuncDsl.notIn(this, array)
+
+}

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtQueryChainWrapper.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtQueryChainWrapper.kt
@@ -31,7 +31,9 @@ import kotlin.reflect.KProperty1
 open class KtQueryChainWrapper<T : Any>(
     internal val baseMapper: BaseMapper<T>?
 ) : AbstractChainWrapper<T, KProperty1<in T, *>, KtQueryChainWrapper<T>, KtQueryWrapper<T>>(),
-    ChainQuery<T>, Query<KtQueryChainWrapper<T>, T, KProperty1<in T, *>> {
+    ChainQuery<T>, Query<KtQueryChainWrapper<T>, T, KProperty1<in T, *>>,
+    CompareDsl<KtQueryChainWrapper<T>, T>,
+    FuncDsl<KtQueryChainWrapper<T>, T> {
 
     constructor(baseMapper: BaseMapper<T>, entityClass: Class<T>) : this(baseMapper) {
         super.wrapperChildren = KtQueryWrapper(entityClass)

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtQueryWrapper.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtQueryWrapper.kt
@@ -24,6 +24,7 @@ import com.baomidou.mybatisplus.core.toolkit.CollectionUtils
 import com.baomidou.mybatisplus.core.toolkit.support.ColumnCache
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Predicate
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 
 /**
@@ -39,6 +40,11 @@ open class KtQueryWrapper<T : Any> : AbstractKtWrapper<T, KtQueryWrapper<T>>, Qu
      * 查询字段
      */
     private var sqlSelect: SharedString = SharedString()
+
+    constructor(entity: KClass<T>) {
+        this.entityClass = entity.java
+        super.initNeed()
+    }
 
     constructor(entity: T) {
         this.entity = entity

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtUpdateWrapper.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/KtUpdateWrapper.kt
@@ -26,6 +26,7 @@ import com.baomidou.mybatisplus.core.toolkit.support.ColumnCache
 import java.math.BigDecimal
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.stream.Collectors.joining
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 
 /**
@@ -41,6 +42,11 @@ open class KtUpdateWrapper<T : Any> : AbstractKtWrapper<T, KtUpdateWrapper<T>>, 
      * SQL 更新字段内容，例如：name='1', age=2
      */
     private val sqlSet = ArrayList<String>()
+
+    constructor(entity: KClass<T>) {
+        this.entityClass = entity.java
+        super.initNeed()
+    }
 
     constructor(entity: T) {
         this.entity = entity

--- a/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/WrapperExt.kt
+++ b/mybatis-plus-extension/src/main/kotlin/com/baomidou/mybatisplus/extension/kotlin/WrapperExt.kt
@@ -1,0 +1,10 @@
+package com.baomidou.mybatisplus.extension.kotlin
+
+/**
+ * @Author lidiwei
+ * @CreateTime 2025/7/31 18:09
+ */
+
+inline fun <reified T : Any> buildKtQueryWrapper(): KtQueryWrapper<T> = KtQueryWrapper(T::class)
+
+inline fun <reified T : Any> buildKtUpdateWrapper(): KtUpdateWrapper<T> = KtUpdateWrapper(T::class)


### PR DESCRIPTION
增加BaseMapper 下所有AbstractWrapper 相关的方法的语法糖，如下，已有逻辑不改变。

新增类
BaseMapperExt.kt
CompareDsl.kt
DbExt.kt
FuncDsl.kt
WrapperExt.kt

`

val user: User? = selectOne {
            eq(User::id, id)

            User::id eq id
            User::id ne id
            User::id le id
            User::id lt id
            User::id ge id
            User::id gt id

            User::id between ("2025-01-01 00:00:00" to "2025-01-01 23:23:59")

            User::name like "baomidou"
            User::name notLike "baomidou"
            User::name likeLeft "baomidou"
            User::name notLikeLeft "baomidou"
            User::name notLikeRight "baomidou"

            User::id.isNull
            User::id.isNotNull
            User::name isIn arrayOf("baomidou")
            User::name isIn listOf("baomidou")
            User::name isNotIn arrayOf("baomidou")
            User::name isNotIn listOf("baomidou")
        }

        val user2: User? =User::class.ktQuery {
            User::id eq id
            User::id ne id
        }.one()

        val user3: User? = ktQuery<User> {
            User::id eq id
            User::id ne id
            User::id le id
            User::id lt id
            User::id ge id
            User::id gt id

            User::id between ("2025-01-01 00:00:00" to "2025-01-01 23:23:59")

            User::name like "%baomidou%"
            User::name notLike "%baomidou%"
            User::name likeLeft "%baomidou%"
            User::name notLikeLeft "%baomidou%"
            User::name notLikeRight "%baomidou%"

            User::id.isNull
            User::id.isNotNull
            User::name isIn arrayOf("%baomidou%")
            User::name isIn listOf("%baomidou%")
            User::name isNotIn arrayOf("%baomidou%")
            User::name isNotIn listOf("%baomidou%")
        }.one()   

`