### PR TITLE
fix: 修正ORACLE注释中错误的ORACLE_NEW为ORACLE_12C

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -39,7 +39,7 @@ public enum DbType {
     /**
      * ORACLE
      */
-    ORACLE("oracle", "Oracle11g及以下数据库(高版本推荐使用ORACLE_NEW)"),
+    ORACLE("oracle", "Oracle11g及以下数据库(高版本推荐使用ORACLE_12C)"),
     /**
      * oracle12c new pagination
      */


### PR DESCRIPTION
## 问题
ORACLE 枚举值的注释中提到了 ORACLE_NEW，但该枚举值并不存在，实际上应为 ORACLE_12C。

## 修改
将注释中的 ORACLE_NEW 修正为 ORACLE_12C。

## 关联 Issue
close #7058