### PR TITLE
fix: correct Javadoc for formatLogicDeleteSql and getLogicDeleteSql

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
@@ -412,7 +412,7 @@ public class TableInfo implements Constants {
      * 获取逻辑删除字段的 sql 脚本
      *
      * @param startWithAnd 是否以 and 开头
-     * @param isWhere      是否需要的是逻辑删除值
+     * @param isWhere      true: 用于 WHERE 条件（未删除值），false: 用于 SET 子句（删除值）
      * @return sql 脚本
      */
     public String getLogicDeleteSql(boolean startWithAnd, boolean isWhere) {
@@ -430,7 +430,7 @@ public class TableInfo implements Constants {
      * format logic delete SQL, can be overrided by subclass
      * github #1386
      *
-     * @param isWhere true: logicDeleteValue, false: logicNotDeleteValue
+     * @param isWhere true: logicNotDeleteValue (for WHERE clause), false: logicDeleteValue (for SET clause)
      * @return sql
      */
     protected String formatLogicDeleteSql(boolean isWhere) {


### PR DESCRIPTION
Fixes #7062

## Summary

The `@param isWhere` Javadoc on `formatLogicDeleteSql()` and `getLogicDeleteSql()` was reversed — the comment said `true: logicDeleteValue` but the code actually uses `getLogicNotDeleteValue()` when `isWhere=true`.

### Code behavior (correct)

```java
// isWhere=true  → WHERE clause → filter for NOT-deleted records → logicNotDeleteValue
// isWhere=false → SET clause   → mark as deleted              → logicDeleteValue
final String value = isWhere
    ? logicDeleteFieldInfo.getLogicNotDeleteValue()   // e.g., 0
    : logicDeleteFieldInfo.getLogicDeleteValue();      // e.g., 1
```

This is verified by callers:
- `AbstractMethod.java:212` — `getLogicDeleteSql(true, true)` in WHERE clause
- `AbstractMethod.java:109` — `getLogicDeleteSql(false, false)` in SET clause (`SET deleted = ?`)
- `DeleteById.java:64` — `getLogicDeleteSql(false, false)` in SET clause

### Fix

Updated Javadoc on both methods to match the code:
- `formatLogicDeleteSql`: `@param isWhere true: logicNotDeleteValue (for WHERE clause), false: logicDeleteValue (for SET clause)`
- `getLogicDeleteSql`: `@param isWhere true: 用于 WHERE 条件（未删除值），false: 用于 SET 子句（删除值）`