### PR TITLE
fix: resolve column from kotlin references in lambda extraction (SFunction)

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/LambdaUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/LambdaUtils.java
@@ -42,6 +42,26 @@ public final class LambdaUtils {
     private static final Map<String, Map<String, ColumnCache>> COLUMN_CACHE_MAP = new ConcurrentHashMap<>();
 
     /**
+     * 按 lambda 实现类缓存 writeReplace 查找结果，避免每次解析列都重复 getDeclaredMethod 和 setAccessible。
+     * <p>
+     * 使用 {@link ClassValue} 让缓存跟随 Class 卸载，避免长期持有 lambda 类及其 ClassLoader。
+     */
+    private static final ClassValue<WriteReplace> WRITE_REPLACE_CACHE = new ClassValue<WriteReplace>() {
+        @Override
+        protected WriteReplace computeValue(Class<?> type) {
+            try {
+                Method method = type.getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return new WriteReplace(method, null);
+            } catch (NoSuchMethodException e) {
+                return WriteReplace.NONE;
+            } catch (Throwable e) {
+                return new WriteReplace(null, e);
+            }
+        }
+    };
+
+    /**
      * 该缓存可能会在任意不定的时间被清除
      *
      * @param func 需要解析的 lambda 对象
@@ -55,30 +75,39 @@ public final class LambdaUtils {
         }
         // 2. 反射读取
         try {
-            Method method = func.getClass().getDeclaredMethod("writeReplace");
-            method.setAccessible(true);
-            SerializedLambda lambda = (SerializedLambda) method.invoke(func);
+            Class<?> clazz = func.getClass();
+            WriteReplace writeReplace = WRITE_REPLACE_CACHE.get(clazz);
+            if (writeReplace.method == null) {
+                if (writeReplace.error == null) {
+                    // 没有 writeReplace 时，才尝试 Kotlin 旧版 class-based SAM 包装类的字段扫描。
+                    Object callable = findKotlinCallableInFields(func);
+                    if (callable != null) {
+                        return KotlinLambdaMeta.ofCallableReference(callable);
+                    }
+                }
+                return new ShadowLambdaMeta(com.baomidou.mybatisplus.core.toolkit.support.SerializedLambda.extract(func));
+            }
+            SerializedLambda lambda = (SerializedLambda) writeReplace.method.invoke(func);
             // 2.1 Kotlin (>=1.6) 的属性引用会被编译为捕获了 KProperty 的 lambda，
             //     其 implMethodName 为合成方法名，需直接从被捕获的 KProperty 解析字段名
-            Object kProperty = findKotlinProperty(lambda);
-            if (kProperty != null) {
-                return KotlinLambdaMeta.ofCapturedProperty(kProperty, lambda);
+            //     普通 Java 方法引用没有捕获参数，先判断数量可直接跳过 Kotlin 接口检测。
+            if (lambda.getCapturedArgCount() > 0) {
+                Object kProperty = findKotlinProperty(lambda);
+                if (kProperty != null) {
+                    return KotlinLambdaMeta.ofCapturedProperty(kProperty, lambda);
+                }
             }
             // 2.2 Kotlin 引用 Java getter（如 UserDO::getName）时会编译出形如 enclosing$getName 的合成适配方法，
             //     此时没有捕获 KProperty，从合成方法名末段还原出 getter 名
-            String kotlinGetter = kotlinGetterAdapterName(lambda.getImplMethodName());
-            if (kotlinGetter != null) {
-                return KotlinLambdaMeta.ofGetterMethodName(kotlinGetter, lambda, func.getClass().getClassLoader());
+            String implMethodName = lambda.getImplMethodName();
+            // 普通 Java getter 方法名不包含 '$'，先做字符门控避免进入 Kotlin 适配逻辑。
+            if (implMethodName.indexOf('$') >= 0) {
+                String kotlinGetter = kotlinGetterAdapterName(implMethodName);
+                if (kotlinGetter != null) {
+                    return KotlinLambdaMeta.ofGetterMethodName(kotlinGetter, lambda, clazz.getClassLoader());
+                }
             }
-            return new ReflectLambdaMeta(lambda, func.getClass().getClassLoader());
-        } catch (NoSuchMethodException e) {
-            // 2.3 Kotlin (<1.6) 将引用编译为 class-based 的 SAM 包装类（没有 writeReplace），
-            //     被引用的 Kotlin 可调用引用（KProperty / KFunction）作为包装类的字段保存，直接读取解析字段名
-            Object callable = findKotlinCallableInFields(func);
-            if (callable != null) {
-                return KotlinLambdaMeta.ofCallableReference(callable);
-            }
-            return new ShadowLambdaMeta(com.baomidou.mybatisplus.core.toolkit.support.SerializedLambda.extract(func));
+            return new ReflectLambdaMeta(lambda, clazz.getClassLoader());
         } catch (Throwable e) {
             // 3. 反射失败使用序列化的方式读取
             return new ShadowLambdaMeta(com.baomidou.mybatisplus.core.toolkit.support.SerializedLambda.extract(func));
@@ -90,6 +119,24 @@ public final class LambdaUtils {
      */
     private static final String KOTLIN_KPROPERTY = "kotlin.reflect.KProperty";
     private static final String KOTLIN_KFUNCTION = "kotlin.reflect.KFunction";
+
+    /**
+     * 按可调用引用实现类缓存是否实现 Kotlin KProperty/KFunction。
+     * <p>
+     * Kotlin 引用对象的接口层级需要递归扫描，缓存后可减少重复列解析时的接口遍历开销。
+     */
+    private static final ClassValue<KotlinReference> KOTLIN_REFERENCE_CACHE = new ClassValue<KotlinReference>() {
+        @Override
+        protected KotlinReference computeValue(Class<?> type) {
+            boolean property = false;
+            boolean function = false;
+            for (Class<?> clazz = type; clazz != null && (!property || !function); clazz = clazz.getSuperclass()) {
+                property = property || implementsInterface(clazz, KOTLIN_KPROPERTY);
+                function = function || implementsInterface(clazz, KOTLIN_KFUNCTION);
+            }
+            return new KotlinReference(property, function);
+        }
+    };
 
     /**
      * 在 lambda 捕获的参数中查找 Kotlin 的属性引用（KProperty）
@@ -155,23 +202,11 @@ public final class LambdaUtils {
     }
 
     private static boolean isKotlinProperty(Object arg) {
-        return isKotlinReference(arg, KOTLIN_KPROPERTY);
+        return arg != null && KOTLIN_REFERENCE_CACHE.get(arg.getClass()).property;
     }
 
     private static boolean isKotlinCallableReference(Object arg) {
-        return isKotlinReference(arg, KOTLIN_KPROPERTY) || isKotlinReference(arg, KOTLIN_KFUNCTION);
-    }
-
-    private static boolean isKotlinReference(Object arg, String interfaceName) {
-        if (arg == null) {
-            return false;
-        }
-        for (Class<?> clazz = arg.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
-            if (implementsInterface(clazz, interfaceName)) {
-                return true;
-            }
-        }
-        return false;
+        return arg != null && KOTLIN_REFERENCE_CACHE.get(arg.getClass()).callable;
     }
 
     private static boolean implementsInterface(Class<?> clazz, String interfaceName) {
@@ -181,6 +216,39 @@ public final class LambdaUtils {
             }
         }
         return false;
+    }
+
+    /**
+     * writeReplace 查找结果。
+     * <p>
+     * method 为 null 且 error 为 null 表示该类确实没有 writeReplace，可继续尝试 Kotlin 旧版兼容路径；
+     * error 非 null 表示查找阶段出现异常，应直接回退到序列化解析。
+     */
+    private static final class WriteReplace {
+        private static final WriteReplace NONE = new WriteReplace(null, null);
+
+        private final Method method;
+        private final Throwable error;
+
+        private WriteReplace(Method method, Throwable error) {
+            this.method = method;
+            this.error = error;
+        }
+    }
+
+    /**
+     * Kotlin 可调用引用类型判断结果。
+     * <p>
+     * property 只表示 KProperty；callable 表示 KProperty 或 KFunction，可覆盖属性引用和 getter 方法引用。
+     */
+    private static final class KotlinReference {
+        private final boolean property;
+        private final boolean callable;
+
+        private KotlinReference(boolean property, boolean function) {
+            this.property = property;
+            this.callable = property || function;
+        }
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/LambdaUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/LambdaUtils.java
@@ -20,6 +20,7 @@ import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.core.toolkit.support.*;
 
 import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Map;
@@ -56,11 +57,130 @@ public final class LambdaUtils {
         try {
             Method method = func.getClass().getDeclaredMethod("writeReplace");
             method.setAccessible(true);
-            return new ReflectLambdaMeta((SerializedLambda) method.invoke(func), func.getClass().getClassLoader());
+            SerializedLambda lambda = (SerializedLambda) method.invoke(func);
+            // 2.1 Kotlin (>=1.6) 的属性引用会被编译为捕获了 KProperty 的 lambda，
+            //     其 implMethodName 为合成方法名，需直接从被捕获的 KProperty 解析字段名
+            Object kProperty = findKotlinProperty(lambda);
+            if (kProperty != null) {
+                return KotlinLambdaMeta.ofCapturedProperty(kProperty, lambda);
+            }
+            // 2.2 Kotlin 引用 Java getter（如 UserDO::getName）时会编译出形如 enclosing$getName 的合成适配方法，
+            //     此时没有捕获 KProperty，从合成方法名末段还原出 getter 名
+            String kotlinGetter = kotlinGetterAdapterName(lambda.getImplMethodName());
+            if (kotlinGetter != null) {
+                return KotlinLambdaMeta.ofGetterMethodName(kotlinGetter, lambda, func.getClass().getClassLoader());
+            }
+            return new ReflectLambdaMeta(lambda, func.getClass().getClassLoader());
+        } catch (NoSuchMethodException e) {
+            // 2.3 Kotlin (<1.6) 将引用编译为 class-based 的 SAM 包装类（没有 writeReplace），
+            //     被引用的 Kotlin 可调用引用（KProperty / KFunction）作为包装类的字段保存，直接读取解析字段名
+            Object callable = findKotlinCallableInFields(func);
+            if (callable != null) {
+                return KotlinLambdaMeta.ofCallableReference(callable);
+            }
+            return new ShadowLambdaMeta(com.baomidou.mybatisplus.core.toolkit.support.SerializedLambda.extract(func));
         } catch (Throwable e) {
             // 3. 反射失败使用序列化的方式读取
             return new ShadowLambdaMeta(com.baomidou.mybatisplus.core.toolkit.support.SerializedLambda.extract(func));
         }
+    }
+
+    /**
+     * Kotlin 标准库中可调用引用接口的全限定名，使用名称匹配以避免 core 模块对 Kotlin 产生编译期依赖
+     */
+    private static final String KOTLIN_KPROPERTY = "kotlin.reflect.KProperty";
+    private static final String KOTLIN_KFUNCTION = "kotlin.reflect.KFunction";
+
+    /**
+     * 在 lambda 捕获的参数中查找 Kotlin 的属性引用（KProperty）
+     */
+    private static Object findKotlinProperty(SerializedLambda lambda) {
+        for (int i = 0; i < lambda.getCapturedArgCount(); i++) {
+            Object arg = lambda.getCapturedArg(i);
+            if (isKotlinProperty(arg)) {
+                return arg;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 在对象自身或其字段中查找 Kotlin 的可调用引用（KProperty 或 KFunction）。
+     * 用于 class-based 的 SAM 包装类：Kotlin 将被引用的 KProperty / KFunction 作为包装类的字段保存。
+     */
+    private static Object findKotlinCallableInFields(Object func) {
+        if (isKotlinCallableReference(func)) {
+            return func;
+        }
+        for (Class<?> clazz = func.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+            for (Field field : clazz.getDeclaredFields()) {
+                Object value;
+                try {
+                    value = ReflectionKit.setAccessible(field).get(func);
+                } catch (Throwable e) {
+                    continue;
+                }
+                if (isKotlinCallableReference(value)) {
+                    return value;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 从 invokedynamic 合成适配方法名中还原 getter 名。
+     * <p>
+     * Kotlin 引用 Java getter（如 {@code UserDO::getName}）时会编译出形如 {@code enclosing$getName} 的合成方法，
+     * 其末段即真实的 getter 名。仅当方法名含 {@code $} 且末段形如 getXxx/isXxx/setXxx 时才识别，
+     * 以免影响普通 Java 方法引用（其 implMethodName 直接就是 getName，无 {@code $}）。
+     */
+    private static String kotlinGetterAdapterName(String implMethodName) {
+        int idx = implMethodName.lastIndexOf('$');
+        if (idx <= 0) {
+            return null;
+        }
+        String candidate = implMethodName.substring(idx + 1);
+        return isGetterName(candidate) ? candidate : null;
+    }
+
+    private static boolean isGetterName(String name) {
+        if ((name.startsWith("get") || name.startsWith("set")) && name.length() > 3) {
+            return Character.isUpperCase(name.charAt(3));
+        }
+        if (name.startsWith("is") && name.length() > 2) {
+            return Character.isUpperCase(name.charAt(2));
+        }
+        return false;
+    }
+
+    private static boolean isKotlinProperty(Object arg) {
+        return isKotlinReference(arg, KOTLIN_KPROPERTY);
+    }
+
+    private static boolean isKotlinCallableReference(Object arg) {
+        return isKotlinReference(arg, KOTLIN_KPROPERTY) || isKotlinReference(arg, KOTLIN_KFUNCTION);
+    }
+
+    private static boolean isKotlinReference(Object arg, String interfaceName) {
+        if (arg == null) {
+            return false;
+        }
+        for (Class<?> clazz = arg.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+            if (implementsInterface(clazz, interfaceName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean implementsInterface(Class<?> clazz, String interfaceName) {
+        for (Class<?> anInterface : clazz.getInterfaces()) {
+            if (interfaceName.equals(anInterface.getName()) || implementsInterface(anInterface, interfaceName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/support/KotlinLambdaMeta.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/support/KotlinLambdaMeta.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.toolkit.support;
+
+import com.baomidou.mybatisplus.core.exceptions.MybatisPlusException;
+import com.baomidou.mybatisplus.core.toolkit.ClassUtils;
+import com.baomidou.mybatisplus.core.toolkit.ReflectionKit;
+import com.baomidou.mybatisplus.core.toolkit.StringPool;
+
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+
+/**
+ * 针对 Kotlin 可调用引用（KProperty / KFunction）适配为 Java {@link SFunction} 时的元信息。
+ * <p>
+ * Kotlin 把形如 {@code User::name}（属性引用）或 {@code UserDO::getName}（getter 方法引用）作为 Java 函数式接口
+ * 参数传递时，{@link SerializedLambda#getImplMethodName()} 往往是合成方法名（如 {@code xxx$lambda$0}、
+ * {@code xxx$getName}），无法直接解析出字段名。该类改为从被引用对象本身解析：
+ * <ul>
+ *     <li>属性引用（KProperty）：{@code getName()} 返回属性名，补成 getter 形式交给 PropertyNamer 还原；</li>
+ *     <li>getter 方法引用（KFunction）：{@code getName()} 已是方法名（如 {@code getName}），直接交给 PropertyNamer；</li>
+ *     <li>归属类取自 {@code getOwner().getJClass()}，或在 invokedynamic 场景下取自 {@code instantiatedMethodType}。</li>
+ * </ul>
+ * <p>
+ * 兼容性：属性引用（{@code Entity::prop}）在 Kotlin 1.2 至 2.4 全部可用；getter 方法引用（{@code JavaDO::getName}）
+ * 在 Kotlin 1.2–1.4 与 1.6+ 可用。<b>已知限制</b>：Kotlin 1.5.x 会把 getter 方法引用优化为直接实现函数式接口的单例类，
+ * 既无 KFunction 元数据也无 {@link SerializedLambda}（字段名仅存在于 {@code apply} 方法的字节码中），因此无法解析；
+ * 此时请改用属性引用（{@code Entity::prop}）或 Kotlin 原生的 KtQueryWrapper。
+ */
+public class KotlinLambdaMeta implements LambdaMeta {
+
+    private static final String KOTLIN_KPROPERTY = "kotlin.reflect.KProperty";
+
+    private final String implMethodName;
+    private final Class<?> instantiatedClass;
+
+    private KotlinLambdaMeta(String implMethodName, Class<?> instantiatedClass) {
+        this.implMethodName = implMethodName;
+        this.instantiatedClass = instantiatedClass;
+    }
+
+    /**
+     * invokedynamic 场景下被捕获的属性引用（KProperty）：字段名来自 KProperty，归属类来自 instantiatedMethodType。
+     */
+    public static KotlinLambdaMeta ofCapturedProperty(Object kProperty, SerializedLambda lambda) {
+        return new KotlinLambdaMeta(getterName(callableName(kProperty), true), classFromLambda(lambda, classLoaderOf(kProperty)));
+    }
+
+    /**
+     * class-based SAM 包装类场景：包装类字段持有的 Kotlin 可调用引用（KProperty 或 KFunction），归属类来自其 owner。
+     */
+    public static KotlinLambdaMeta ofCallableReference(Object callable) {
+        return new KotlinLambdaMeta(getterName(callableName(callable), isKotlinProperty(callable)), ownerClass(callable));
+    }
+
+    /**
+     * invokedynamic 场景下引用 Java getter 时编译出的合成适配方法（形如 {@code enclosing$getName}），
+     * getter 名取自方法名的末段，归属类来自 instantiatedMethodType。
+     */
+    public static KotlinLambdaMeta ofGetterMethodName(String getterName, SerializedLambda lambda, ClassLoader classLoader) {
+        return new KotlinLambdaMeta(getterName, classFromLambda(lambda, classLoader));
+    }
+
+    @Override
+    public String getImplMethodName() {
+        return implMethodName;
+    }
+
+    @Override
+    public Class<?> getInstantiatedClass() {
+        return instantiatedClass;
+    }
+
+    /**
+     * 属性引用的 name 是属性名，需补成 getter 形式（{@code name -> getName}），以便 PropertyNamer.methodToProperty 还原；
+     * 方法引用的 name 已是 getter 方法名（{@code getName}），原样返回。
+     */
+    private static String getterName(String name, boolean isProperty) {
+        if (!isProperty) {
+            return name;
+        }
+        return "get" + Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    }
+
+    private static String callableName(Object callable) {
+        try {
+            // setAccessible: Kotlin (<1.4) 生成的引用类是非 public 的，反射调用其 public 方法仍需放开访问
+            Method getName = callable.getClass().getMethod("getName");
+            return (String) ReflectionKit.setAccessible(getName).invoke(callable);
+        } catch (ReflectiveOperationException e) {
+            throw new MybatisPlusException(e);
+        }
+    }
+
+    /**
+     * 通过 {@code getOwner().getJClass()} 取得引用归属的实体类。
+     * {@code getJClass()} 在有无 kotlin-reflect 时分别由 KClassImpl / ClassReference 提供，均可用。
+     */
+    private static Class<?> ownerClass(Object callable) {
+        try {
+            Method getOwner = callable.getClass().getMethod("getOwner");
+            Object owner = ReflectionKit.setAccessible(getOwner).invoke(callable);
+            Method getJClass = owner.getClass().getMethod("getJClass");
+            return (Class<?>) ReflectionKit.setAccessible(getJClass).invoke(owner);
+        } catch (ReflectiveOperationException e) {
+            throw new MybatisPlusException(e);
+        }
+    }
+
+    private static Class<?> classFromLambda(SerializedLambda lambda, ClassLoader classLoader) {
+        String instantiatedMethodType = lambda.getInstantiatedMethodType();
+        String instantiatedType = instantiatedMethodType.substring(2, instantiatedMethodType.indexOf(StringPool.SEMICOLON)).replace(StringPool.SLASH, StringPool.DOT);
+        return ClassUtils.toClassConfident(instantiatedType, classLoader);
+    }
+
+    private static ClassLoader classLoaderOf(Object o) {
+        return o.getClass().getClassLoader();
+    }
+
+    private static boolean isKotlinProperty(Object callable) {
+        for (Class<?> clazz = callable.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+            if (implementsInterface(clazz, KOTLIN_KPROPERTY)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean implementsInterface(Class<?> clazz, String interfaceName) {
+        for (Class<?> anInterface : clazz.getInterfaces()) {
+            if (interfaceName.equals(anInterface.getName()) || implementsInterface(anInterface, interfaceName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/pagination/dialects/IDialectTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/pagination/dialects/IDialectTest.java
@@ -1,6 +1,7 @@
 package com.baomidou.mybatisplus.test.extension.plugins.pagination.dialects;
 
 import com.baomidou.mybatisplus.core.plugins.pagination.DialectModel;
+import com.baomidou.mybatisplus.core.plugins.pagination.Page;
 import com.baomidou.mybatisplus.core.plugins.pagination.dialects.IDialect;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ class IDialectTest {
         Map<String, List<Class<?>>> map = new ConcurrentHashMap<>();
         classList.forEach(i -> {
             IDialect o = (IDialect) ReflectionUtils.newInstance(i);
-            DialectModel model = o.buildPaginationSql("select * from table", 1, 10);
+            DialectModel model = o.buildPaginationSql("select * from table", Page.of(1, 10));
             String sql = model.getDialectSql();
             if (!map.containsKey(sql)) {
                 ArrayList<Class<?>> list = new ArrayList<>();

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/kotlin/PermissionDO.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/kotlin/PermissionDO.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.test.kotlin;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+
+/**
+ * 一个普通的 Java 实体（带 JavaBean getter），用于验证 Kotlin 代码中
+ * 形如 {@code PermissionDO::getBizType} 的 getter 方法引用（KFunction）能被正确解析。
+ */
+@TableName("crm_permission")
+public class PermissionDO {
+
+    private Long id;
+    private Integer bizType;
+    private Long bizId;
+    private Long userId;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getBizType() {
+        return bizType;
+    }
+
+    public void setBizType(Integer bizType) {
+        this.bizType = bizType;
+    }
+
+    public Long getBizId() {
+        return bizId;
+    }
+
+    public void setBizId(Long bizId) {
+        this.bizId = bizId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/plugins/pagination/SQLServer2005DialectTest.java
+++ b/mybatis-plus-extension/src/test/java/com/baomidou/mybatisplus/test/plugins/pagination/SQLServer2005DialectTest.java
@@ -1,5 +1,6 @@
 package com.baomidou.mybatisplus.test.plugins.pagination;
 
+import com.baomidou.mybatisplus.core.plugins.pagination.Page;
 import com.baomidou.mybatisplus.core.plugins.pagination.dialects.SQLServer2005Dialect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -11,47 +12,49 @@ public class SQLServer2005DialectTest {
 
     private final SQLServer2005Dialect sqlServer2005Dialect = new SQLServer2005Dialect();
 
+    private final Page<?> page = Page.of(1, 10);
+
     @Test
     void test() {
-        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql("select distinct *,(select 1) from test", 1, 10).getDialectSql());
-        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql(" select distinct *,(select 1) from test", 1, 10).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql("select distinct *,(select 1) from test", page).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql(" select distinct *,(select 1) from test", page).getDialectSql());
 
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql("select *,(select 1) from test", 1, 10).getDialectSql());
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql(" select *,(select 1) from test", 1, 10).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql("select *,(select 1) from test", page).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql(" select *,(select 1) from test", page).getDialectSql());
 
-        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql("select   distinct   *,(select 1) from test", 1, 10).getDialectSql());
-        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql(" select   distinct *,(select 1) from test", 1, 10).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql("select   distinct   *,(select 1) from test", page).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql(" select   distinct *,(select 1) from test", page).getDialectSql());
 
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql("select   *,(select 1) from test", 1, 10).getDialectSql());
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql(" select   *,(select 1) from test", 1, 10).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql("select   *,(select 1) from test", page).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(select 1) from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql(" select   *,(select 1) from test", page).getDialectSql());
 
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  * from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql("select * from test", 1, 10).getDialectSql());
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  * from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql(" select * from test", 1, 10).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  * from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql("select * from test", page).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  * from test) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql(" select * from test", page).getDialectSql());
 
-        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(SELECT 1) FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql("SELECT DISTINCT *,(SELECT 1) FROM TEST", 1, 10).getDialectSql());
-        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(SELECT 1) FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql(" SELECT DISTINCT *,(SELECT 1) FROM TEST", 1, 10).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(SELECT 1) FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql("SELECT DISTINCT *,(SELECT 1) FROM TEST", page).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT DISTINCT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(SELECT 1) FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql(" SELECT DISTINCT *,(SELECT 1) FROM TEST", page).getDialectSql());
 
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(SELECT 1) FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql("SELECT *,(SELECT 1) FROM TEST", 1, 10).getDialectSql());
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(SELECT 1) FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql(" SELECT *,(SELECT 1) FROM TEST", 1, 10).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(SELECT 1) FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql("SELECT *,(SELECT 1) FROM TEST", page).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  *,(SELECT 1) FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql(" SELECT *,(SELECT 1) FROM TEST", page).getDialectSql());
 
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  * FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql("SELECT * FROM TEST", 1, 10).getDialectSql());
-        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  * FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 2 AND 11 ORDER BY __row_number__",
-            sqlServer2005Dialect.buildPaginationSql(" SELECT * FROM TEST", 1, 10).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  * FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql("SELECT * FROM TEST", page).getDialectSql());
+        Assertions.assertEquals("WITH selectTemp AS (SELECT TOP 100 PERCENT  ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row_number__,  * FROM TEST) SELECT * FROM selectTemp WHERE __row_number__ BETWEEN 1 AND 10 ORDER BY __row_number__",
+            sqlServer2005Dialect.buildPaginationSql(" SELECT * FROM TEST", page).getDialectSql());
 
     }
 

--- a/mybatis-plus-extension/src/test/kotlin/com/baomidou/mybatisplus/test/kotlin/KotlinSFunctionColumnTest.kt
+++ b/mybatis-plus-extension/src/test/kotlin/com/baomidou/mybatisplus/test/kotlin/KotlinSFunctionColumnTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.test.kotlin
+
+import com.baomidou.mybatisplus.annotation.TableField
+import com.baomidou.mybatisplus.annotation.TableName
+import com.baomidou.mybatisplus.core.MybatisConfiguration
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper
+import org.apache.ibatis.builder.MapperBuilderAssistant
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@TableName("sys_user")
+class User {
+    var id: Int? = null
+
+    @TableField("username")
+    var name: String? = null
+
+    var roleId: Int? = null
+}
+
+@TableName("account")
+class Account {
+    var id: Int? = null
+    var isActive: Boolean = false
+}
+
+/**
+ * 当 Kotlin (>= 1.5) 把属性引用 (User::name) 或 Java getter 方法引用 (PermissionDO::getBizType)
+ * 作为 Java 的 SFunction 参数传递时，编译器会生成合成的 implMethodName，导致列名无法解析。
+ * 该测试覆盖在 Kotlin 中直接使用 Java 版 Lambda Wrapper 的场景。
+ */
+class KotlinSFunctionColumnTest {
+
+    @BeforeEach
+    fun init() {
+        TableInfoHelper.initTableInfo(MapperBuilderAssistant(MybatisConfiguration(), ""), User::class.java)
+    }
+
+    @Test
+    fun `query wrapper resolves column from kotlin property reference`() {
+        val sql = QueryWrapper(User::class.java)
+            .eq(User::name, "sss")
+            .eq(User::roleId, 1)
+            .sqlSegment
+        // name 通过 @TableField("username") 映射, roleId 映射为 role_id
+        assertThat(sql).contains("username", "role_id")
+    }
+
+    @Test
+    fun `update wrapper resolves column from kotlin property reference`() {
+        val sql = UpdateWrapper(User::class.java)
+            .eq(User::name, "sss")
+            .sqlSegment
+        assertThat(sql).contains("username")
+    }
+
+    @Test
+    fun `query wrapper resolves column from kotlin getter method reference`() {
+        TableInfoHelper.initTableInfo(MapperBuilderAssistant(MybatisConfiguration(), ""), PermissionDO::class.java)
+        // PermissionDO::getBizType 是对 Java getter 的方法引用 (KFunction), 不同于属性引用 (KProperty)
+        val sql = QueryWrapper(PermissionDO::class.java)
+            .eq(PermissionDO::getBizType, 1)
+            .eq(PermissionDO::getUserId, 2L)
+            .sqlSegment
+        assertThat(sql).contains("biz_type", "user_id")
+    }
+
+    @Test
+    fun `resolves column from is-prefixed boolean property reference`() {
+        TableInfoHelper.initTableInfo(MapperBuilderAssistant(MybatisConfiguration(), ""), Account::class.java)
+        val sql = QueryWrapper(Account::class.java)
+            .eq(Account::isActive, true)
+            .sqlSegment
+        // isActive 的属性名以 "is" 开头, getter 形式还原后须仍为 isActive -> is_active
+        assertThat(sql).contains("is_active")
+    }
+}


### PR DESCRIPTION
When a Kotlin reference is passed to a Java lambda-wrapper operator, Kotlin (>= 1.5) emits a synthetic SerializedLambda.implMethodName (e.g. xxx$lambda$0 or enclosing$getName), so PropertyNamer cannot recover the column and resolution fails. LambdaUtils.extract now recovers the field name from the Kotlin reference itself (reflectively, so core keeps no compile-time Kotlin dependency):

- captured KProperty (invokedynamic property reference);
- KProperty/KFunction held in the class-based SAM wrapper's field (Kotlin < 1.6);
- the getter name embedded in the indy adapter (enclosing$getName).

Adds a Kotlin regression test covering property refs, getter method refs, and is-prefixed boolean properties.

Known limitation: Kotlin 1.5.x compiles a getter method reference into a metadata-less singleton, which cannot be resolved; use a property reference or KtQueryWrapper there.