### PR TITLE
feat(wrapper): 添加eqOrIsNull方法并优化参数别名设置逻辑

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/AbstractWrapper.java
@@ -147,6 +147,17 @@ public abstract class AbstractWrapper<T, R, Children extends AbstractWrapper<T, 
     }
 
     @Override
+    public Children eqOrIsNull(boolean condition, R column, Object val) {
+        return maybeDo(condition, () -> {
+            if (StringUtils.checkValNotNull(val)) {
+                addCondition(true, column, EQ, val);
+            } else {
+                appendSqlSegments(columnToSqlSegment(column), IS_NULL);
+            }
+        });
+    }
+
+    @Override
     public Children ne(boolean condition, R column, Object val) {
         return addCondition(condition, column, NE, val);
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
@@ -115,6 +115,27 @@ public interface Compare<Children, R> extends Serializable {
     Children eq(boolean condition, R column, Object val);
 
     /**
+     * 等于 = ，值为 null 时自动转为 IS NULL
+     *
+     * @param column 字段
+     * @param val    值
+     * @return children
+     */
+    default Children eqOrIsNull(R column, Object val) {
+        return eqOrIsNull(true, column, val);
+    }
+
+    /**
+     * 等于 = ，值为 null 时自动转为 IS NULL
+     *
+     * @param condition 执行条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    Children eqOrIsNull(boolean condition, R column, Object val);
+
+    /**
      * 不等于 &lt;&gt;
      *
      * @param column    字段

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/AbstractChainWrapper.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/AbstractChainWrapper.java
@@ -88,6 +88,12 @@ public abstract class AbstractChainWrapper<T, R, Children extends AbstractChainW
     }
 
     @Override
+    public Children eqOrIsNull(boolean condition, R column, Object val) {
+        getWrapper().eqOrIsNull(condition, column, val);
+        return typedThis;
+    }
+
+    @Override
     public Children ne(boolean condition, R column, Object val) {
         getWrapper().ne(condition, column, val);
         return typedThis;


### PR DESCRIPTION
- 在AbstractChainWrapper中新增eqOrIsNull方法实现
- 简化AbstractWrapper中setParamAlias方法的参数别名变更处理逻辑
- 移除onParamAliasChanged回调方法和相关断言检查
- 使用clearSqlSegmentCache替代原有的表达式参数别名变更处理