### PR TITLE
fix: 修复 BlockAttackInnerInterceptor 插件在使用带 Schema 的数据库 (如 PostgreSQL) 时，未能正确拦截全表更新脚本的问题

### DIFF
--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BlockAttackInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BlockAttackInnerInterceptor.java
@@ -64,12 +64,12 @@ public class BlockAttackInnerInterceptor extends JsqlParserSupport implements In
 
     @Override
     protected void processDelete(Delete delete, int index, String sql, Object obj) {
-        this.checkWhere(delete.getTable().getName(), delete.getWhere(), "Prohibition of full table deletion");
+        this.checkWhere(delete.getTable().getFullyQualifiedName(), delete.getWhere(), "Prohibition of full table deletion");
     }
 
     @Override
     protected void processUpdate(Update update, int index, String sql, Object obj) {
-        this.checkWhere(update.getTable().getName(), update.getWhere(), "Prohibition of table update operation");
+        this.checkWhere(update.getTable().getFullyQualifiedName(), update.getWhere(), "Prohibition of table update operation");
     }
 
     protected void checkWhere(String tableName, Expression where, String ex) {

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BlockAttackInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BlockAttackInnerInterceptor.java
@@ -64,12 +64,12 @@ public class BlockAttackInnerInterceptor extends JsqlParserSupport implements In
 
     @Override
     protected void processDelete(Delete delete, int index, String sql, Object obj) {
-        this.checkWhere(delete.getTable().getName(), delete.getWhere(), "Prohibition of full table deletion");
+        this.checkWhere(delete.getTable().getFullyQualifiedName(), delete.getWhere(), "Prohibition of full table deletion");
     }
 
     @Override
     protected void processUpdate(Update update, int index, String sql, Object obj) {
-        this.checkWhere(update.getTable().getName(), update.getWhere(), "Prohibition of table update operation");
+        this.checkWhere(update.getTable().getFullyQualifiedName(), update.getWhere(), "Prohibition of table update operation");
     }
 
     protected void checkWhere(String tableName, Expression where, String ex) {

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BlockAttackInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/BlockAttackInnerInterceptor.java
@@ -64,12 +64,12 @@ public class BlockAttackInnerInterceptor extends JsqlParserSupport implements In
 
     @Override
     protected void processDelete(Delete delete, int index, String sql, Object obj) {
-        this.checkWhere(delete.getTable().getName(), delete.getWhere(), "Prohibition of full table deletion");
+        this.checkWhere(delete.getTable().getFullyQualifiedName(), delete.getWhere(), "Prohibition of full table deletion");
     }
 
     @Override
     protected void processUpdate(Update update, int index, String sql, Object obj) {
-        this.checkWhere(update.getTable().getName(), update.getWhere(), "Prohibition of table update operation");
+        this.checkWhere(update.getTable().getFullyQualifiedName(), update.getWhere(), "Prohibition of table update operation");
     }
 
     protected void checkWhere(String tableName, Expression where, String ex) {


### PR DESCRIPTION
fix issue: https://github.com/baomidou/mybatis-plus/issues/7081