### PR TITLE
Fix/localdatetime millisecond precision

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/handlers/LocalDateTimeTypeHandler.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/handlers/LocalDateTimeTypeHandler.java
@@ -1,0 +1,37 @@
+package com.baomidou.mybatisplus.core.handlers;
+
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeHandler;
+
+import java.sql.*;
+import java.time.LocalDateTime;
+
+public class LocalDateTimeTypeHandler implements TypeHandler<LocalDateTime> {
+
+    @Override
+    public void setParameter(PreparedStatement ps, int i, LocalDateTime parameter, JdbcType jdbcType) throws SQLException {
+        if (parameter == null) {
+            ps.setNull(i, Types.TIMESTAMP);
+        } else {
+            ps.setTimestamp(i, Timestamp.valueOf(parameter));
+        }
+    }
+
+    @Override
+    public LocalDateTime getResult(ResultSet rs, String columnName) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnName);
+        return timestamp != null ? timestamp.toLocalDateTime() : null;
+    }
+
+    @Override
+    public LocalDateTime getResult(ResultSet rs, int columnIndex) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnIndex);
+        return timestamp != null ? timestamp.toLocalDateTime() : null;
+    }
+
+    @Override
+    public LocalDateTime getResult(CallableStatement cs, int columnIndex) throws SQLException {
+        Timestamp timestamp = cs.getTimestamp(columnIndex);
+        return timestamp != null ? timestamp.toLocalDateTime() : null;
+    }
+}

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/handlers/LocalDateTimeTypeHandlerTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/handlers/LocalDateTimeTypeHandlerTest.java
@@ -1,0 +1,100 @@
+package com.baomidou.mybatisplus.core.handlers;
+
+import org.apache.ibatis.type.JdbcType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.*;
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * LocalDateTimeTypeHandler 单元测试
+ *
+ * @author mybatis-plus
+ */
+@ExtendWith(MockitoExtension.class)
+public class LocalDateTimeTypeHandlerTest {
+
+    private static final LocalDateTimeTypeHandler HANDLER = new LocalDateTimeTypeHandler();
+
+    @Test
+    public void setParameterNull() throws SQLException {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        HANDLER.setParameter(ps, 1, null, JdbcType.TIMESTAMP);
+        verify(ps).setNull(1, Types.TIMESTAMP);
+    }
+
+    @Test
+    public void setParameterWithLocalDateTime() throws SQLException {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        LocalDateTime dateTime = LocalDateTime.of(2023, 12, 25, 10, 30, 45, 123456789);
+        HANDLER.setParameter(ps, 1, dateTime, JdbcType.TIMESTAMP);
+        Timestamp expectedTimestamp = Timestamp.valueOf(dateTime);
+        verify(ps).setTimestamp(1, expectedTimestamp);
+    }
+
+    @Test
+    public void setParameterWithMillisecondPrecision() throws SQLException {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        // 测试毫秒精度
+        LocalDateTime dateTime = LocalDateTime.of(2023, 12, 25, 10, 30, 45, 123000000);
+        HANDLER.setParameter(ps, 1, dateTime, JdbcType.TIMESTAMP);
+        verify(ps).setTimestamp(1, Timestamp.valueOf(dateTime));
+    }
+
+    @Test
+    public void getResultFromResultSetByColumnNameNull() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getTimestamp("column")).thenReturn(null);
+        LocalDateTime result = HANDLER.getResult(rs, "column");
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void getResultFromResultSetByColumnName() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        Timestamp timestamp = Timestamp.valueOf(LocalDateTime.of(2023, 12, 25, 10, 30, 45, 123000000));
+        when(rs.getTimestamp("column")).thenReturn(timestamp);
+        LocalDateTime result = HANDLER.getResult(rs, "column");
+        Assertions.assertEquals(LocalDateTime.of(2023, 12, 25, 10, 30, 45, 123000000), result);
+    }
+
+    @Test
+    public void getResultFromResultSetByColumnIndexNull() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getTimestamp(1)).thenReturn(null);
+        LocalDateTime result = HANDLER.getResult(rs, 1);
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void getResultFromResultSetByColumnIndex() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        Timestamp timestamp = Timestamp.valueOf(LocalDateTime.of(2023, 12, 25, 10, 30, 45, 456000000));
+        when(rs.getTimestamp(1)).thenReturn(timestamp);
+        LocalDateTime result = HANDLER.getResult(rs, 1);
+        Assertions.assertEquals(LocalDateTime.of(2023, 12, 25, 10, 30, 45, 456000000), result);
+    }
+
+    @Test
+    public void getResultFromCallableStatementNull() throws SQLException {
+        CallableStatement cs = mock(CallableStatement.class);
+        when(cs.getTimestamp(1)).thenReturn(null);
+        LocalDateTime result = HANDLER.getResult(cs, 1);
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void getResultFromCallableStatement() throws SQLException {
+        CallableStatement cs = mock(CallableStatement.class);
+        Timestamp timestamp = Timestamp.valueOf(LocalDateTime.of(2023, 12, 25, 10, 30, 45, 789000000));
+        when(cs.getTimestamp(1)).thenReturn(timestamp);
+        LocalDateTime result = HANDLER.getResult(cs, 1);
+        Assertions.assertEquals(LocalDateTime.of(2023, 12, 25, 10, 30, 45, 789000000), result);
+    }
+
+}


### PR DESCRIPTION
### 修复问题
LocalDateTime类型转换器在存储到数据库时丢失毫秒精度，只能保存到秒级。
### 修复方案
1. 修改`LocalDateTimeTypeHandler`的`setParameter`方法，直接使用`Timestamp.valueOf(parameter)`设置参数，避免字符串转换丢失毫秒
2. 优化`getResult`方法，直接从`Timestamp`转换为`LocalDateTime`，保留完整精度
3. 添加单元测试验证毫秒级时间的存储和读取
### 测试验证
- ✅ 新增单元测试覆盖毫秒精度场景
- ✅ 所有现有测试用例全部通过
- ✅ 手动验证MySQL 8.0环境下毫秒精度存储正常
关联Issue: #5912