### PR TITLE
feat: add strictResultMapCollectionTypeCheck for ResultMap <collection> ofType validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿# CHANGELOG
 
+## [v3.5.18] 2026.07.13
+- feat: 新增 `strictResultMapCollectionTypeCheck` ResultMap `collection` 元素 `ofType` 类型严格校验
+
 ## [v3.5.17] 2026.07.07
 - fix: 修复 `issues/6899` 多租户插件 `@Many` 注解查无效问题
 - fix: 修复 `issues/6938` `HashMap` 设置类型转换器异常

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisConfiguration.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisConfiguration.java
@@ -23,6 +23,7 @@ import com.baomidou.mybatisplus.core.toolkit.ReflectionKit;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.binding.MapperRegistry;
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.executor.Executor;
@@ -33,6 +34,7 @@ import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.mapping.ParameterMap;
 import org.apache.ibatis.mapping.ResultMap;
+import org.apache.ibatis.mapping.ResultMapping;
 import org.apache.ibatis.parsing.XNode;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.session.Configuration;
@@ -78,6 +80,20 @@ public class MybatisConfiguration extends Configuration {
     @Setter
     @Getter
     private boolean useGeneratedShortKey = true;
+    /**
+     * Whether to enable strict type checking for {@code <collection>} elements in ResultMap.
+     * <p>
+     * When enabled, the {@code ofType} attribute of each {@code <collection>} element is validated
+     * against the generic element type of the corresponding collection field in the entity class.
+     * A {@link BuilderException} is thrown if the declared type is not assignable to the expected type.
+     * Default is false.
+     * </p>
+     *
+     * @since 3.5.18
+     */
+    @Setter
+    @Getter
+    private boolean strictResultMapCollectionTypeCheck = false;
 
     public MybatisConfiguration(Environment environment) {
         this();
@@ -280,6 +296,10 @@ public class MybatisConfiguration extends Configuration {
         resultMaps.put(rm.getId(), rm);
         checkLocallyForDiscriminatedNestedResultMaps(rm);
         checkGloballyForDiscriminatedNestedResultMaps(rm);
+
+        if (strictResultMapCollectionTypeCheck) {
+            validateCollectionResultMapTypes(rm);
+        }
     }
 
     @Override
@@ -404,6 +424,75 @@ public class MybatisConfiguration extends Configuration {
                 }
             }
         }
+    }
+
+    /**
+     * Validates that the element type declared via {@code ofType} on each {@code <collection>}
+     * element is compatible with the generic element type of the corresponding collection field
+     * in the entity class.
+     * <p>
+     * For each {@link ResultMapping} that maps to a collection property, the expected element type
+     * is resolved from the entity field's generic signature, and the declared element type is
+     * resolved from the XML mapping. A {@link BuilderException} is thrown if the declared type
+     * is not assignable to the expected type.
+     * </p>
+     *
+     * @param rm the ResultMap to validate
+     */
+    private void validateCollectionResultMapTypes(ResultMap rm) {
+        Class<?> entityType = rm.getType();
+        for (ResultMapping mapping : rm.getResultMappings()) {
+            if (mapping.getProperty() == null) continue;
+
+            Class<?> expectedElementType = ReflectionKit.getCollectionElementType(
+                entityType, mapping.getProperty());
+            if (expectedElementType == null) continue;
+
+            Class<?> declaredElementType = resolveDeclaredElementType(mapping);
+            if (declaredElementType == null) continue;
+
+            if (!expectedElementType.isAssignableFrom(declaredElementType)) {
+                throw new BuilderException(
+                    "ResultMap '" + rm.getId() + "': " +
+                        "Collection property '" + mapping.getProperty() + "' " +
+                        "expects elements of type '" + expectedElementType.getName() + "' " +
+                        "but XML declares '" + declaredElementType.getName() + "'. " +
+                        "Please check the 'ofType' attribute on your <collection> element."
+                );
+            }
+        }
+    }
+
+    /**
+     * Resolves the element type declared in the XML mapping for a {@code <collection>} element.
+     * <p>
+     * The resolution strategy, in order of priority:
+     * <ol>
+     *   <li>The {@code type} of the nested {@link ResultMap} referenced via {@code ofType}
+     *       or {@code resultMap} attribute</li>
+     *   <li>The {@code javaType} attribute value, only if it is not itself a collection type</li>
+     * </ol>
+     * Returns {@code null} if the declared element type cannot be determined, in which case
+     * the type check for this mapping is skipped.
+     * </p>
+     *
+     * @param mapping the ResultMapping to inspect
+     * @return the declared element type, or {@code null} if it cannot be determined
+     */
+    private Class<?> resolveDeclaredElementType(ResultMapping mapping) {
+        String nestedResultMapId = mapping.getNestedResultMapId();
+        if (nestedResultMapId != null) {
+            ResultMap nestedResultMap = getResultMap(nestedResultMapId);
+            if (nestedResultMap != null) {
+                return nestedResultMap.getType();
+            }
+            return null;
+        }
+        Class<?> javaType = mapping.getJavaType();
+        if (javaType != null && !Collection.class.isAssignableFrom(javaType)) {
+            return javaType;
+        }
+        return null;
     }
 
     protected class StrictMap<V> extends ConcurrentHashMap<String, V> {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKit.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/ReflectionKit.java
@@ -21,6 +21,7 @@ import com.baomidou.mybatisplus.core.toolkit.reflect.TypeParameterResolver;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
 import java.security.AccessController;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -201,4 +202,50 @@ public final class ReflectionKit {
         return AccessController.doPrivileged(new SetAccessibleAction<>(object));
     }
 
+    /**
+     * Resolves the generic element type of a collection-typed field on the given entity class.
+     * <p>
+     * For example, given a class {@code Group} with field {@code List<User> users},
+     * calling {@code getCollectionElementType(Group.class, "users")} returns {@code User.class}.
+     * </p>
+     *
+     * @param entityClass  the entity class to inspect
+     * @param propertyName the field name
+     * @return the collection element type, or {@code null} if the field is not a
+     *         parameterized collection or does not exist
+     */
+    public static Class<?> getCollectionElementType(Class<?> entityClass, String propertyName) {
+        try {
+            Field field = findField(entityClass, propertyName);
+            return extractCollectionElementType(field);
+        } catch (NoSuchFieldException e) {
+            return null;
+        }
+    }
+
+    private static Field findField(Class<?> clazz, String name) throws NoSuchFieldException {
+        try {
+            return clazz.getDeclaredField(name);
+        } catch (NoSuchFieldException e) {
+            Class<?> parent = clazz.getSuperclass();
+            if (parent != null && parent != Object.class) {
+                return findField(parent, name);
+            }
+            throw e;
+        }
+    }
+
+    private static Class<?> extractCollectionElementType(Field field) {
+        java.lang.reflect.Type genericType = field.getGenericType();
+        if (genericType instanceof ParameterizedType) {
+            ParameterizedType pt = (ParameterizedType) genericType;
+            if (Collection.class.isAssignableFrom((Class<?>) pt.getRawType())) {
+                java.lang.reflect.Type[] typeArgs = pt.getActualTypeArguments();
+                if (typeArgs.length == 1 && typeArgs[0] instanceof Class) {
+                    return (Class<?>) typeArgs[0];
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionMapper.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionMapper.java
@@ -1,0 +1,16 @@
+package com.baomidou.mybatisplus.test.strictcollection;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+/**
+ * @author nieqiurong
+ * @since 3.5.18
+ */
+@Mapper
+public interface StrictCollectionMapper extends BaseMapper<StrictGroupEntity> {
+
+    List<StrictGroupEntity> selectAllWithUsers();
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionTypeCheckTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionTypeCheckTest.java
@@ -1,0 +1,326 @@
+package com.baomidou.mybatisplus.test.strictcollection;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.MybatisSqlSessionFactoryBuilder;
+import com.baomidou.mybatisplus.core.MybatisXMLMapperBuilder;
+import com.baomidou.mybatisplus.core.toolkit.ExceptionUtils;
+import org.apache.ibatis.builder.BuilderException;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.logging.slf4j.Slf4jImpl;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.transaction.managed.ManagedTransactionFactory;
+import org.h2.Driver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link MybatisConfiguration#setStrictResultMapCollectionTypeCheck(boolean)}.
+ *
+ * <h2>Background</h2>
+ * <p>
+ * In MyBatis, when mapping a one-to-many relationship via {@code <collection>} in XML ResultMap,
+ * the {@code ofType} attribute specifies the element type of the collection. For example:
+ * </p>
+ * <pre>{@code
+ * // Entity class:
+ * public class Group {
+ *     private List<User> users;  // expects User elements
+ * }
+ *
+ * <!-- XML ResultMap: -->
+ * <collection property="users" ofType="com.example.User">
+ *     ...
+ * </collection>
+ * }</pre>
+ * <p>
+ * However, due to Java type erasure, MyBatis does <strong>not</strong> validate whether the
+ * {@code ofType} type matches the generic element type declared in the entity class. If a
+ * developer accidentally writes {@code ofType="WrongType"}, the error is silently accepted
+ * at parse time and only surfaces as a {@link ClassCastException} at runtime — often far
+ * from the root cause, making it very hard to debug.
+ * </p>
+ *
+ * <h2>What This Feature Solves</h2>
+ * <p>
+ * The {@code strictResultMapCollectionTypeCheck} option, when enabled, performs type validation
+ * at ResultMap registration time (i.e. when {@code addResultMap()} is called during XML parsing).
+ * It compares the {@code ofType} declared type against the entity field's generic element type
+ * and throws a {@link BuilderException} immediately if they are incompatible — turning a
+ * hard-to-debug runtime error into a clear, early fail-fast error message.
+ * </p>
+ *
+ * <h2>Test Scenarios</h2>
+ * <p>
+ * This class contains three test cases that together verify the feature works correctly
+ * and does not break existing behavior:
+ * </p>
+ * <ol>
+ *   <li>{@link #correctOfType_passesWhenStrictCheckEnabled()} — correct mapping works fine</li>
+ *   <li>{@link #wrongOfType_throwsBuilderExceptionWhenStrictCheckEnabled()} — wrong mapping is rejected</li>
+ *   <li>{@link #wrongOfType_passesWhenStrictCheckDisabled()} — backward compatibility preserved</li>
+ * </ol>
+ *
+ * @author nieqiurong
+ * @since 3.5.18
+ */
+public class StrictCollectionTypeCheckTest {
+
+    private DataSource dataSource;
+    private JdbcTemplate jdbcTemplate;
+
+    /**
+     * Sets up an H2 in-memory database with test data before each test.
+     * <p>
+     * Creates two tables:
+     * </p>
+     * <ul>
+     *   <li>{@code t_strict_group} — 2 groups: "Developers" and "QA Team"</li>
+     *   <li>{@code t_strict_user} — 3 users: Alice & Bob in group 1, Charlie in group 2</li>
+     * </ul>
+     * <p>
+     * Tables are dropped and recreated before each test to ensure isolation.
+     * </p>
+     */
+    @BeforeEach
+    void setUp() {
+        dataSource = createDataSource();
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        initSchema();
+    }
+
+    /**
+     * Test 1: Correct {@code ofType} with strict checking enabled — should work normally.
+     * <p>
+     * <b>Problem addressed:</b> Ensures that enabling strict checking does not break
+     * existing, correctly-configured ResultMap mappings. Developers should be able to
+     * turn on the feature without worrying about false positives.
+     * </p>
+     * <p>
+     * <b>Setup:</b>
+     * </p>
+     * <ul>
+     *   <li>Entity: {@code StrictGroupEntity} with field {@code List<StrictUserEntity> users}</li>
+     *   <li>XML: {@code <collection property="users" ofType="StrictUserEntity">}</li>
+     *   <li>Strict checking: <strong>ON</strong></li>
+     * </ul>
+     * <p>
+     * <b>Expected:</b> XML parsing succeeds, query returns 2 groups with correct user data.
+     * </p>
+     */
+    @Test
+    void correctOfType_passesWhenStrictCheckEnabled() {
+        MybatisConfiguration configuration = createConfiguration(true);
+        parseMapperXml(configuration, "com/baomidou/mybatisplus/test/strictcollection/StrictCollectionMapper.xml");
+        configuration.addMapper(StrictCollectionMapper.class);
+
+        SqlSessionFactory factory = new MybatisSqlSessionFactoryBuilder().build(configuration);
+        try (SqlSession session = factory.openSession()) {
+            StrictCollectionMapper mapper = session.getMapper(StrictCollectionMapper.class);
+            List<StrictGroupEntity> groups = mapper.selectAllWithUsers();
+
+            // Verify: 2 groups returned
+            assertThat(groups).hasSize(2);
+            StrictGroupEntity firstGroup = groups.get(0);
+            // Verify: first group is "Developers"
+            assertThat(firstGroup.getGroupName()).isEqualTo("Developers");
+            // Verify: first group has 2 users (Alice, Bob)
+            assertThat(firstGroup.getUsers()).hasSize(2);
+            // Verify: users are instances of StrictUserEntity (the correct type)
+            assertThat(firstGroup.getUsers().get(0)).isInstanceOf(StrictUserEntity.class);
+            assertThat(firstGroup.getUsers().get(0).getUserName()).isEqualTo("Alice");
+        }
+    }
+
+    /**
+     * Test 2: Wrong {@code ofType} with strict checking enabled — should fail fast.
+     * <p>
+     * <b>Problem addressed:</b> This is the core scenario the feature is designed to catch.
+     * Without strict checking, a developer who accidentally writes
+     * {@code ofType="StrictWrongUserEntity"} instead of {@code ofType="StrictUserEntity"}
+     * would get no error at startup — the mismatch would only surface later as a
+     * confusing {@link ClassCastException} at runtime.
+     * </p>
+     * <p>
+     * <b>Setup:</b>
+     * </p>
+     * <ul>
+     *   <li>Entity: {@code StrictGroupEntity} with field {@code List<StrictUserEntity> users}</li>
+     *   <li>XML: {@code <collection property="users" ofType="StrictWrongUserEntity">} (WRONG!)</li>
+     *   <li>Strict checking: <strong>ON</strong></li>
+     * </ul>
+     * <p>
+     * <b>Expected:</b> A {@link BuilderException} is thrown at XML parse time (not at query time),
+     * with an error message that clearly states:
+     * </p>
+     * <ul>
+     *   <li>Which collection property has the mismatch ({@code users})</li>
+     *   <li>What type was expected ({@code StrictUserEntity})</li>
+     *   <li>What type was actually declared ({@code StrictWrongUserEntity})</li>
+     * </ul>
+     */
+    @Test
+    void wrongOfType_throwsBuilderExceptionWhenStrictCheckEnabled() {
+        MybatisConfiguration configuration = createConfiguration(true);
+
+        // Parsing the wrong XML must throw BuilderException immediately
+        assertThatThrownBy(() ->
+            parseMapperXml(configuration, "com/baomidou/mybatisplus/test/strictcollection/StrictCollectionWrongMapper.xml")
+        ).isInstanceOf(BuilderException.class)
+            // Error message must mention the collection property name
+            .hasMessageContaining("Collection property 'users'")
+            // Error message must mention the expected type (from entity field generic)
+            .hasMessageContaining("StrictUserEntity")
+            // Error message must mention the wrong type declared in XML
+            .hasMessageContaining("StrictWrongUserEntity");
+    }
+
+    /**
+     * Test 3: Wrong {@code ofType} with strict checking disabled — should be silently accepted.
+     * <p>
+     * <b>Problem addressed:</b> Ensures backward compatibility. When strict checking is off
+     * (the default), the framework behaves exactly as before — no new errors are introduced.
+     * Existing projects that upgrade to this version will not break even if they have
+     * type-mismatched ResultMap mappings.
+     * </p>
+     * <p>
+     * <b>Setup:</b>
+     * </p>
+     * <ul>
+     *   <li>Entity: {@code StrictGroupEntity} with field {@code List<StrictUserEntity> users}</li>
+     *   <li>XML: {@code <collection property="users" ofType="StrictWrongUserEntity">} (WRONG!)</li>
+     *   <li>Strict checking: <strong>OFF</strong> (default)</li>
+     * </ul>
+     * <p>
+     * <b>Expected:</b> XML parsing succeeds, query runs without error. Due to Java type erasure,
+     * {@code StrictWrongUserEntity} objects are silently inserted into the {@code List} field
+     * — this is the pre-existing behavior that the strict checking feature is designed to
+     * make opt-in detectable.
+     * </p>
+     */
+    @Test
+    void wrongOfType_passesWhenStrictCheckDisabled() {
+        MybatisConfiguration configuration = createConfiguration(false);
+        parseMapperXml(configuration, "com/baomidou/mybatisplus/test/strictcollection/StrictCollectionWrongMapper.xml");
+        configuration.addMapper(StrictCollectionWrongMapper.class);
+
+        SqlSessionFactory factory = new MybatisSqlSessionFactoryBuilder().build(configuration);
+        try (SqlSession session = factory.openSession()) {
+            StrictCollectionWrongMapper mapper = session.getMapper(StrictCollectionWrongMapper.class);
+            List<StrictGroupEntity> groups = mapper.selectAllWithWrongUsers();
+
+            // Verify: query still works (backward compatible)
+            assertThat(groups).hasSize(2);
+            // Due to Java erasure, StrictWrongUserEntity objects are silently inserted
+            // into the List<StrictUserEntity> field without any error.
+            // This is exactly the type-safety gap that strictResultMapCollectionTypeCheck
+            // is designed to catch when enabled.
+            assertThat(groups.get(0).getUsers()).hasSize(2);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Helper methods
+    // ------------------------------------------------------------------
+
+    /**
+     * Creates a {@link MybatisConfiguration} with the specified strict checking mode.
+     *
+     * @param strictCheck {@code true} to enable strict collection type checking,
+     *                    {@code false} to disable (default behavior)
+     */
+    private MybatisConfiguration createConfiguration(boolean strictCheck) {
+        Environment environment = new Environment("test", new ManagedTransactionFactory(), dataSource);
+        MybatisConfiguration configuration = new MybatisConfiguration(environment);
+        configuration.setStrictResultMapCollectionTypeCheck(strictCheck);
+        configuration.setLogImpl(Slf4jImpl.class);
+        configuration.setMapUnderscoreToCamelCase(true);
+        return configuration;
+    }
+
+    /**
+     * Parses a mapper XML file and registers its ResultMaps in the configuration.
+     *
+     * @param configuration the MybatisConfiguration to parse into
+     * @param resource      the classpath resource path of the XML file
+     */
+    private void parseMapperXml(MybatisConfiguration configuration, String resource) {
+        try {
+            InputStream inputStream = Resources.getResourceAsStream(resource);
+            MybatisXMLMapperBuilder xmlMapperBuilder = new MybatisXMLMapperBuilder(
+                inputStream, configuration, resource, configuration.getSqlFragments());
+            xmlMapperBuilder.parse();
+        } catch (IOException e) {
+            throw ExceptionUtils.mpe(e);
+        }
+    }
+
+    /**
+     * Creates an H2 in-memory data source for testing.
+     * <p>
+     * Uses {@code DB_CLOSE_DELAY=-1} to keep the database alive across connections
+     * within the same test, so that {@code @BeforeEach} setup and the test itself
+     * can share the same data.
+     * </p>
+     */
+    private DataSource createDataSource() {
+        SimpleDriverDataSource ds = new SimpleDriverDataSource();
+        ds.setDriver(new Driver());
+        ds.setUrl("jdbc:h2:mem:strict_collection_test;MODE=mysql;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        ds.setUsername("sa");
+        ds.setPassword("");
+        return ds;
+    }
+
+    /**
+     * Initializes the database schema and test data.
+     * <p>
+     * Tables are dropped first to ensure a clean state between tests (the H2 in-memory
+     * database is shared via {@code DB_CLOSE_DELAY=-1}).
+     * </p>
+     * <p>
+     * Test data:
+     * </p>
+     * <pre>
+     * t_strict_group:
+     *   id=1  group_name=Developers  description=Dev Team
+     *   id=2  group_name=QA Team     description=QA Team
+     *
+     * t_strict_user:
+     *   id=1  group_id=1  user_name=Alice    email=alice@example.com    age=28
+     *   id=2  group_id=1  user_name=Bob      email=bob@example.com      age=32
+     *   id=3  group_id=2  user_name=Charlie  email=charlie@example.com  age=25
+     * </pre>
+     */
+    private void initSchema() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS t_strict_user");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS t_strict_group");
+        jdbcTemplate.execute("CREATE TABLE t_strict_group (" +
+            "id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+            "group_name VARCHAR(100) NOT NULL, " +
+            "description VARCHAR(255))");
+        jdbcTemplate.execute("CREATE TABLE t_strict_user (" +
+            "id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+            "group_id BIGINT NOT NULL, " +
+            "user_name VARCHAR(100) NOT NULL, " +
+            "email VARCHAR(100), " +
+            "age INT)");
+        jdbcTemplate.execute("INSERT INTO t_strict_group (group_name, description) VALUES " +
+            "('Developers', 'Dev Team'), ('QA Team', 'QA Team')");
+        jdbcTemplate.execute("INSERT INTO t_strict_user (group_id, user_name, email, age) VALUES " +
+            "(1, 'Alice', 'alice@example.com', 28), " +
+            "(1, 'Bob', 'bob@example.com', 32), " +
+            "(2, 'Charlie', 'charlie@example.com', 25)");
+    }
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionWrongMapper.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionWrongMapper.java
@@ -1,0 +1,15 @@
+package com.baomidou.mybatisplus.test.strictcollection;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+/**
+ * Mapper interface used to verify that strict collection type checking
+ * rejects mismatched {@code ofType} declarations.
+ *
+ * @author nieqiurong
+ * @since 3.5.18
+ */
+public interface StrictCollectionWrongMapper extends BaseMapper<StrictGroupEntity> {
+
+    java.util.List<StrictGroupEntity> selectAllWithWrongUsers();
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictGroupEntity.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictGroupEntity.java
@@ -1,0 +1,33 @@
+package com.baomidou.mybatisplus.test.strictcollection;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * @author nieqiurong
+ * @since 3.5.18
+ */
+@Data
+@TableName("t_strict_group")
+public class StrictGroupEntity {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private String groupName;
+
+    private String description;
+
+    /**
+     * Collection field whose generic element type is {@link StrictUserEntity}.
+     * When {@code strictResultMapCollectionTypeCheck} is enabled, the
+     * {@code ofType} attribute in the XML mapping must be compatible with this type.
+     */
+    @TableField(exist = false)
+    private List<StrictUserEntity> users;
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictUserEntity.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictUserEntity.java
@@ -1,0 +1,26 @@
+package com.baomidou.mybatisplus.test.strictcollection;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * @author nieqiurong
+ * @since 3.5.18
+ */
+@Data
+@TableName("t_strict_user")
+public class StrictUserEntity {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private Long groupId;
+
+    private String userName;
+
+    private String email;
+
+    private Integer age;
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictWrongUserEntity.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/strictcollection/StrictWrongUserEntity.java
@@ -1,0 +1,20 @@
+package com.baomidou.mybatisplus.test.strictcollection;
+
+import lombok.Data;
+
+/**
+ * An entity whose type is <em>not</em> compatible with {@link StrictUserEntity}.
+ * Used to verify that strict collection type checking detects mismatches.
+ *
+ * @author nieqiurong
+ * @since 3.5.18
+ */
+@Data
+public class StrictWrongUserEntity {
+
+    private Long id;
+
+    private Long groupId;
+
+    private String userName;
+}

--- a/mybatis-plus/src/test/resources/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionMapper.xml
+++ b/mybatis-plus/src/test/resources/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.baomidou.mybatisplus.test.strictcollection.StrictCollectionMapper">
+
+    <resultMap id="GroupWithUsersMap" type="com.baomidou.mybatisplus.test.strictcollection.StrictGroupEntity">
+        <id property="id" column="group_id"/>
+        <result property="groupName" column="group_name"/>
+        <result property="description" column="description"/>
+        <collection property="users"
+                    ofType="com.baomidou.mybatisplus.test.strictcollection.StrictUserEntity">
+            <id property="id" column="user_id"/>
+            <result property="groupId" column="user_group_id"/>
+            <result property="userName" column="user_name"/>
+            <result property="email" column="email"/>
+            <result property="age" column="age"/>
+        </collection>
+    </resultMap>
+
+    <select id="selectAllWithUsers" resultMap="GroupWithUsersMap">
+        SELECT
+            g.id   AS group_id,
+            g.group_name,
+            g.description,
+            u.id   AS user_id,
+            u.group_id AS user_group_id,
+            u.user_name,
+            u.email,
+            u.age
+        FROM t_strict_group g
+        LEFT JOIN t_strict_user u ON u.group_id = g.id
+        ORDER BY g.id
+    </select>
+
+</mapper>

--- a/mybatis-plus/src/test/resources/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionWrongMapper.xml
+++ b/mybatis-plus/src/test/resources/com/baomidou/mybatisplus/test/strictcollection/StrictCollectionWrongMapper.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.baomidou.mybatisplus.test.strictcollection.StrictCollectionWrongMapper">
+
+    <!--
+        Deliberately incorrect: ofType declares StrictWrongUserEntity
+        while StrictGroupEntity.users is List<StrictUserEntity>.
+        When strictResultMapCollectionTypeCheck is enabled, parsing
+        this XML must throw a BuilderException.
+    -->
+    <resultMap id="GroupWithWrongUsersMap" type="com.baomidou.mybatisplus.test.strictcollection.StrictGroupEntity">
+        <id property="id" column="group_id"/>
+        <result property="groupName" column="group_name"/>
+        <result property="description" column="description"/>
+        <collection property="users"
+                    ofType="com.baomidou.mybatisplus.test.strictcollection.StrictWrongUserEntity">
+            <id property="id" column="user_id"/>
+            <result property="groupId" column="user_group_id"/>
+            <result property="userName" column="user_name"/>
+        </collection>
+    </resultMap>
+
+    <select id="selectAllWithWrongUsers" resultMap="GroupWithWrongUsersMap">
+        SELECT
+            g.id   AS group_id,
+            g.group_name,
+            g.description,
+            u.id   AS user_id,
+            u.group_id AS user_group_id,
+            u.user_name
+        FROM t_strict_group g
+        LEFT JOIN t_strict_user u ON u.group_id = g.id
+        ORDER BY g.id
+    </select>
+
+</mapper>

--- a/spring-boot-starter/mybatis-plus-spring-boot-autoconfigure/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusProperties.java
+++ b/spring-boot-starter/mybatis-plus-spring-boot-autoconfigure/src/main/java/com/baomidou/mybatisplus/autoconfigure/MybatisPlusProperties.java
@@ -339,6 +339,13 @@ public class MybatisPlusProperties {
 
         private Boolean useGeneratedShortKey;
 
+        /**
+         * Whether to enable strict type checking for {@code <collection>} elements in ResultMap.
+         * When enabled, the {@code ofType} attribute is validated against the generic element
+         * type of the corresponding collection field in the entity class. Default is false.
+         */
+        private Boolean strictResultMapCollectionTypeCheck;
+
         public void applyTo(MybatisConfiguration target) {
             Optional.ofNullable(getSafeRowBoundsEnabled()).ifPresent(target::setSafeRowBoundsEnabled);
             Optional.ofNullable(getSafeResultHandlerEnabled()).ifPresent(target::setSafeResultHandlerEnabled);
@@ -374,6 +381,7 @@ public class MybatisPlusProperties {
             Optional.ofNullable(getDefaultScriptingLanguageDriver()).ifPresent(target::setDefaultScriptingLanguage);
             Optional.ofNullable(getDatabaseId()).ifPresent(target::setDatabaseId);
             Optional.ofNullable(getUseGeneratedShortKey()).ifPresent(target::setUseGeneratedShortKey);
+            Optional.ofNullable(getStrictResultMapCollectionTypeCheck()).ifPresent(target::setStrictResultMapCollectionTypeCheck);
         }
     }
 


### PR DESCRIPTION
# Pull Request: Add strict type checking for ResultMap collection elements

## Title

```
feat: add strictResultMapCollectionTypeCheck for ResultMap <collection> ofType validation
```

## Description

### Motivation

When using `<collection>` in XML ResultMap mappings, MyBatis relies on Java type erasure and silently accepts mismatched `ofType` declarations at runtime. For example, if an entity defines `List<User> users` but the XML declares `ofType="WrongType"`, no error is reported during parsing — the mismatch only surfaces as obscure `ClassCastException`s at runtime, often far from the root cause.

This makes it difficult to catch configuration errors early, especially in large codebases with complex ResultMap mappings.

### Changes

This PR introduces an opt-in strict validation mode that checks `ofType` declarations against the entity field's generic element type at ResultMap registration time.

**Modified files:**

1. **`MybatisConfiguration.java`** (`mybatis-plus-core`)
   - Added `strictResultMapCollectionTypeCheck` field (default: `false`)
   - Added `validateCollectionResultMapTypes()` — iterates ResultMappings, resolves expected vs. declared element types, throws `BuilderException` on mismatch
   - Added `resolveDeclaredElementType()` — resolves the declared element type from nested ResultMap (`ofType`/`resultMap` attribute) or `javaType`
   - Validation hook added to `addResultMap()`

2. **`ReflectionKit.java`** (`mybatis-plus-core`)
   - Added `getCollectionElementType()` — resolves the generic element type of a collection field via reflection (e.g., `List<User>` → `User.class`)
   - Added `findField()` and `extractCollectionElementType()` helpers

3. **`MybatisPlusProperties.java`** (`mybatis-plus-spring-boot-autoconfigure`)
   - Added `strictResultMapCollectionTypeCheck` field to `CoreConfiguration` inner class
   - Added mapping in `applyTo()` to propagate the value to `MybatisConfiguration`

**New test files:**

4. `StrictCollectionTypeCheckTest.java` — 3 test cases covering enabled/disabled scenarios
5. `StrictGroupEntity.java`, `StrictUserEntity.java`, `StrictWrongUserEntity.java` — test entities
6. `StrictCollectionMapper.java`, `StrictCollectionWrongMapper.java` — mapper interfaces
7. `StrictCollectionMapper.xml`, `StrictCollectionWrongMapper.xml` — XML mappings

### Usage

Enable via `application.yml` (Spring Boot):

```yaml
mybatis-plus:
  configuration:
    strict-result-map-collection-type-check: true
```

Or programmatically:

```java
MybatisConfiguration configuration = new MybatisConfiguration();
configuration.setStrictResultMapCollectionTypeCheck(true);
```

When enabled and a mismatch is detected, the following exception is thrown at parse time:

```
BuilderException: ResultMap 'com.example.mapper.GroupMapper.GroupWithUsersMap':
Collection property 'users' expects elements of type 'com.example.entity.User'
but XML declares 'com.example.entity.UserError'.
Please check the 'ofType' attribute on your <collection> element.
```

### Design Decisions

- **Opt-in by default**: `false` by default to preserve full backward compatibility. Existing projects are unaffected.
- **Assignability check**: Uses `Class.isAssignableFrom()` instead of strict equality, so inheritance hierarchies (e.g., `ofType="Dog"` for `List<Animal>`) are correctly accepted.
- **Graceful skipping**: Fields that are not parameterized collections, nested ResultMaps not yet registered, or `select`-based collections are silently skipped — no false positives.
- **Type resolution priority**: Nested ResultMap `type` → `javaType` attribute (if not a collection type itself).

### Testing

3 unit tests using H2 in-memory database:

| Test | Scenario | Expected Result |
|------|----------|----------------|
| `correctOfType_passesWhenStrictCheckEnabled` | Correct `ofType` with strict check ON | Query succeeds, returns expected data |
| `wrongOfType_throwsBuilderExceptionWhenStrictCheckEnabled` | Wrong `ofType` with strict check ON | `BuilderException` thrown at parse time |
| `wrongOfType_passesWhenStrictCheckDisabled` | Wrong `ofType` with strict check OFF | Silently accepted (backward compatible) |

```
BUILD SUCCESSFUL in 21s
3 tests completed, 0 failed
```