### PR TITLE
fix:Jackson3TypeHandler

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/handlers/Jackson3TypeHandler.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/handlers/Jackson3TypeHandler.java
@@ -40,7 +40,7 @@ public class Jackson3TypeHandler extends AbstractJsonTypeHandler<Object> {
     }
 
     public static ObjectMapper getObjectMapper() {
-        return OBJECT_MAPPER == null ? Instance.OBJECT_MAPPER: new ObjectMapper();
+        return OBJECT_MAPPER == null ? Instance.OBJECT_MAPPER: OBJECT_MAPPER;
     }
 
     public static void setObjectMapper(ObjectMapper objectMapper) {


### PR DESCRIPTION
修复 判断错误导致永远new一个新的，导致项目自定义的ObjectMapper没生效