### PR TITLE
docs: correct ORACLE_NEW to ORACLE_12C in DbType enum comment

### DIFF
--- a/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
+++ b/mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java
@@ -39,7 +39,7 @@ public enum DbType {
     /**
      * ORACLE
      */
-    ORACLE("oracle", "Oracle11g及以下数据库(高版本推荐使用ORACLE_NEW)"),
+    ORACLE("oracle", "Oracle11g及以下数据库(高版本推荐使用ORACLE_12C)"),
     /**
      * oracle12c new pagination
      */


### PR DESCRIPTION
## 问题描述
DbType 枚举中 ORACLE 常量的注释引用了 `ORACLE_NEW`，但该枚举常量已被重命名为 `ORACLE_12C`。

## 修改内容
将 `ORACLE` 枚举注释中的 `ORACLE_NEW` 修正为 `ORACLE_12C`。

## 修改文件
- `mybatis-plus-annotation/src/main/java/com/baomidou/mybatisplus/annotation/DbType.java`

Closes #7058