### PR TITLE
fix: 将mpw:加密数据放入系统环境变量读取失败

### DIFF
--- a/spring-boot-starter/mybatis-plus-spring-boot-autoconfigure/src/main/java/com/baomidou/mybatisplus/autoconfigure/SafetyEncryptProcessor.java
+++ b/spring-boot-starter/mybatis-plus-spring-boot-autoconfigure/src/main/java/com/baomidou/mybatisplus/autoconfigure/SafetyEncryptProcessor.java
@@ -50,8 +50,9 @@ public class SafetyEncryptProcessor implements EnvironmentPostProcessor {
                         Object value = source.getProperty(name);
                         if (value instanceof String) {
                             String str = (String) value;
-                            if (str.startsWith("mpw:")) {
-                                map.put(name, AES.decrypt(str.substring(4), mpwKey));
+                            String resolvedValue = environment.resolveRequiredPlaceholders(str);
+                            if (resolvedValue.startsWith("mpw:")) {
+                                map.put(name, AES.decrypt(resolvedValue.substring(4), mpwKey));
                             }
                         }
                     }


### PR DESCRIPTION
将mpw:加密数据放入到系统环境变量未先进行系统环境变量值读取会导致读取的数据为占位符标识
例如url:${EVN_URL}，读取到的数据则就是${EVN_URL}导致数据库驱动加载链接失败
#7012 