### PR TITLE
docs: fix inverted param description in formatLogicDeleteSql JavaDoc

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
@@ -465,7 +465,7 @@ public class TableInfo implements Constants {
      * format logic delete SQL, can be overrided by subclass
      * github #1386
      *
-     * @param isWhere true: logicDeleteValue, false: logicNotDeleteValue
+     * @param isWhere true: logicNotDeleteValue, false: logicDeleteValue
      * @return sql
      */
     protected String formatLogicDeleteSql(boolean isWhere) {


### PR DESCRIPTION
## 问题描述
`TableInfo.formatLogicDeleteSql` 方法的 JavaDoc 中 `@param isWhere` 的描述写反了。

## 详细分析
- 注释写的是 `true: logicDeleteValue, false: logicNotDeleteValue`
- 但实际代码中，`isWhere=true` 时返回的是 `logicNotDeleteValue`（用于 WHERE 子句过滤未删除的记录）
- `isWhere=false` 时返回的是 `logicDeleteValue`（用于 SET 子句标记删除）

## 修改内容
将注释修正为 `true: logicNotDeleteValue, false: logicDeleteValue`，与代码实际逻辑保持一致。

## 修改文件
- `mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java`

Closes #7062