### PR TITLE
崖山数据库 更新为 Oracle 类型

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -281,14 +281,14 @@ public enum DbType {
             || this == DbType.OCEAN_BASE
             || this == DbType.CUBRID
             || this == DbType.SUNDB
-            || this == DbType.GOLDENDB
-            || this == DbType.YASDB;
+            || this == DbType.GOLDENDB;
     }
 
     public boolean oracleSameType() {
         return this == DbType.ORACLE
             || this == DbType.DM
-            || this == DbType.GAUSS;
+            || this == DbType.GAUSS
+            || this == DbType.YASDB;
     }
 
     public boolean postgresqlSameType() {


### PR DESCRIPTION

崖山数据库 归类到 Oracle 的数据库, 而不是Mysql. 这数据有两种模式, 
1. yashan模式（同Oracle）
2. mysql模式    - 需要另开端口连接

Mysql 模式仅在单机模式下和MySQL5.7的语法兼容, 想要完全使用崖山数据库应该是使用yashan模式（同Oracle）.

并且在分页上和Oracle一样有着这样的字段: ROWNUM, ROWID.

并且如果是 Mysql 模式的连接,  则直接可以使用 DbType.MYSQL, URL也可以使用: jdbc:mysql:// 

- [参考官网文档](https://doc.yashandb.com/yashandb/23.4/zh/mysql-Mode-Refrence/Overview-of-mysql-Mode.html)
- [官方关于兼容mysql模式数据库连接](https://doc.yashandb.com/yashandb/23.4/zh/mysql-Mode-Refrence/Connection-of-mysql-Mode.html)

<img width="1809" height="1029" alt="image" src="https://github.com/user-attachments/assets/ca396389-8d9c-40b6-8328-8ce4681becbb" />
<img width="1988" height="1796" alt="image" src="https://github.com/user-attachments/assets/0dbd5219-72f0-4af5-a6a3-e63d510af025" />


