### PR TITLE
docs(core): clarify IdWorker sequence configuration

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/config/GlobalConfig.java
@@ -216,10 +216,13 @@ public class GlobalConfig implements Serializable {
     /**
      * 雪花ID配置
      * <p>
-     * 1. 手动指定{@link #workerId} 和 {@link #datacenterId}
+     * 1. 手动指定{@link #workerId} 和 {@link #datacenterId}，多实例部署时需保证两者组合在所有实例中唯一
      * </p>
      * <p>
      * 2. 基于网卡信息和进程PID计算 {@link #workerId} 和 {@link #datacenterId}
+     * </p>
+     * <p>
+     * 注意：随机值不能保证全局唯一，重启或扩容时仍可能和其他实例碰撞
      * </p>
      *
      * @since 3.5.7
@@ -230,11 +233,13 @@ public class GlobalConfig implements Serializable {
 
         /**
          * 工作机器 ID
+         * <p>取值范围 0-31，多实例部署时需与 {@link #datacenterId} 组合保持唯一</p>
          */
         private Long workerId;
 
         /**
          * 数据标识 ID 部分
+         * <p>取值范围 0-31，多实例部署时需与 {@link #workerId} 组合保持唯一</p>
          */
         private Long datacenterId;
 

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/incrementer/DefaultIdentifierGenerator.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/incrementer/DefaultIdentifierGenerator.java
@@ -44,6 +44,13 @@ public class DefaultIdentifierGenerator implements IdentifierGenerator {
         this.sequence = new Sequence(inetAddress);
     }
 
+    /**
+     * 使用指定的工作机器 ID 和数据中心 ID 初始化雪花 ID 生成器
+     * <p>生产多实例部署时，请确保 workerId 与 dataCenterId 的组合全局唯一。</p>
+     *
+     * @param workerId     工作机器 ID，取值范围 0-31
+     * @param dataCenterId 数据中心 ID，取值范围 0-31
+     */
     public DefaultIdentifierGenerator(long workerId, long dataCenterId) {
         this.sequence = new Sequence(workerId, dataCenterId);
     }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/IdWorker.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/IdWorker.java
@@ -94,7 +94,8 @@ public class IdWorker {
     }
 
     /**
-     * 有参构造器
+     * 初始化雪花 ID 生成器
+     * <p>多实例部署时，需要为每个实例分配唯一的 workerId 和 dataCenterId 组合，避免不同实例生成重复 ID。</p>
      *
      * @param workerId     工作机器 ID
      * @param dataCenterId 序列号


### PR DESCRIPTION
### 变更

- 补充雪花 ID `workerId` 与 `datacenterId` 在多实例部署下需要保持组合唯一的说明。
- 为 `IdWorker.initSequence` 和 `DefaultIdentifierGenerator(long, long)` 增加使用提醒与参数范围说明。
- 明确随机值不能保证全局唯一，重启或扩容时仍可能和其他实例碰撞。

### 背景

Related to #7135。

`IdWorker.getId()` 使用雪花 ID 生成逻辑时，唯一性依赖每个实例的 `workerId` + `datacenterId` 组合不冲突。补充该说明可以减少多实例部署时因配置不当导致的重复 ID 风险。

### 验证

- `git diff --check`
- `./gradlew.bat --no-daemon :mybatis-plus-core:compileJava`