### PR TITLE
feat(generator): 支持组合字段元信息自定义器

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/ITableFieldMetaInfoCustomizer.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/ITableFieldMetaInfoCustomizer.java
@@ -7,6 +7,8 @@ import com.baomidou.mybatisplus.generator.config.rules.DbColumnType;
 import org.apache.ibatis.type.JdbcType;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * Customizes generator field metadata after type conversion and before templates render.
  * <p>
@@ -41,4 +43,20 @@ public interface ITableFieldMetaInfoCustomizer {
      * @param tableField current field info, including {@link TableField.MetaInfo}
      */
     void customize(@NotNull TableInfo tableInfo, @NotNull TableField tableField);
+
+    /**
+     * Returns a composed customizer that performs this customizer,
+     * followed by the {@code after} customizer.
+     *
+     * @param after the customizer to perform after this customizer
+     * @return a composed customizer
+     */
+    @NotNull
+    default ITableFieldMetaInfoCustomizer andThen(@NotNull ITableFieldMetaInfoCustomizer after) {
+        Objects.requireNonNull(after, "after");
+        return (tableInfo, tableField) -> {
+            customize(tableInfo, tableField);
+            after.customize(tableInfo, tableField);
+        };
+    }
 }

--- a/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/ITableFieldMetaInfoCustomizerTest.java
+++ b/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/ITableFieldMetaInfoCustomizerTest.java
@@ -1,0 +1,44 @@
+package com.baomidou.mybatisplus.generator;
+
+import com.baomidou.mybatisplus.generator.config.po.TableField;
+import com.baomidou.mybatisplus.generator.config.po.TableInfo;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class ITableFieldMetaInfoCustomizerTest {
+
+    @Test
+    void shouldComposeCustomizersInOrder() {
+        TableInfo tableInfo = Mockito.mock(TableInfo.class);
+        TableField tableField = Mockito.mock(TableField.class);
+        List<String> calls = new ArrayList<>();
+        ITableFieldMetaInfoCustomizer first = (currentTableInfo, currentTableField) -> {
+            assertThat(currentTableInfo).isSameAs(tableInfo);
+            assertThat(currentTableField).isSameAs(tableField);
+            calls.add("first");
+        };
+        ITableFieldMetaInfoCustomizer second = (currentTableInfo, currentTableField) -> {
+            assertThat(currentTableInfo).isSameAs(tableInfo);
+            assertThat(currentTableField).isSameAs(tableField);
+            calls.add("second");
+        };
+
+        first.andThen(second).customize(tableInfo, tableField);
+
+        assertThat(calls).containsExactly("first", "second");
+    }
+
+    @Test
+    void shouldRejectNullCustomizerWhenComposing() {
+        ITableFieldMetaInfoCustomizer customizer = (tableInfo, tableField) -> {
+        };
+
+        assertThatNullPointerException().isThrownBy(() -> customizer.andThen(null));
+    }
+}


### PR DESCRIPTION
### 变更说明

为 `ITableFieldMetaInfoCustomizer` 增加 `andThen` 默认方法，支持按顺序组合多个字段元信息自定义器。

在需要处理多个独立规则时，例如不同数据库特殊类型、字段注解或字段类型映射，用户可以将多个 customizer 拆分后组合使用，避免把所有逻辑都写在一个较大的 lambda 中。

### 主要改动

- 新增 `ITableFieldMetaInfoCustomizer#andThen(...)`
- 补充测试覆盖 customizer 顺序执行
- 补充测试覆盖传入 `null` 时快速失败

### 验证

`本地已通过相关测试：

- `ITableFieldMetaInfoCustomizerTest`
- `TableFieldMetaInfoCustomizerTest`