### PR TITLE
fix(generator): collect imports for customized field annotations

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Entity.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Entity.java
@@ -457,6 +457,8 @@ public class Entity implements ITemplate {
                 }
             });
         }
+        tableInfo.getFields().forEach(tableField -> tableField.getAnnotationAttributesList()
+            .forEach(attributes -> importPackages.addAll(attributes.getImportPackages())));
         data.put("entityFieldUseJavaDoc", fieldUseJavaDoc);
         data.put("entityClassAnnotations", annotationAttributesFunction != null ? annotationAttributesFunction.apply(classAnnotationAttributes) :
             classAnnotationAttributes.stream().sorted(Comparator.comparingInt(s -> s.getDisplayName().length())).collect(Collectors.toList()));

--- a/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/samples/TableFieldMetaInfoCustomizerTest.java
+++ b/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/samples/TableFieldMetaInfoCustomizerTest.java
@@ -1,5 +1,6 @@
 package com.baomidou.mybatisplus.generator.samples;
 
+import com.baomidou.mybatisplus.generator.AutoGenerator;
 import com.baomidou.mybatisplus.generator.config.DataSourceConfig;
 import com.baomidou.mybatisplus.generator.config.GlobalConfig;
 import com.baomidou.mybatisplus.generator.config.StrategyConfig;
@@ -7,11 +8,17 @@ import com.baomidou.mybatisplus.generator.config.builder.ConfigBuilder;
 import com.baomidou.mybatisplus.generator.config.po.TableField;
 import com.baomidou.mybatisplus.generator.config.po.TableInfo;
 import com.baomidou.mybatisplus.generator.config.rules.DbColumnType;
+import com.baomidou.mybatisplus.generator.model.AnnotationAttributes;
 import com.baomidou.mybatisplus.generator.query.DefaultQuery;
 import org.apache.ibatis.type.JdbcType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -55,5 +62,32 @@ class TableFieldMetaInfoCustomizerTest extends BaseGeneratorTest {
         assertThat(field.getMetaInfo().getJdbcType()).isEqualTo(JdbcType.OTHER);
         assertThat(field.getMetaInfo().getTypeName()).isEqualTo("POINT");
         assertThat(field.getColumnType()).isEqualTo(DbColumnType.OBJECT);
+    }
+
+    @Test
+    void shouldGenerateImportForCustomizedFieldAnnotation(@TempDir Path outputDir) throws IOException {
+        StrategyConfig strategyConfig = new StrategyConfig.Builder()
+            .addInclude("t_simple")
+            .addTablePrefix("t_")
+            .entityBuilder()
+            .tableFieldMetaInfoCustomizer((tableInfo, tableField) -> {
+                if ("name".equals(tableField.getColumnName())) {
+                    tableField.addAnnotationAttributesList(new AnnotationAttributes("@Sensitive",
+                        "com.example.security.Sensitive"));
+                }
+            })
+            .mapperBuilder().disable()
+            .serviceBuilder().disable()
+            .controllerBuilder().disable()
+            .build();
+        GlobalConfig globalConfig = globalConfig().disableOpenDir().outputDir(outputDir.toString()).build();
+
+        AutoGenerator generator = new AutoGenerator(DATA_SOURCE_CONFIG);
+        generator.config(new ConfigBuilder(null, DATA_SOURCE_CONFIG, strategyConfig, null, globalConfig, null));
+        generator.execute();
+
+        String entity = new String(Files.readAllBytes(outputDir.resolve("com/baomidou/entity/Simple.java")), StandardCharsets.UTF_8);
+        assertThat(entity).contains("import com.example.security.Sensitive;");
+        assertThat(entity).contains("@Sensitive");
     }
 }


### PR DESCRIPTION
Follow-up to #7041.

Custom field annotations added through `tableFieldMetaInfoCustomizer` were rendered on generated entity fields, but their import packages were not collected into the entity import set. This updates entity render data to include imports from field annotation attributes after customization.

Adds a regression test that customizes a field with `@Sensitive` and verifies the generated entity contains both the annotation and `com.example.security.Sensitive` import.

Validation:
- `git diff --check`
- marker scan for debug/focused-test leftovers