### PR TITLE
fix: 修复 IdType.AUTO 手动设置主键后被生成主键覆盖的问题

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/executor/keygen/AutoIdKeyGenerator.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/executor/keygen/AutoIdKeyGenerator.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.executor.keygen;
+
+import com.baomidou.mybatisplus.core.toolkit.Constants;
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
+import org.apache.ibatis.executor.BatchExecutor;
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.executor.ExecutorException;
+import org.apache.ibatis.executor.keygen.Jdbc3KeyGenerator;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeHandler;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Key generator for {@code IdType.AUTO} that does not overwrite manually assigned ids.
+ */
+public class AutoIdKeyGenerator extends Jdbc3KeyGenerator {
+
+    public static final AutoIdKeyGenerator INSTANCE = new AutoIdKeyGenerator();
+
+    private static final String MSG_TOO_MANY_KEYS = "Too many keys are generated. There are only %d target objects. "
+        + "You either specified a wrong 'keyProperty' or encountered a driver bug like #1523.";
+
+    private final Map<Statement, ResultSet> generatedKeys = Collections.synchronizedMap(new WeakHashMap<>());
+
+    @Override
+    public void processBefore(Executor executor, MappedStatement ms, Statement stmt, Object parameter) {
+        // do nothing
+    }
+
+    @Override
+    public void processAfter(Executor executor, MappedStatement ms, Statement stmt, Object parameter) {
+        processBatch(ms, stmt, parameter, executor instanceof BatchExecutor);
+    }
+
+    @Override
+    public void processBatch(MappedStatement ms, Statement stmt, Object parameter) {
+        processBatch(ms, stmt, parameter, true);
+    }
+
+    private void processBatch(MappedStatement ms, Statement stmt, Object parameter, boolean batch) {
+        String[] keyProperties = ms.getKeyProperties();
+        if (keyProperties == null || keyProperties.length == 0) {
+            return;
+        }
+        try {
+            ResultSet rs = getGeneratedKeys(stmt, batch);
+            ResultSetMetaData rsmd = rs.getMetaData();
+            if (rsmd.getColumnCount() < keyProperties.length) {
+                return;
+            }
+            Collection<?> parameters = collectionize(parameter);
+            for (Object parameterObject : parameters) {
+                if (!rs.next()) {
+                    return;
+                }
+                assignKeys(ms.getConfiguration(), rs, rsmd, keyProperties, parameterObject);
+            }
+            if (!isSingleParameter(parameter) && rs.next()) {
+                throw new ExecutorException(String.format(MSG_TOO_MANY_KEYS, parameters.size()));
+            }
+        } catch (Exception e) {
+            throw new ExecutorException("Error getting generated key or setting result to parameter object. Cause: " + e, e);
+        }
+    }
+
+    private ResultSet getGeneratedKeys(Statement stmt, boolean batch) throws SQLException {
+        if (!batch) {
+            return stmt.getGeneratedKeys();
+        }
+        synchronized (generatedKeys) {
+            ResultSet rs = generatedKeys.get(stmt);
+            if (rs == null) {
+                rs = stmt.getGeneratedKeys();
+                generatedKeys.put(stmt, rs);
+            }
+            return rs;
+        }
+    }
+
+    private void assignKeys(Configuration configuration, ResultSet rs, ResultSetMetaData rsmd, String[] keyProperties, Object parameter) throws SQLException {
+        for (int i = 0; i < keyProperties.length; i++) {
+            KeyTarget keyTarget = resolveKeyTarget(parameter, keyProperties[i]);
+            if (keyTarget == null || keyTarget.target == null) {
+                continue;
+            }
+            assignKey(configuration, rs, rsmd, i + 1, keyTarget);
+        }
+    }
+
+    private void assignKey(Configuration configuration, ResultSet rs, ResultSetMetaData rsmd, int columnPosition, KeyTarget keyTarget) throws SQLException {
+        MetaObject metaObject = configuration.newMetaObject(keyTarget.target);
+        if (!metaObject.hasSetter(keyTarget.propertyName)) {
+            throw new ExecutorException("No setter found for the keyProperty '" + keyTarget.propertyName + "' in '"
+                + metaObject.getOriginalObject().getClass().getName() + "'.");
+        }
+        if (StringUtils.checkValNotNull(metaObject.getValue(keyTarget.propertyName))) {
+            return;
+        }
+        Class<?> propertyType = metaObject.getSetterType(keyTarget.propertyName);
+        TypeHandler<?> typeHandler = configuration.getTypeHandlerRegistry()
+            .getTypeHandler(propertyType, JdbcType.forCode(rsmd.getColumnType(columnPosition)));
+        if (typeHandler != null) {
+            metaObject.setValue(keyTarget.propertyName, typeHandler.getResult(rs, columnPosition));
+        }
+    }
+
+    private KeyTarget resolveKeyTarget(Object parameter, String keyProperty) {
+        if (parameter instanceof Map) {
+            Map<?, ?> paramMap = (Map<?, ?>) parameter;
+            int dotIndex = keyProperty.indexOf('.');
+            if (dotIndex > -1) {
+                String paramName = keyProperty.substring(0, dotIndex);
+                if (paramMap.containsKey(paramName)) {
+                    return new KeyTarget(paramMap.get(paramName), keyProperty.substring(dotIndex + 1));
+                }
+            }
+            if (paramMap.containsKey(Constants.ENTITY)) {
+                return new KeyTarget(paramMap.get(Constants.ENTITY), keyProperty);
+            }
+        }
+        return new KeyTarget(parameter, keyProperty);
+    }
+
+    private Collection<?> collectionize(Object parameter) {
+        if (parameter instanceof Collection) {
+            return (Collection<?>) parameter;
+        }
+        if (parameter instanceof Object[]) {
+            return Arrays.asList((Object[]) parameter);
+        }
+        return Collections.singletonList(parameter);
+    }
+
+    private boolean isSingleParameter(Object parameter) {
+        return !(parameter instanceof Collection) && !(parameter instanceof Object[]);
+    }
+
+    private static class KeyTarget {
+        private final Object target;
+        private final String propertyName;
+
+        private KeyTarget(Object target, String propertyName) {
+            this.target = target;
+            this.propertyName = propertyName;
+        }
+    }
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/Insert.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/injector/methods/Insert.java
@@ -17,13 +17,13 @@ package com.baomidou.mybatisplus.core.injector.methods;
 
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.core.enums.SqlMethod;
+import com.baomidou.mybatisplus.core.executor.keygen.AutoIdKeyGenerator;
 import com.baomidou.mybatisplus.core.injector.AbstractMethod;
 import com.baomidou.mybatisplus.core.metadata.TableInfo;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtils;
 import com.baomidou.mybatisplus.core.toolkit.sql.SqlScriptUtils;
-import org.apache.ibatis.executor.keygen.Jdbc3KeyGenerator;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
 import org.apache.ibatis.executor.keygen.NoKeyGenerator;
 import org.apache.ibatis.mapping.MappedStatement;
@@ -89,7 +89,7 @@ public class Insert extends AbstractMethod {
         if (StringUtils.isNotBlank(tableInfo.getKeyProperty())) {
             if (tableInfo.getIdType() == IdType.AUTO) {
                 /* 自增主键 */
-                keyGenerator = Jdbc3KeyGenerator.INSTANCE;
+                keyGenerator = AutoIdKeyGenerator.INSTANCE;
                 keyProperty = tableInfo.getKeyProperty();
                 // 去除转义符
                 keyColumn = SqlInjectionUtils.removeEscapeCharacter(tableInfo.getKeyColumn());

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/executor/keygen/AutoIdKeyGeneratorTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/executor/keygen/AutoIdKeyGeneratorTest.java
@@ -1,0 +1,117 @@
+package com.baomidou.mybatisplus.core.executor.keygen;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.injector.methods.Insert;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.metadata.TableInfo;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.executor.BatchExecutor;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AutoIdKeyGeneratorTest {
+
+    @Test
+    void shouldKeepManuallyAssignedAutoId() throws Exception {
+        MappedStatement mappedStatement = mappedStatement();
+        AutoEntity entity = new AutoEntity();
+        entity.setId(300000L);
+
+        mappedStatement.getKeyGenerator().processAfter(null, mappedStatement, statementWithGeneratedKeys(1L), entity);
+
+        Assertions.assertEquals(300000L, entity.getId());
+    }
+
+    @Test
+    void shouldConsumeGeneratedKeysAndOnlyFillNullAutoId() throws Exception {
+        MappedStatement mappedStatement = mappedStatement();
+        AutoEntity manuallyAssigned = new AutoEntity();
+        manuallyAssigned.setId(300000L);
+        AutoEntity generated = new AutoEntity();
+        Statement statement = statementWithGeneratedKeys(1L, 2L);
+
+        mappedStatement.getKeyGenerator().processAfter(mock(BatchExecutor.class), mappedStatement, statement, manuallyAssigned);
+        mappedStatement.getKeyGenerator().processAfter(mock(BatchExecutor.class), mappedStatement, statement, generated);
+
+        Assertions.assertEquals(300000L, manuallyAssigned.getId());
+        Assertions.assertEquals(2L, generated.getId());
+    }
+
+    @Test
+    void shouldReadGeneratedKeysEachTimeForNonBatchExecutor() throws Exception {
+        MappedStatement mappedStatement = mappedStatement();
+        AutoEntity first = new AutoEntity();
+        AutoEntity second = new AutoEntity();
+        Statement statement = mock(Statement.class);
+        ResultSet firstResultSet = resultSetWithGeneratedKeys(1L);
+        ResultSet secondResultSet = resultSetWithGeneratedKeys(2L);
+        when(statement.getGeneratedKeys()).thenReturn(firstResultSet, secondResultSet);
+
+        mappedStatement.getKeyGenerator().processAfter(null, mappedStatement, statement, first);
+        mappedStatement.getKeyGenerator().processAfter(null, mappedStatement, statement, second);
+
+        Assertions.assertEquals(1L, first.getId());
+        Assertions.assertEquals(2L, second.getId());
+    }
+
+    private MappedStatement mappedStatement() {
+        MybatisConfiguration configuration = new MybatisConfiguration();
+        MapperBuilderAssistant assistant = new MapperBuilderAssistant(configuration, "");
+        assistant.setCurrentNamespace(AutoMapper.class.getName());
+        TableInfo tableInfo = TableInfoHelper.initTableInfo(assistant, AutoEntity.class);
+        new Insert().inject(assistant, AutoMapper.class, AutoEntity.class, tableInfo);
+        return configuration.getMappedStatement(AutoMapper.class.getName() + ".insert");
+    }
+
+    private Statement statementWithGeneratedKeys(Long... keys) throws Exception {
+        Statement statement = mock(Statement.class);
+        ResultSet resultSet = resultSetWithGeneratedKeys(keys);
+        when(statement.getGeneratedKeys()).thenReturn(resultSet);
+        return statement;
+    }
+
+    private ResultSet resultSetWithGeneratedKeys(Long... keys) throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        ResultSetMetaData metaData = mock(ResultSetMetaData.class);
+        AtomicInteger row = new AtomicInteger(-1);
+        when(resultSet.getMetaData()).thenReturn(metaData);
+        when(resultSet.next()).thenAnswer(invocation -> row.incrementAndGet() < keys.length);
+        when(resultSet.getLong(1)).thenAnswer(invocation -> keys[row.get()]);
+        when(resultSet.wasNull()).thenReturn(false);
+        when(metaData.getColumnCount()).thenReturn(1);
+        when(metaData.getColumnType(1)).thenReturn(Types.BIGINT);
+        return resultSet;
+    }
+
+    private interface AutoMapper extends BaseMapper<AutoEntity> {
+    }
+
+    @TableName("auto_entity")
+    private static class AutoEntity {
+
+        @TableId(type = IdType.AUTO)
+        private Long id;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+    }
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2StudentMapperTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2StudentMapperTest.java
@@ -1,15 +1,19 @@
 package com.baomidou.mybatisplus.test.h2;
 
+import com.baomidou.mybatisplus.core.batch.MybatisBatch;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.toolkit.Assert;
+import com.baomidou.mybatisplus.core.toolkit.MybatisBatchUtils;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.baomidou.mybatisplus.extension.toolkit.SqlHelper;
 import com.baomidou.mybatisplus.test.h2.entity.H2Student;
 import com.baomidou.mybatisplus.test.h2.enums.GenderEnum;
 import com.baomidou.mybatisplus.test.h2.enums.GradeEnum;
 import com.baomidou.mybatisplus.test.h2.mapper.H2StudentMapper;
+import org.apache.ibatis.session.SqlSessionFactory;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +37,9 @@ class H2StudentMapperTest extends BaseTest {
 
     @Autowired
     protected H2StudentMapper studentMapper;
+
+    @Autowired
+    private SqlSessionFactory sqlSessionFactory;
 
     @Test
     @Order(1)
@@ -93,6 +100,19 @@ class H2StudentMapperTest extends BaseTest {
         H2Student h2Student = new H2Student(111L, "测试根据实体删除", 12);
         studentMapper.insert(h2Student);
         Assertions.assertEquals(1, studentMapper.deleteById(h2Student));
+    }
+
+    @Test
+    void insertBatchShouldKeepManuallyAssignedAutoId() {
+        Long id = 300000L;
+        H2Student h2Student = new H2Student(id, "manual-auto-id", 18);
+        H2Student generated = new H2Student(null, "generated-auto-id", 19);
+        MybatisBatch.Method<H2Student> mapperMethod = new MybatisBatch.Method<>(H2StudentMapper.class);
+
+        Assertions.assertTrue(SqlHelper.retBool(MybatisBatchUtils.execute(sqlSessionFactory, List.of(h2Student, generated), mapperMethod.insert())));
+        Assertions.assertEquals(id, h2Student.getId());
+        Assertions.assertNotNull(generated.getId());
+        Assertions.assertNotNull(studentMapper.selectById(id));
     }
 
     @Test


### PR DESCRIPTION
### 关联 issue

Fixes #6896

### 问题背景

在 `IdType.AUTO` 场景下，如果用户在插入前已经手动设置了实体主键，数据库实际插入的是用户设置的主键值，但插入完成后，实体对象中的主键会被 JDBC 返回的 generated key 覆盖。

这会导致数据库中的主键值和 Java 实体对象中的主键值不一致，尤其在批量插入后继续使用实体 ID 进行后续业务操作时，容易产生错误。

### 原因分析

当前 `Insert` 方法在 `IdType.AUTO` 时会使用 MyBatis 原生的 `Jdbc3KeyGenerator.INSTANCE`。

在 batch insert 场景下，`BatchExecutor` 会在 `doFlushStatements` 阶段统一执行 generated key 回填。此时即使实体主键原本已经有值，也仍然可能被 JDBC 返回的自增主键覆盖。

也就是说，问题不在于数据库插入值错误，而在于插入后的实体主键回填阶段覆盖了用户手动设置的 ID。

### 修复方式

本次修改为 `IdType.AUTO` 场景增加专用的 key generator 处理逻辑：

- 当实体主键当前值为 `null` 时，保持原有行为，继续回填数据库生成的主键；
- 当实体主键当前值不为 `null` 时，认为这是用户手动设置的主键，不再用 generated key 覆盖；
- batch 场景下按顺序消费 generated keys，避免影响后续空 ID 实体的正常回填；
- 非 batch 场景仍保持每次从当前 statement 读取 generated keys，避免复用 statement 时出现旧值影响。

这样可以保持 `IdType.AUTO` 原有自动回填能力，同时避免手动设置主键后实体状态被覆盖。

### 测试

已补充测试覆盖以下场景：

- `IdType.AUTO` 手动设置主键时，插入后实体 ID 保持不变；
- batch 场景下，手动 ID 不被覆盖，空 ID 仍可正常回填；
- 非 batch 场景下，多次使用 statement 时 generated keys 不会串值。

本地验证：

```bash
./gradlew :mybatis-plus-core:test --tests "com.baomidou.mybatisplus.core.executor.keygen.AutoIdKeyGeneratorTest" --no-daemon --stacktrace

./gradlew :mybatis-plus:test --tests "com.baomidou.mybatisplus.test.h2.H2StudentMapperTest.insertBatchShouldKeepManuallyAssignedAutoId" -x :mybatis-plus:compileTestKotlin --no-daemon --stacktrace