### PR TITLE
feat(generator): add table field meta info customizer

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/ITableFieldMetaInfoCustomizer.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/ITableFieldMetaInfoCustomizer.java
@@ -1,0 +1,22 @@
+package com.baomidou.mybatisplus.generator;
+
+import com.baomidou.mybatisplus.generator.config.po.TableField;
+import com.baomidou.mybatisplus.generator.config.po.TableInfo;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Customizes generator field metadata after type conversion and before templates render.
+ *
+ * @since 3.5.18
+ */
+@FunctionalInterface
+public interface ITableFieldMetaInfoCustomizer {
+
+    /**
+     * Customize current field metadata.
+     *
+     * @param tableInfo current table info
+     * @param tableField current field info, including {@link TableField.MetaInfo}
+     */
+    void customize(@NotNull TableInfo tableInfo, @NotNull TableField tableField);
+}

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Entity.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Entity.java
@@ -24,6 +24,7 @@ import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.generator.DefaultTableAnnotationHandler;
 import com.baomidou.mybatisplus.generator.DefaultTableFieldAnnotationHandler;
 import com.baomidou.mybatisplus.generator.IFill;
+import com.baomidou.mybatisplus.generator.ITableFieldMetaInfoCustomizer;
 import com.baomidou.mybatisplus.generator.ITableAnnotationHandler;
 import com.baomidou.mybatisplus.generator.ITableFieldAnnotationHandler;
 import com.baomidou.mybatisplus.generator.ITemplate;
@@ -190,6 +191,14 @@ public class Entity implements ITemplate {
      * 表填充字段
      */
     private final List<IFill> tableFillList = new ArrayList<>();
+
+    /**
+     * Field meta info customizers.
+     *
+     * @since 3.5.18
+     */
+    @Getter
+    private final List<ITableFieldMetaInfoCustomizer> tableFieldMetaInfoCustomizers = new ArrayList<>();
 
     /**
      * 数据库表映射到实体的命名策略，默认下划线转驼峰命名
@@ -463,6 +472,17 @@ public class Entity implements ITemplate {
         return data;
     }
 
+    /**
+     * Customize field meta info.
+     *
+     * @param tableInfo current table info
+     * @param tableField current table field
+     * @since 3.5.18
+     */
+    public void handleTableFieldMetaInfo(@NotNull TableInfo tableInfo, @NotNull com.baomidou.mybatisplus.generator.config.po.TableField tableField) {
+        tableFieldMetaInfoCustomizers.forEach(customizer -> customizer.customize(tableInfo, tableField));
+    }
+
     public static class Builder extends BaseBuilder {
 
         private final Entity entity = new Entity();
@@ -731,6 +751,29 @@ public class Entity implements ITemplate {
          */
         public Builder addTableFills(@NotNull List<IFill> tableFillList) {
             this.entity.tableFillList.addAll(tableFillList);
+            return this;
+        }
+
+        /**
+         * Add table field meta info customizers.
+         *
+         * @param customizers customizers
+         * @return this
+         * @since 3.5.18
+         */
+        public Builder addTableFieldMetaInfoCustomizers(@NotNull ITableFieldMetaInfoCustomizer... customizers) {
+            return addTableFieldMetaInfoCustomizers(Arrays.asList(customizers));
+        }
+
+        /**
+         * Add table field meta info customizers.
+         *
+         * @param customizers customizer list
+         * @return this
+         * @since 3.5.18
+         */
+        public Builder addTableFieldMetaInfoCustomizers(@NotNull List<ITableFieldMetaInfoCustomizer> customizers) {
+            this.entity.tableFieldMetaInfoCustomizers.addAll(customizers);
             return this;
         }
 

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
@@ -530,36 +530,80 @@ public class TableField {
             return tableName;
         }
 
+        public void setTableName(String tableName) {
+            this.tableName = tableName;
+        }
+
         public String getColumnName() {
             return columnName;
+        }
+
+        public void setColumnName(String columnName) {
+            this.columnName = columnName;
         }
 
         public int getLength() {
             return length;
         }
 
+        public void setLength(int length) {
+            this.length = length;
+        }
+
         public boolean isNullable() {
             return nullable;
+        }
+
+        public void setNullable(boolean nullable) {
+            this.nullable = nullable;
         }
 
         public String getRemarks() {
             return remarks;
         }
 
+        public void setRemarks(String remarks) {
+            this.remarks = remarks;
+        }
+
         public String getDefaultValue() {
             return defaultValue;
+        }
+
+        public void setDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
         }
 
         public int getScale() {
             return scale;
         }
 
+        public void setScale(int scale) {
+            this.scale = scale;
+        }
+
         public JdbcType getJdbcType() {
             return jdbcType;
         }
 
+        public void setJdbcType(JdbcType jdbcType) {
+            this.jdbcType = jdbcType;
+        }
+
         public String getTypeName() {
             return typeName;
+        }
+
+        public void setTypeName(String typeName) {
+            this.typeName = typeName;
+        }
+
+        public boolean isGeneratedColumn() {
+            return generatedColumn;
+        }
+
+        public void setGeneratedColumn(boolean generatedColumn) {
+            this.generatedColumn = generatedColumn;
         }
 
         @Override

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/query/DefaultQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/query/DefaultQuery.java
@@ -129,8 +129,9 @@ public class DefaultQuery extends AbstractDatabaseQuery {
                 columnType = typeRegistry.getColumnType(metaInfo);
             }
             field.setColumnName(columnName).setColumnType(columnType).setComment(columnInfo.getRemarks()).setMetaInfo(metaInfo);
+            entity.handleTableFieldMetaInfo(tableInfo, field);
             String propertyName = entity.getNameConvert().propertyNameConvert(field);
-            field.setPropertyName(propertyName, columnType);
+            field.setPropertyName(propertyName);
             tableInfo.addField(field);
         });
         tableInfo.setIndexList(getIndex(tableName));

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/query/SQLQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/query/SQLQuery.java
@@ -128,10 +128,11 @@ public class SQLQuery extends AbstractDatabaseQuery {
                     .setType(result.getStringResult(dbQuery.fieldType()))
                     .setComment(result.getFiledComment())
                     .setCustomMap(dbQuery.getCustomFields(result.getResultSet()));
-                String propertyName = entity.getNameConvert().propertyNameConvert(field);
                 IColumnType columnType = dataSourceConfig.getTypeConvert().processTypeConvert(globalConfig, field);
-                field.setPropertyName(propertyName, columnType);
-                field.setMetaInfo(metaInfo);
+                field.setColumnType(columnType).setMetaInfo(metaInfo);
+                entity.handleTableFieldMetaInfo(tableInfo, field);
+                String propertyName = entity.getNameConvert().propertyNameConvert(field);
+                field.setPropertyName(propertyName);
                 tableInfo.addField(field);
             });
         } catch (SQLException e) {

--- a/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/config/StrategyConfigTest.java
+++ b/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/config/StrategyConfigTest.java
@@ -2,6 +2,7 @@ package com.baomidou.mybatisplus.generator.config;
 
 import com.baomidou.mybatisplus.annotation.FieldFill;
 import com.baomidou.mybatisplus.generator.IFill;
+import com.baomidou.mybatisplus.generator.ITableFieldMetaInfoCustomizer;
 import com.baomidou.mybatisplus.generator.config.builder.ConfigBuilder;
 import com.baomidou.mybatisplus.generator.config.builder.GeneratorBuilder;
 import com.baomidou.mybatisplus.generator.config.po.TableField;
@@ -283,6 +284,17 @@ class StrategyConfigTest {
             .controllerBuilder().superClass("com.baomidou.mp.SuperController").enableHyphenStyle().enableRestStyle()
             .mapperBuilder().superClass("com.baomidou.mp.SuperMapper").build();
         buildAssert(strategyConfig);
+    }
+
+    @Test
+    void tableFieldMetaInfoCustomizerBuilderTest() {
+        ITableFieldMetaInfoCustomizer customizer = (tableInfo, tableField) -> {
+        };
+        StrategyConfig strategyConfig = GeneratorBuilder.strategyConfigBuilder()
+            .entityBuilder()
+            .addTableFieldMetaInfoCustomizers(customizer)
+            .build();
+        assertThat(strategyConfig.entity().getTableFieldMetaInfoCustomizers()).containsExactly(customizer);
     }
 
     @Data

--- a/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/samples/TableFieldMetaInfoCustomizerTest.java
+++ b/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/samples/TableFieldMetaInfoCustomizerTest.java
@@ -1,0 +1,58 @@
+package com.baomidou.mybatisplus.generator.samples;
+
+import com.baomidou.mybatisplus.generator.config.DataSourceConfig;
+import com.baomidou.mybatisplus.generator.config.GlobalConfig;
+import com.baomidou.mybatisplus.generator.config.StrategyConfig;
+import com.baomidou.mybatisplus.generator.config.builder.ConfigBuilder;
+import com.baomidou.mybatisplus.generator.config.po.TableField;
+import com.baomidou.mybatisplus.generator.config.po.TableInfo;
+import com.baomidou.mybatisplus.generator.config.rules.DbColumnType;
+import com.baomidou.mybatisplus.generator.query.DefaultQuery;
+import org.apache.ibatis.type.JdbcType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TableFieldMetaInfoCustomizerTest extends BaseGeneratorTest {
+
+    private static final String H2URL = "jdbc:h2:mem:test-h2-meta-customizer;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;MODE=MYSQL;DATABASE_TO_LOWER=TRUE";
+
+    private static final DataSourceConfig DATA_SOURCE_CONFIG = new DataSourceConfig.Builder(H2URL, "sa", "")
+        .databaseQueryClass(DefaultQuery.class).build();
+
+    @BeforeAll
+    static void before() throws SQLException {
+        initDataSource(DATA_SOURCE_CONFIG);
+    }
+
+    @Test
+    void shouldCustomizeFieldMetaInfoAfterTypeConversion() {
+        StrategyConfig strategyConfig = new StrategyConfig.Builder()
+            .addInclude("t_simple")
+            .entityBuilder()
+            .addTableFieldMetaInfoCustomizers((tableInfo, tableField) -> {
+                if ("name".equals(tableField.getColumnName())) {
+                    tableField.getMetaInfo().setJdbcType(JdbcType.OTHER);
+                    tableField.getMetaInfo().setTypeName("POINT");
+                    tableField.setColumnType(DbColumnType.OBJECT);
+                }
+            })
+            .build();
+        GlobalConfig globalConfig = globalConfig().build();
+        ConfigBuilder configBuilder = new ConfigBuilder(null, DATA_SOURCE_CONFIG, strategyConfig, null, globalConfig, null);
+
+        List<TableInfo> tableInfoList = configBuilder.getTableInfoList();
+        TableField field = tableInfoList.get(0).getFields().stream()
+            .filter(tableField -> "name".equals(tableField.getColumnName()))
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(field.getMetaInfo().getJdbcType()).isEqualTo(JdbcType.OTHER);
+        assertThat(field.getMetaInfo().getTypeName()).isEqualTo("POINT");
+        assertThat(field.getColumnType()).isEqualTo(DbColumnType.OBJECT);
+    }
+}


### PR DESCRIPTION
## 变更说明

为 `mybatis-plus-generator` 增加一个小范围、向后兼容的扩展点，允许用户在字段初始类型转换完成后、模板渲染前，对最终字段元信息进行自定义调整。

## 背景

当前 `ITypeConvertHandler` 主要负责类型转换逻辑。
但是在类型转换完成后，到模板真正消费字段信息之间，缺少一个统一的后置处理入口。

这会让一些场景不太容易优雅处理，例如：

- 特殊数据库类型需要在生成阶段二次修正 `jdbcType` 或 `typeName`
- 自定义 Java 类型映射后，还需要同步调整字段最终元信息
- 在模板渲染前，需要补充字段级扩展属性或附加配置

## 本次改动

本 PR 新增一个扩展接口：

- `ITableFieldMetaInfoCustomizer`

并通过 `Entity.Builder` 暴露配置入口：

- `addTableFieldMetaInfoCustomizers(ITableFieldMetaInfoCustomizer...)`
- `addTableFieldMetaInfoCustomizers(List<ITableFieldMetaInfoCustomizer>)`

该扩展点会在以下两条查询链路中执行：

- `DefaultQuery`
- `SQLQuery`

同时，为了支持后置调整，`TableField.MetaInfo` 增加了部分 setter 方法，用于修改可变元信息字段。

## 使用示例

```java
strategyConfigBuilder.entityBuilder()
    .addTableFieldMetaInfoCustomizers((tableInfo, tableField) -> {
        if ("point".equalsIgnoreCase(tableField.getMetaInfo().getTypeName())) {
            tableField.getMetaInfo().setJdbcType(JdbcType.OTHER);
            tableField.setColumnType(DbColumnType.OBJECT);
        }
    });
```

## 兼容性说明

- 未配置 customizer 时，默认行为保持不变
- 改动范围仅限 `mybatis-plus-generator`
- 不影响运行时模块行为

## 测试情况

已补充以下测试：

- Builder 层配置 customizer 的保存测试
- 查询阶段执行字段元信息自定义的测试

## 设计考虑

相比继续增加更多单点配置项，这种字段元信息后置扩展点更通用，也更容易复用，适用于后续类似场景，例如：

- geometry / point
- JSON / ARRAY
- 自定义值对象映射
- 模板渲染前的字段元信息调整

本次实现尽量保持改动面小，并避免修改现有默认生成行为。

Related to #7037
