### PR TITLE
fix(extension): support foreach parameters in data change recorder

### DIFF
--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
@@ -339,7 +339,7 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
                 final String columnName = columnSetIndexMap.getOrDefault(index++, getColumnNameByProperty(propertyNameTrim, tableName));
                 if (relatedColumnsUpperCaseWithoutUnderline.containsKey(propertyNameTrim)) {
                     final String colkey = relatedColumnsUpperCaseWithoutUnderline.get(propertyNameTrim);
-                    Object valObj = metaObject.getValue(propertyName);
+                    Object valObj = getParameterValue(updateSql, metaObject, propertyName);
                     if (valObj instanceof IEnum) {
                         valObj = ((IEnum<?>) valObj).getValue();
                     } else if (valObj instanceof Enum) {
@@ -353,7 +353,7 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
                     }
                 } else {
                     if (columnName != null) {
-                        columnNameValMap.put(columnName, metaObject.getValue(propertyName));
+                        columnNameValMap.put(columnName, getParameterValue(updateSql, metaObject, propertyName));
                     }
                 }
             } catch (Exception e) {
@@ -505,11 +505,18 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
             if (propertyName.startsWith("ew.paramNameValuePairs")) {
                 continue;
             }
-            Object propertyValue = metaObject.getValue(propertyName);
+            Object propertyValue = getParameterValue(boundSql, metaObject, propertyName);
             propertyValMap.put(propertyName, propertyValue);
         }
         return propertyValMap;
 
+    }
+
+    private Object getParameterValue(BoundSql boundSql, MetaObject metaObject, String propertyName) {
+        if (boundSql.hasAdditionalParameter(propertyName)) {
+            return boundSql.getAdditionalParameter(propertyName);
+        }
+        return metaObject.getValue(propertyName);
     }
 
 

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/inner/DataChangeRecorderInnerInterceptorTest.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/inner/DataChangeRecorderInnerInterceptorTest.java
@@ -1,15 +1,20 @@
 package com.baomidou.mybatisplus.test.extension.plugins.inner;
 
+import com.baomidou.mybatisplus.extension.parser.JsqlParserGlobal;
 import com.baomidou.mybatisplus.extension.plugins.inner.DataChangeRecorderInnerInterceptor;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.update.Update;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.session.Configuration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -50,6 +55,32 @@ class DataChangeRecorderInnerInterceptorTest {
         Assertions.assertEquals(operationResult.getTableName(), "H2USER:*");
         Assertions.assertFalse(operationResult.isRecordStatus());
         Assertions.assertNull(operationResult.getChangedData());
+    }
+
+    @Test
+    void processInsertWithForeachAdditionalParameter() throws Exception {
+        Configuration configuration = new Configuration();
+        List<ParameterMapping> parameterMappings = List.of(
+            new ParameterMapping.Builder(configuration, "__frch_item_0.id", Long.class).build(),
+            new ParameterMapping.Builder(configuration, "__frch_item_0.name", String.class).build(),
+            new ParameterMapping.Builder(configuration, "__frch_item_1.id", Long.class).build(),
+            new ParameterMapping.Builder(configuration, "__frch_item_1.name", String.class).build()
+        );
+        BoundSql boundSql = new BoundSql(configuration, "insert into sys_user (id, name) values (?, ?), (?, ?)",
+            parameterMappings, Map.of("list", List.of(
+                Map.of("id", 1L, "name", "Alice"),
+                Map.of("id", 2L, "name", "Bob")
+            )));
+        boundSql.setAdditionalParameter("__frch_item_0", Map.of("id", 1L, "name", "Alice"));
+        boundSql.setAdditionalParameter("__frch_item_1", Map.of("id", 2L, "name", "Bob"));
+        Insert insert = (Insert) JsqlParserGlobal.parse("insert into sys_user (id, name) values (?, ?), (?, ?)");
+
+        DataChangeRecorderInnerInterceptor.OperationResult operationResult = interceptor.processInsert(insert, boundSql);
+
+        Assertions.assertEquals("sys_user", operationResult.getTableName());
+        Assertions.assertTrue(operationResult.isRecordStatus());
+        Assertions.assertTrue(operationResult.getChangedData().contains("\"ID\":\"null->1\""));
+        Assertions.assertTrue(operationResult.getChangedData().contains("\"NAME\":\"null->Alice\""));
     }
 
     @Test

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
@@ -339,7 +339,7 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
                 final String columnName = columnSetIndexMap.getOrDefault(index++, getColumnNameByProperty(propertyNameTrim, tableName));
                 if (relatedColumnsUpperCaseWithoutUnderline.containsKey(propertyNameTrim)) {
                     final String colkey = relatedColumnsUpperCaseWithoutUnderline.get(propertyNameTrim);
-                    Object valObj = metaObject.getValue(propertyName);
+                    Object valObj = getParameterValue(updateSql, metaObject, propertyName);
                     if (valObj instanceof IEnum) {
                         valObj = ((IEnum<?>) valObj).getValue();
                     } else if (valObj instanceof Enum) {
@@ -353,7 +353,7 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
                     }
                 } else {
                     if (columnName != null) {
-                        columnNameValMap.put(columnName, metaObject.getValue(propertyName));
+                        columnNameValMap.put(columnName, getParameterValue(updateSql, metaObject, propertyName));
                     }
                 }
             } catch (Exception e) {
@@ -505,11 +505,18 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
             if (propertyName.startsWith("ew.paramNameValuePairs")) {
                 continue;
             }
-            Object propertyValue = metaObject.getValue(propertyName);
+            Object propertyValue = getParameterValue(boundSql, metaObject, propertyName);
             propertyValMap.put(propertyName, propertyValue);
         }
         return propertyValMap;
 
+    }
+
+    private Object getParameterValue(BoundSql boundSql, MetaObject metaObject, String propertyName) {
+        if (boundSql.hasAdditionalParameter(propertyName)) {
+            return boundSql.getAdditionalParameter(propertyName);
+        }
+        return metaObject.getValue(propertyName);
     }
 
 

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/inner/DataChangeRecorderInnerInterceptorTest.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/inner/DataChangeRecorderInnerInterceptorTest.java
@@ -1,15 +1,20 @@
 package com.baomidou.mybatisplus.test.extension.plugins.inner;
 
+import com.baomidou.mybatisplus.extension.parser.JsqlParserGlobal;
 import com.baomidou.mybatisplus.extension.plugins.inner.DataChangeRecorderInnerInterceptor;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.update.Update;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.session.Configuration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -50,6 +55,32 @@ class DataChangeRecorderInnerInterceptorTest {
         Assertions.assertEquals(operationResult.getTableName(), "H2USER:*");
         Assertions.assertFalse(operationResult.isRecordStatus());
         Assertions.assertNull(operationResult.getChangedData());
+    }
+
+    @Test
+    void processInsertWithForeachAdditionalParameter() throws Exception {
+        Configuration configuration = new Configuration();
+        List<ParameterMapping> parameterMappings = List.of(
+            new ParameterMapping.Builder(configuration, "__frch_item_0.id", Long.class).build(),
+            new ParameterMapping.Builder(configuration, "__frch_item_0.name", String.class).build(),
+            new ParameterMapping.Builder(configuration, "__frch_item_1.id", Long.class).build(),
+            new ParameterMapping.Builder(configuration, "__frch_item_1.name", String.class).build()
+        );
+        BoundSql boundSql = new BoundSql(configuration, "insert into sys_user (id, name) values (?, ?), (?, ?)",
+            parameterMappings, Map.of("list", List.of(
+                Map.of("id", 1L, "name", "Alice"),
+                Map.of("id", 2L, "name", "Bob")
+            )));
+        boundSql.setAdditionalParameter("__frch_item_0", Map.of("id", 1L, "name", "Alice"));
+        boundSql.setAdditionalParameter("__frch_item_1", Map.of("id", 2L, "name", "Bob"));
+        Insert insert = (Insert) JsqlParserGlobal.parse("insert into sys_user (id, name) values (?, ?), (?, ?)");
+
+        DataChangeRecorderInnerInterceptor.OperationResult operationResult = interceptor.processInsert(insert, boundSql);
+
+        Assertions.assertEquals("sys_user", operationResult.getTableName());
+        Assertions.assertTrue(operationResult.isRecordStatus());
+        Assertions.assertTrue(operationResult.getChangedData().contains("\"ID\":\"null->1\""));
+        Assertions.assertTrue(operationResult.getChangedData().contains("\"NAME\":\"null->Alice\""));
     }
 
     @Test

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/DataChangeRecorderInnerInterceptor.java
@@ -339,7 +339,7 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
                 final String columnName = columnSetIndexMap.getOrDefault(index++, getColumnNameByProperty(propertyNameTrim, tableName));
                 if (relatedColumnsUpperCaseWithoutUnderline.containsKey(propertyNameTrim)) {
                     final String colkey = relatedColumnsUpperCaseWithoutUnderline.get(propertyNameTrim);
-                    Object valObj = metaObject.getValue(propertyName);
+                    Object valObj = getParameterValue(updateSql, metaObject, propertyName);
                     if (valObj instanceof IEnum) {
                         valObj = ((IEnum<?>) valObj).getValue();
                     } else if (valObj instanceof Enum) {
@@ -353,7 +353,7 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
                     }
                 } else {
                     if (columnName != null) {
-                        columnNameValMap.put(columnName, metaObject.getValue(propertyName));
+                        columnNameValMap.put(columnName, getParameterValue(updateSql, metaObject, propertyName));
                     }
                 }
             } catch (Exception e) {
@@ -505,11 +505,18 @@ public class DataChangeRecorderInnerInterceptor implements InnerInterceptor {
             if (propertyName.startsWith("ew.paramNameValuePairs")) {
                 continue;
             }
-            Object propertyValue = metaObject.getValue(propertyName);
+            Object propertyValue = getParameterValue(boundSql, metaObject, propertyName);
             propertyValMap.put(propertyName, propertyValue);
         }
         return propertyValMap;
 
+    }
+
+    private Object getParameterValue(BoundSql boundSql, MetaObject metaObject, String propertyName) {
+        if (boundSql.hasAdditionalParameter(propertyName)) {
+            return boundSql.getAdditionalParameter(propertyName);
+        }
+        return metaObject.getValue(propertyName);
     }
 
 

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/inner/DataChangeRecorderInnerInterceptorTest.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/inner/DataChangeRecorderInnerInterceptorTest.java
@@ -1,15 +1,20 @@
 package com.baomidou.mybatisplus.test.extension.plugins.inner;
 
+import com.baomidou.mybatisplus.extension.parser.JsqlParserGlobal;
 import com.baomidou.mybatisplus.extension.plugins.inner.DataChangeRecorderInnerInterceptor;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.update.Update;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.session.Configuration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -50,6 +55,32 @@ class DataChangeRecorderInnerInterceptorTest {
         Assertions.assertEquals(operationResult.getTableName(), "H2USER:*");
         Assertions.assertFalse(operationResult.isRecordStatus());
         Assertions.assertNull(operationResult.getChangedData());
+    }
+
+    @Test
+    void processInsertWithForeachAdditionalParameter() throws Exception {
+        Configuration configuration = new Configuration();
+        List<ParameterMapping> parameterMappings = List.of(
+            new ParameterMapping.Builder(configuration, "__frch_item_0.id", Long.class).build(),
+            new ParameterMapping.Builder(configuration, "__frch_item_0.name", String.class).build(),
+            new ParameterMapping.Builder(configuration, "__frch_item_1.id", Long.class).build(),
+            new ParameterMapping.Builder(configuration, "__frch_item_1.name", String.class).build()
+        );
+        BoundSql boundSql = new BoundSql(configuration, "insert into sys_user (id, name) values (?, ?), (?, ?)",
+            parameterMappings, Map.of("list", List.of(
+                Map.of("id", 1L, "name", "Alice"),
+                Map.of("id", 2L, "name", "Bob")
+            )));
+        boundSql.setAdditionalParameter("__frch_item_0", Map.of("id", 1L, "name", "Alice"));
+        boundSql.setAdditionalParameter("__frch_item_1", Map.of("id", 2L, "name", "Bob"));
+        Insert insert = (Insert) JsqlParserGlobal.parse("insert into sys_user (id, name) values (?, ?), (?, ?)");
+
+        DataChangeRecorderInnerInterceptor.OperationResult operationResult = interceptor.processInsert(insert, boundSql);
+
+        Assertions.assertEquals("sys_user", operationResult.getTableName());
+        Assertions.assertTrue(operationResult.isRecordStatus());
+        Assertions.assertTrue(operationResult.getChangedData().contains("\"ID\":\"null->1\""));
+        Assertions.assertTrue(operationResult.getChangedData().contains("\"NAME\":\"null->Alice\""));
     }
 
     @Test

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
@@ -311,11 +311,13 @@ class H2UserTest extends BaseTest {
             Configuration configuration = sqlSessionFactory.getConfiguration();
             for (Interceptor interceptor : configuration.getInterceptors()) {
                 if (interceptor instanceof MybatisPlusInterceptor) {
-                    List<InnerInterceptor> innerInterceptors = ((MybatisPlusInterceptor) interceptor).getInterceptors();
+                    MybatisPlusInterceptor mybatisPlusInterceptor = (MybatisPlusInterceptor) interceptor;
+                    List<InnerInterceptor> innerInterceptors = new ArrayList<>(mybatisPlusInterceptor.getInterceptors());
                     for (int i = 0; i < innerInterceptors.size(); i++) {
                         InnerInterceptor innerInterceptor = innerInterceptors.get(i);
                         if (innerInterceptor instanceof DataChangeRecorderInnerInterceptor) {
                             innerInterceptors.set(i, replacement);
+                            mybatisPlusInterceptor.setInterceptors(innerInterceptors);
                             return (DataChangeRecorderInnerInterceptor) innerInterceptor;
                         }
                     }
@@ -877,8 +879,9 @@ class H2UserTest extends BaseTest {
             DataChangeRecorderInnerInterceptor.OperationResult operationResult = recorder.getOperationResult();
             Assertions.assertNotNull(operationResult);
             Assertions.assertTrue(operationResult.isRecordStatus());
-            Assertions.assertTrue(operationResult.getChangedData().contains("\"NAME\":\"null->xmlForeachInsertA\""));
-            Assertions.assertTrue(operationResult.getChangedData().contains("\"NAME\":\"null->xmlForeachInsertB\""));
+            String changedData = operationResult.getChangedData();
+            Assertions.assertTrue(changedData.contains("\"TESTID\":\"null->" + id1 + "\""), changedData);
+            Assertions.assertTrue(changedData.contains("\"NAME\":\"null->xmlForeachInsertA\""), changedData);
         } finally {
             replaceDataChangeRecorder(original);
         }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserTest.java
@@ -306,6 +306,39 @@ class H2UserTest extends BaseTest {
         return checkIsDataUpdateLimitationException(e.getCause());
     }
 
+    private DataChangeRecorderInnerInterceptor replaceDataChangeRecorder(DataChangeRecorderInnerInterceptor replacement) {
+        if (sqlSessionFactory instanceof DefaultSqlSessionFactory) {
+            Configuration configuration = sqlSessionFactory.getConfiguration();
+            for (Interceptor interceptor : configuration.getInterceptors()) {
+                if (interceptor instanceof MybatisPlusInterceptor) {
+                    List<InnerInterceptor> innerInterceptors = ((MybatisPlusInterceptor) interceptor).getInterceptors();
+                    for (int i = 0; i < innerInterceptors.size(); i++) {
+                        InnerInterceptor innerInterceptor = innerInterceptors.get(i);
+                        if (innerInterceptor instanceof DataChangeRecorderInnerInterceptor) {
+                            innerInterceptors.set(i, replacement);
+                            return (DataChangeRecorderInnerInterceptor) innerInterceptor;
+                        }
+                    }
+                }
+            }
+        }
+        throw new IllegalStateException("DataChangeRecorderInnerInterceptor not found");
+    }
+
+    private static class CapturingDataChangeRecorderInnerInterceptor extends DataChangeRecorderInnerInterceptor {
+
+        private OperationResult operationResult;
+
+        @Override
+        protected void dealOperationResult(OperationResult operationResult) {
+            this.operationResult = operationResult;
+        }
+
+        private OperationResult getOperationResult() {
+            return operationResult;
+        }
+    }
+
     @Test
     @Order(18)
     void testBatchTransactional() {
@@ -822,6 +855,33 @@ class H2UserTest extends BaseTest {
         map.put("array", h2Users);
         h2StudentMapper.insertFillByCustomMethod13(map);
         list.forEach(user -> Assertions.assertNotNull(user.getTestType()));
+    }
+
+    @Test
+    void testDataChangeRecorderWithRealXmlForeachInsert() {
+        CapturingDataChangeRecorderInnerInterceptor recorder = new CapturingDataChangeRecorderInnerInterceptor();
+        DataChangeRecorderInnerInterceptor original = replaceDataChangeRecorder(recorder);
+        Long id1 = IdWorker.getId();
+        Long id2 = IdWorker.getId();
+        List<H2User> users = Arrays.asList(
+            new H2User(id1, "xmlForeachInsertA", AgeEnum.ONE, 1),
+            new H2User(id2, "xmlForeachInsertB", AgeEnum.TWO, 1)
+        );
+
+        try {
+            long rows = Assertions.assertDoesNotThrow(() -> h2StudentMapper.insertUsersByXmlForeach(users));
+
+            Assertions.assertEquals(2, rows);
+            Assertions.assertEquals("xmlForeachInsertA", userService.getById(id1).getName());
+            Assertions.assertEquals("xmlForeachInsertB", userService.getById(id2).getName());
+            DataChangeRecorderInnerInterceptor.OperationResult operationResult = recorder.getOperationResult();
+            Assertions.assertNotNull(operationResult);
+            Assertions.assertTrue(operationResult.isRecordStatus());
+            Assertions.assertTrue(operationResult.getChangedData().contains("\"NAME\":\"null->xmlForeachInsertA\""));
+            Assertions.assertTrue(operationResult.getChangedData().contains("\"NAME\":\"null->xmlForeachInsertB\""));
+        } finally {
+            replaceDataChangeRecorder(original);
+        }
     }
 
     @Test

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/mapper/H2StudentMapper.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/mapper/H2StudentMapper.java
@@ -40,6 +40,8 @@ public interface H2StudentMapper extends SuperMapper<H2Student> {
 
     long insertFillByCustomMethod13(Map<String, Object> paramMap);
 
+    long insertUsersByXmlForeach(@Param("list") List<H2User> h2Users);
+
     long updateFillByCustomMethod1(Map<String, Object> paramMap);
 
     long updateFillByCustomMethod2(@Param("coll") Collection<Long> ids, @Param("et") H2User h2User);

--- a/mybatis-plus/src/test/resources/com/baomidou/mybatisplus/test/h2/mapper/H2StudentMapper.xml
+++ b/mybatis-plus/src/test/resources/com/baomidou/mybatisplus/test/h2/mapper/H2StudentMapper.xml
@@ -86,6 +86,13 @@
         </foreach>
     </insert>
 
+    <insert id="insertUsersByXmlForeach">
+        insert into h2user(test_id, name, age, test_type) values
+        <foreach collection="list" item="item" separator=",">
+            (#{item.testId}, #{item.name}, #{item.age}, #{item.testType})
+        </foreach>
+    </insert>
+
     <update id="updateFillByCustomMethod1">
         update h2user set deleted = 1,last_updated_dt = #{et.lastUpdatedDt} where test_id in (
         <foreach collection="list" item="col" separator=",">


### PR DESCRIPTION
Related to #7061.

## Summary
- Resolve custom XML foreach insert parameter names such as `__frch_item_0.id` through `BoundSql` additional parameters before falling back to the original parameter object lookup.
- This lets `DataChangeRecorderInnerInterceptor` record inserted values from foreach item/list data instead of failing to resolve the generated foreach binding names.
- Add regression tests for foreach insert additional parameters across the jsqlparser variants.

## Validation
- `git diff --check origin/3.0...HEAD` passed.
- Marker scan on changed files for TODO/FIXME/XXX/debug/focus leftovers found no matches.
- `./gradlew.bat --version` used cached Gradle 8.13.
- `./gradlew.bat :mybatis-plus-jsqlparser-support:mybatis-plus-jsqlparser:testClasses :mybatis-plus-jsqlparser-support:mybatis-plus-jsqlparser-4.9:testClasses :mybatis-plus-jsqlparser-support:mybatis-plus-jsqlparser-5.0:testClasses --no-daemon --max-workers=1` passed.
- Focused `DataChangeRecorderInnerInterceptorTest` execution was attempted, but the local Gradle test worker failed before running tests with `ClassNotFoundException: worker.org.gradle.process.internal.worker.GradleWorkerMain`.