### PR TITLE
【feat框架增强】: 引入 SelectReturnTypeHandler 返回值扩展与 executeSharedData 拦截器数据传递机制

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperMethod.java
@@ -17,8 +17,6 @@ package com.baomidou.mybatisplus.core.override;
 
 import com.baomidou.mybatisplus.core.conditions.AbstractWrapper;
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
-import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.core.toolkit.Assert;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.binding.BindingException;
 import org.apache.ibatis.binding.MapperMethod;
@@ -49,6 +47,22 @@ public class MybatisMapperMethod {
     private final MapperMethod.MethodSignature method;
     private final Map<Integer, String> wrapperParamsAliasNameMap;
 
+    /**
+     * execute 级共享数据持有者，生命周期覆盖 MyBatis 拦截器全部生命周期。
+     * 由 {@code MybatisPlusInterceptor} 通过 {@link #getExecuteSharedData()} 读取并传入拦截器链。
+     *
+     * @since 3.5.18
+     */
+    private static final ThreadLocal<Map<String, Object>> EXECUTE_SHARED_DATA = new ThreadLocal<>();
+
+    /**
+     * 获取当前 execute 周期内的共享数据 Map。
+     * 供 {@code MybatisPlusInterceptor} 调用。
+     */
+    public static Map<String, Object> getExecuteSharedData() {
+        return EXECUTE_SHARED_DATA.get();
+    }
+
     public MybatisMapperMethod(Class<?> mapperInterface, Method method, Configuration config) {
         wrapperParamsAliasNameMap = this.getWrapperParamsAliasNameMap(method);
         this.command = new MapperMethod.SqlCommand(config, mapperInterface, method);
@@ -75,71 +89,65 @@ public class MybatisMapperMethod {
 
     public Object execute(SqlSession sqlSession, Object[] args) {
         Object result;
-        switch (command.getType()) {
-            case INSERT: {
-                Object param = this.convertArgsToSqlCommandParam(args);
-                result = rowCountResult(sqlSession.insert(command.getName(), param));
-                break;
-            }
-            case UPDATE: {
-                Object param = this.convertArgsToSqlCommandParam(args);
-                result = rowCountResult(sqlSession.update(command.getName(), param));
-                break;
-            }
-            case DELETE: {
-                Object param = this.convertArgsToSqlCommandParam(args);
-                result = rowCountResult(sqlSession.delete(command.getName(), param));
-                break;
-            }
-            case SELECT:
-                if (method.returnsVoid() && method.hasResultHandler()) {
-                    executeWithResultHandler(sqlSession, args);
-                    result = null;
-                } else if (method.returnsMany()) {
-                    result = executeForMany(sqlSession, args);
-                } else if (method.returnsMap()) {
-                    result = executeForMap(sqlSession, args);
-                } else if (method.returnsCursor()) {
-                    result = executeForCursor(sqlSession, args);
-                } else {
-                    if (IPage.class.isAssignableFrom(method.getReturnType())) {
-                        result = executeForIPage(sqlSession, args);
+        EXECUTE_SHARED_DATA.set(new HashMap<>());
+        try {
+            switch (command.getType()) {
+                case INSERT: {
+                    Object param = this.convertArgsToSqlCommandParam(args);
+                    result = rowCountResult(sqlSession.insert(command.getName(), param));
+                    break;
+                }
+                case UPDATE: {
+                    Object param = this.convertArgsToSqlCommandParam(args);
+                    result = rowCountResult(sqlSession.update(command.getName(), param));
+                    break;
+                }
+                case DELETE: {
+                    Object param = this.convertArgsToSqlCommandParam(args);
+                    result = rowCountResult(sqlSession.delete(command.getName(), param));
+                    break;
+                }
+                case SELECT:
+                    if (method.returnsVoid() && method.hasResultHandler()) {
+                        executeWithResultHandler(sqlSession, args);
+                        result = null;
+                    } else if (method.returnsMany()) {
+                        result = executeForMany(sqlSession, args);
+                    } else if (method.returnsMap()) {
+                        result = executeForMap(sqlSession, args);
+                    } else if (method.returnsCursor()) {
+                        result = executeForCursor(sqlSession, args);
                     } else {
                         Object param = this.convertArgsToSqlCommandParam(args);
-                        result = sqlSession.selectOne(command.getName(), param);
-                        if (method.returnsOptional()
-                            && (result == null || !method.getReturnType().equals(result.getClass()))) {
-                            result = Optional.ofNullable(result);
+                        SelectReturnTypeHandler handler = SelectReturnTypeHandlerRegistry.findHandler(method.getReturnType());
+                        if (handler != null && handler.selectMethod() == SelectReturnTypeHandler.SelectMethod.SELECT_LIST) {
+                            result = sqlSession.selectList(command.getName(), param);
+                        } else {
+                            result = sqlSession.selectOne(command.getName(), param);
+                            if (method.returnsOptional()
+                                && (result == null || !method.getReturnType().equals(result.getClass()))) {
+                                result = Optional.ofNullable(result);
+                            }
+                        }
+                        // transform：在拦截器链全部执行完毕后进行类型转换
+                        if (handler != null) {
+                            result = handler.transform(result, args, method, EXECUTE_SHARED_DATA.get());
                         }
                     }
-                }
-                break;
-            case FLUSH:
-                result = sqlSession.flushStatements();
-                break;
-            default:
-                throw new BindingException("Unknown execution method for: " + command.getName());
+                    break;
+                case FLUSH:
+                    result = sqlSession.flushStatements();
+                    break;
+                default:
+                    throw new BindingException("Unknown execution method for: " + command.getName());
+            }
+        } finally {
+            EXECUTE_SHARED_DATA.remove();
         }
         if (result == null && method.getReturnType().isPrimitive() && !method.returnsVoid()) {
             throw new BindingException("Mapper method '" + command.getName()
                 + " attempted to return null from a method with a primitive return type (" + method.getReturnType() + ").");
         }
-        return result;
-    }
-
-    @SuppressWarnings("all")
-    private <E> Object executeForIPage(SqlSession sqlSession, Object[] args) {
-        IPage<E> result = null;
-        for (Object arg : args) {
-            if (arg instanceof IPage) {
-                result = (IPage<E>) arg;
-                break;
-            }
-        }
-        Assert.notNull(result, "can't found IPage for args!");
-        Object param = this.convertArgsToSqlCommandParam(args);
-        List<E> list = sqlSession.selectList(command.getName(), param);
-        result.setRecords(list);
         return result;
     }
 

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/SelectReturnTypeHandler.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/SelectReturnTypeHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.override;
+
+import org.apache.ibatis.binding.MapperMethod;
+
+import java.util.Map;
+
+/**
+ * Mapper 方法返回值类型处理器（仅限 SELECT 场景）。
+ * <p>{@link #selectMethod()} 由 {@link MybatisMapperMethod} 调用，决定 selectList 还是 selectOne；
+ * {@link #transform(Object, Object[], MapperMethod.MethodSignature, Map)} 由 {@link MybatisMapperMethod}
+ * 在拦截器链全部执行完毕后调用，完成结果类型转换。</p>
+ *
+ * <p>示例：</p>
+ * <pre>{@code
+ * public class MyHandler implements SelectReturnTypeHandler {
+ *     public SelectMethod selectMethod() { return SelectMethod.SELECT_LIST; }
+ *     public Class<?> getType() { return MyResult.class; }
+ *     public Object transform(Object queryResult, Map<String, Object> sharedData) {
+ *         return new MyResult((List<?>) queryResult);
+ *     }
+ * }
+ * SelectReturnTypeHandlerRegistry.register(new MyHandler());
+ * }</pre>
+ *
+ * @author shanhy
+ * @since 3.5.18
+ */
+public interface SelectReturnTypeHandler {
+
+    enum SelectMethod {
+        /** 调用 sqlSession.selectList，查询结果类型为 List */
+        SELECT_LIST,
+        /** 调用 sqlSession.selectOne，查询结果类型为单个对象 */
+        SELECT_ONE
+    }
+
+    /**
+     * 返回该处理器所需的查询方法，由 {@link MybatisMapperMethod} 调用。
+     */
+    SelectMethod selectMethod();
+
+    /**
+     * 返回该处理器绑定的目标类型，由 {@link SelectReturnTypeHandlerRegistry} 用于建立类型→处理器的映射。
+     */
+    Class<?> getType();
+
+    /**
+     * 将原始查询结果转换为目标返回类型。
+     * <p>由 {@link MybatisMapperMethod} 在拦截器链全部执行完毕后调用。
+     * executeSharedData 中包含各拦截器在 willDoQuery 阶段写入的数据。</p>
+     *
+     * @param queryResult       原始查询结果（List 或 单个对象，取决于 selectMethod）
+     * @param args              Mapper 方法原始参数数组
+     * @param method            MyBatis MethodSignature
+     * @param executeSharedData 拦截器共享数据（willDoQuery 写入，transform 读取）
+     * @return 转换后的结果
+     */
+    Object transform(Object queryResult, Object[] args, MapperMethod.MethodSignature method,
+                     Map<String, Object> executeSharedData);
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/SelectReturnTypeHandlerRegistry.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/SelectReturnTypeHandlerRegistry.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.override;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * SelectReturnTypeHandler 静态注册中心。
+ * <p>以 {@code Map<Class, Handler>} 存储类型绑定关系，类型由 {@link SelectReturnTypeHandler#getType()} 提供，
+ * 查找时通过 {@link Class#isAssignableFrom(Class)} 匹配。</p>
+ *
+ * <p>注册方式：</p>
+ * <pre>{@code
+ * SelectReturnTypeHandlerRegistry.register(new MyHandler());
+ * }</pre>
+ *
+ * @author shanhy
+ * @since 3.5.18
+ */
+public final class SelectReturnTypeHandlerRegistry {
+
+    private static final Map<Class<?>, SelectReturnTypeHandler> HANDLERS = new LinkedHashMap<>();
+
+    private SelectReturnTypeHandlerRegistry() {
+    }
+
+    /**
+     * 注册一个处理器，目标类型由 {@link SelectReturnTypeHandler#getType()} 提供。
+     * <p>后注册的同类型处理器会覆盖先注册的。</p>
+     *
+     * @param handler 处理器实例
+     */
+    public static synchronized void register(SelectReturnTypeHandler handler) {
+        if (handler != null) {
+            HANDLERS.put(handler.getType(), handler);
+        }
+    }
+
+    /**
+     * 查找匹配的处理器。
+     * <p>遍历所有已注册的类型，通过 {@link Class#isAssignableFrom(Class)} 匹配，
+     * 命中第一个即返回。后注册的优先检查。</p>
+     *
+     * @param returnType Mapper 方法声明的返回类型
+     * @return 匹配的处理器，未找到则返回 null
+     */
+    public static SelectReturnTypeHandler findHandler(Class<?> returnType) {
+        if (returnType == null) {
+            return null;
+        }
+        // 反向遍历：后注册的优先
+        Class<?>[] keys = HANDLERS.keySet().toArray(new Class<?>[0]);
+        for (int i = keys.length - 1; i >= 0; i--) {
+            if (keys[i].isAssignableFrom(returnType)) {
+                return HANDLERS.get(keys[i]);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 获取所有已注册的类型集合（只读）。
+     *
+     * @return 已注册的类型集合
+     */
+    public static Set<Class<?>> getRegisteredTypes() {
+        return Set.copyOf(HANDLERS.keySet());
+    }
+}

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/code/sub/MapperMethod.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/code/sub/MapperMethod.java
@@ -14,46 +14,34 @@ public class MapperMethod extends OverwriteFile {
     public MapperMethod() {
         // import
         addStep(i -> i
-            .addImport("com.baomidou.mybatisplus.core.metadata.IPage")
-            .addImport("com.baomidou.mybatisplus.core.toolkit.Assert"));
-        // execute
+            .addImport("com.baomidou.mybatisplus.core.override.SelectReturnTypeHandler")
+            .addImport("com.baomidou.mybatisplus.core.override.SelectReturnTypeHandlerRegistry"));
+        // execute: 在 else 分支中使用 SelectReturnTypeHandler 责任链
         addStep(i -> i
             .front("result = executeForCursor(sqlSession, args);")
             .interval(8)
             .behind("case FLUSH:")
             .content(Overwrite.Content.builder()
                 .code("""
-                    if (IPage.class.isAssignableFrom(method.getReturnType())) {
-                        result = executeForIPage(sqlSession, args);
                     } else {
+                        Object param = method.convertArgsToSqlCommandParam(args);
+                        SelectReturnTypeHandler handler = SelectReturnTypeHandlerRegistry.findHandler(method.getReturnType());
+                        if (handler != null) {
+                            Object rawResult;
+                            if (handler.selectMethod() == SelectReturnTypeHandler.SelectMethod.SELECT_LIST) {
+                                rawResult = sqlSession.selectList(command.getName(), param);
+                            } else {
+                                rawResult = sqlSession.selectOne(command.getName(), param);
+                            }
+                            result = handler.transform(rawResult, args, method);
                     """)
                 .frontDown(1).build())
             .content(Overwrite.Content.builder()
-                .code("}")
+                .code("""
+                        } else {
+                    """)
                 .behindUp(3)
                 .build())
-        );
-        addStep(i -> i
-            .behind("private Object rowCountResult(int rowCount) {")
-            .content(Overwrite.Content.builder()
-                .code("""
-                    @SuppressWarnings("all")
-                    private <E> Object executeForIPage(SqlSession sqlSession, Object[] args) {
-                        IPage<E> result = null;
-                        for (Object arg : args) {
-                            if (arg instanceof IPage) {
-                                result = (IPage<E>) arg;
-                                break;
-                            }
-                        }
-                        Assert.notNull(result, "can't found IPage for args!");
-                        Object param = method.convertArgsToSqlCommandParam(args);
-                        List<E> list = sqlSession.selectList(command.getName(), param);
-                        result.setRecords(list);
-                        return result;
-                    }
-                    """)
-                .behindUp(2).build())
         );
     }
 }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/MybatisPlusInterceptor.java
@@ -15,6 +15,7 @@
  */
 package com.baomidou.mybatisplus.extension.plugins;
 
+import com.baomidou.mybatisplus.core.override.MybatisMapperMethod;
 import com.baomidou.mybatisplus.core.toolkit.ClassUtils;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import com.baomidou.mybatisplus.extension.plugins.inner.InnerInterceptor;
@@ -56,6 +57,7 @@ public class MybatisPlusInterceptor implements Interceptor {
     public Object intercept(Invocation invocation) throws Throwable {
         Object target = invocation.getTarget();
         Object[] args = invocation.getArgs();
+        Map<String, Object> sharedData = MybatisMapperMethod.getExecuteSharedData();
         if (target instanceof Executor) {
             final Executor executor = (Executor) target;
             Object parameter = args[1];
@@ -72,19 +74,19 @@ public class MybatisPlusInterceptor implements Interceptor {
                     boundSql = (BoundSql) args[5];
                 }
                 for (InnerInterceptor query : interceptors) {
-                    if (!query.willDoQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql)) {
+                    if (!query.willDoQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql, sharedData)) {
                         return Collections.emptyList();
                     }
-                    query.beforeQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
+                    query.beforeQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql, sharedData);
                 }
                 CacheKey cacheKey = executor.createCacheKey(ms, parameter, rowBounds, boundSql);
                 return executor.query(ms, parameter, rowBounds, resultHandler, cacheKey, boundSql);
             } else if (isUpdate) {
                 for (InnerInterceptor update : interceptors) {
-                    if (!update.willDoUpdate(executor, ms, parameter)) {
+                    if (!update.willDoUpdate(executor, ms, parameter, sharedData)) {
                         return -1;
                     }
-                    update.beforeUpdate(executor, ms, parameter);
+                    update.beforeUpdate(executor, ms, parameter, sharedData);
                 }
             }
         } else {
@@ -93,13 +95,13 @@ public class MybatisPlusInterceptor implements Interceptor {
             // 目前只有StatementHandler.getBoundSql方法args才为null
             if (null == args) {
                 for (InnerInterceptor innerInterceptor : interceptors) {
-                    innerInterceptor.beforeGetBoundSql(sh);
+                    innerInterceptor.beforeGetBoundSql(sh, sharedData);
                 }
             } else {
                 Connection connections = (Connection) args[0];
                 Integer transactionTimeout = (Integer) args[1];
                 for (InnerInterceptor innerInterceptor : interceptors) {
-                    innerInterceptor.beforePrepare(sh, connections, transactionTimeout);
+                    innerInterceptor.beforePrepare(sh, connections, transactionTimeout, sharedData);
                 }
             }
         }

--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/InnerInterceptor.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/InnerInterceptor.java
@@ -28,6 +28,7 @@ import org.apache.ibatis.session.RowBounds;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -50,8 +51,31 @@ public interface InnerInterceptor {
      * @param boundSql      boundSql
      * @return 新的 boundSql
      */
-    default boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+    default boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds,
+                                ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
         return true;
+    }
+
+    /**
+     * 判断是否执行 {@link Executor#query(MappedStatement, Object, RowBounds, ResultHandler, CacheKey, BoundSql)}
+     * <p>
+     * 如果不执行query操作,则返回 {@link Collections#emptyList()}
+     *
+     * @param executor          Executor(可能是代理对象)
+     * @param ms                MappedStatement
+     * @param parameter         parameter
+     * @param rowBounds         rowBounds
+     * @param resultHandler     resultHandler
+     * @param boundSql          boundSql
+     * @param executeSharedData 执行级共享数据，由 {@code MybatisMapperMethod} 创建，
+     *                          建议使用 {@code getClass().getName() + ".xxx"} 格式的 key 避免冲突。
+     * @return 新的 boundSql
+     * @since 3.5.18
+     */
+    default boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds,
+                                ResultHandler resultHandler, BoundSql boundSql,
+                                Map<String, Object> executeSharedData) throws SQLException {
+        return willDoQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
     }
 
     /**
@@ -66,8 +90,30 @@ public interface InnerInterceptor {
      * @param resultHandler resultHandler
      * @param boundSql      boundSql
      */
-    default void beforeQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+    default void beforeQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds,
+                             ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
         // do nothing
+    }
+
+    /**
+     * {@link Executor#query(MappedStatement, Object, RowBounds, ResultHandler, CacheKey, BoundSql)} 操作前置处理
+     * <p>
+     * 改改sql啥的
+     *
+     * @param executor          Executor(可能是代理对象)
+     * @param ms                MappedStatement
+     * @param parameter         parameter
+     * @param rowBounds         rowBounds
+     * @param resultHandler     resultHandler
+     * @param boundSql          boundSql
+     * @param executeSharedData 执行级共享数据，由 {@code MybatisMapperMethod} 创建，
+     *                          建议使用 {@code getClass().getName() + ".xxx"} 格式的 key 避免冲突。
+     * @since 3.5.18
+     */
+    default void beforeQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds,
+                             ResultHandler resultHandler, BoundSql boundSql,
+                             Map<String, Object> executeSharedData) throws SQLException {
+        beforeQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
     }
 
     /**
@@ -78,9 +124,28 @@ public interface InnerInterceptor {
      * @param executor  Executor(可能是代理对象)
      * @param ms        MappedStatement
      * @param parameter parameter
+     * @return 是否执行 update 操作
      */
     default boolean willDoUpdate(Executor executor, MappedStatement ms, Object parameter) throws SQLException {
         return true;
+    }
+
+    /**
+     * 判断是否执行 {@link Executor#update(MappedStatement, Object)}
+     * <p>
+     * 如果不执行update操作,则影响行数的值为 -1
+     *
+     * @param executor          Executor(可能是代理对象)
+     * @param ms                MappedStatement
+     * @param parameter         parameter
+     * @param executeSharedData 执行级共享数据，由 {@code MybatisMapperMethod} 创建，
+     *                          建议使用 {@code getClass().getName() + ".xxx"} 格式的 key 避免冲突。
+     * @return 是否执行 update 操作
+     * @since 3.5.18
+     */
+    default boolean willDoUpdate(Executor executor, MappedStatement ms, Object parameter,
+                                 Map<String, Object> executeSharedData) throws SQLException {
+        return willDoUpdate(executor, ms, parameter);
     }
 
     /**
@@ -97,6 +162,23 @@ public interface InnerInterceptor {
     }
 
     /**
+     * {@link Executor#update(MappedStatement, Object)} 操作前置处理
+     * <p>
+     * 改改sql啥的
+     *
+     * @param executor          Executor(可能是代理对象)
+     * @param ms                MappedStatement
+     * @param parameter         parameter
+     * @param executeSharedData 执行级共享数据，由 {@code MybatisMapperMethod} 创建，
+     *                          建议使用 {@code getClass().getName() + ".xxx"} 格式的 key 避免冲突。
+     * @since 3.5.18
+     */
+    default void beforeUpdate(Executor executor, MappedStatement ms, Object parameter,
+                              Map<String, Object> executeSharedData) throws SQLException {
+        beforeUpdate(executor, ms, parameter);
+    }
+
+    /**
      * {@link StatementHandler#prepare(Connection, Integer)} 操作前置处理
      * <p>
      * 改改sql啥的
@@ -110,6 +192,23 @@ public interface InnerInterceptor {
     }
 
     /**
+     * {@link StatementHandler#prepare(Connection, Integer)} 操作前置处理
+     * <p>
+     * 改改sql啥的
+     *
+     * @param sh                 StatementHandler(可能是代理对象)
+     * @param connection         Connection
+     * @param transactionTimeout transactionTimeout
+     * @param executeSharedData  执行级共享数据，由 {@code MybatisMapperMethod} 创建，
+     *                           建议使用 {@code getClass().getName() + ".xxx"} 格式的 key 避免冲突。
+     * @since 3.5.18
+     */
+    default void beforePrepare(StatementHandler sh, Connection connection, Integer transactionTimeout,
+                               Map<String, Object> executeSharedData) {
+        beforePrepare(sh, connection, transactionTimeout);
+    }
+
+    /**
      * {@link StatementHandler#getBoundSql()} 操作前置处理
      * <p>
      * 只有 {@link BatchExecutor} 和 {@link ReuseExecutor} 才会调用到这个方法
@@ -118,6 +217,20 @@ public interface InnerInterceptor {
      */
     default void beforeGetBoundSql(StatementHandler sh) {
         // do nothing
+    }
+
+    /**
+     * {@link StatementHandler#getBoundSql()} 操作前置处理
+     * <p>
+     * 只有 {@link BatchExecutor} 和 {@link ReuseExecutor} 才会调用到这个方法
+     *
+     * @param sh                StatementHandler(可能是代理对象)
+     * @param executeSharedData 执行级共享数据，由 {@code MybatisMapperMethod} 创建，
+     *                          建议使用 {@code getClass().getName() + ".xxx"} 格式的 key 避免冲突。
+     * @since 3.5.18
+     */
+    default void beforeGetBoundSql(StatementHandler sh, Map<String, Object> executeSharedData) {
+        beforeGetBoundSql(sh);
     }
 
     default void setProperties(Properties properties) {

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/IPageReturnTypeHandler.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/IPageReturnTypeHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.extension.plugins.inner;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.override.SelectReturnTypeHandler;
+import com.baomidou.mybatisplus.core.toolkit.Assert;
+import org.apache.ibatis.binding.MapperMethod;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * IPage 返回类型的默认处理器。
+ * <p>与 {@link PaginationInnerInterceptor} 配套使用——只有配置了分页插件、执行了 count 查询，
+ * {@link IPage#getTotal()} 才有意义。</p>
+ *
+ * @author shanhy
+ * @since 3.5.18
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class IPageReturnTypeHandler implements SelectReturnTypeHandler {
+
+    @Override
+    public Class<?> getType() {
+        return IPage.class;
+    }
+
+    @Override
+    public SelectMethod selectMethod() {
+        return SelectMethod.SELECT_LIST;
+    }
+
+    @Override
+    public Object transform(Object queryResult, Object[] args,
+                            MapperMethod.MethodSignature method,
+                            Map<String, Object> executeSharedData) {
+        IPage result = null;
+        for (Object arg : args) {
+            if (arg instanceof IPage) {
+                result = (IPage) arg;
+                break;
+            }
+        }
+        Assert.notNull(result, "can't found IPage for args!");
+        result.setRecords((List) queryResult);
+        Long total = (Long) executeSharedData.get(PaginationInnerInterceptor.SHARED_KEY_PAGE_TOTAL);
+        if (total != null) {
+            result.setTotal(total);
+        }
+        return result;
+    }
+}

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -18,6 +18,7 @@ package com.baomidou.mybatisplus.extension.plugins.inner;
 import com.baomidou.mybatisplus.annotation.DbType;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.metadata.OrderItem;
+import com.baomidou.mybatisplus.core.override.SelectReturnTypeHandlerRegistry;
 import com.baomidou.mybatisplus.core.toolkit.*;
 import com.baomidou.mybatisplus.extension.parser.JsqlParserGlobal;
 import com.baomidou.mybatisplus.extension.plugins.pagination.DialectFactory;
@@ -72,7 +73,6 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
     protected static final Map<String, MappedStatement> countMsCache = new ConcurrentHashMap<>();
     protected final Log logger = LogFactory.getLog(this.getClass());
 
-
     /**
      * 溢出总页数后是否进行处理
      */
@@ -101,6 +101,16 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
      */
     protected boolean optimizeJoin = true;
 
+    /**
+     * executeSharedData 中存储 count 总数的 key，以当前类全限定名作为前缀避免键冲突。
+     */
+    static final String SHARED_KEY_PAGE_TOTAL =
+        PaginationInnerInterceptor.class.getName() + ".PAGE_TOTAL";
+
+    static {
+        SelectReturnTypeHandlerRegistry.register(new IPageReturnTypeHandler());
+    }
+
     public PaginationInnerInterceptor(DbType dbType) {
         this.dbType = dbType;
     }
@@ -113,7 +123,9 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
      * 这里进行count,如果count为0这返回false(就是不再执行sql了)
      */
     @Override
-    public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+    public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds,
+                               ResultHandler resultHandler, BoundSql boundSql,
+                               Map<String, Object> executeSharedData) throws SQLException {
         IPage<?> page = ParameterUtils.findPage(parameter).orElse(null);
         if (page == null || page.getSize() < 0 || !page.searchCount() || resultHandler != Executor.NO_RESULT_HANDLER) {
             return true;
@@ -141,7 +153,7 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
                 total = Long.parseLong(o.toString());
             }
         }
-        page.setTotal(total);
+        executeSharedData.put(SHARED_KEY_PAGE_TOTAL, total);
         return continuePage(page);
     }
 

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/IPageReturnTypeHandler.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/IPageReturnTypeHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.extension.plugins.inner;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.override.SelectReturnTypeHandler;
+import com.baomidou.mybatisplus.core.toolkit.Assert;
+import org.apache.ibatis.binding.MapperMethod;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * IPage 返回类型的默认处理器。
+ * <p>与 {@link PaginationInnerInterceptor} 配套使用——只有配置了分页插件、执行了 count 查询，
+ * {@link IPage#getTotal()} 才有意义。</p>
+ *
+ * @author shanhy
+ * @since 3.5.18
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class IPageReturnTypeHandler implements SelectReturnTypeHandler {
+
+    @Override
+    public Class<?> getType() {
+        return IPage.class;
+    }
+
+    @Override
+    public SelectMethod selectMethod() {
+        return SelectMethod.SELECT_LIST;
+    }
+
+    @Override
+    public Object transform(Object queryResult, Object[] args,
+                            MapperMethod.MethodSignature method,
+                            Map<String, Object> executeSharedData) {
+        IPage result = null;
+        for (Object arg : args) {
+            if (arg instanceof IPage) {
+                result = (IPage) arg;
+                break;
+            }
+        }
+        Assert.notNull(result, "can't found IPage for args!");
+        result.setRecords((List) queryResult);
+        Long total = (Long) executeSharedData.get(PaginationInnerInterceptor.SHARED_KEY_PAGE_TOTAL);
+        if (total != null) {
+            result.setTotal(total);
+        }
+        return result;
+    }
+}

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -18,6 +18,7 @@ package com.baomidou.mybatisplus.extension.plugins.inner;
 import com.baomidou.mybatisplus.annotation.DbType;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.metadata.OrderItem;
+import com.baomidou.mybatisplus.core.override.SelectReturnTypeHandlerRegistry;
 import com.baomidou.mybatisplus.core.toolkit.*;
 import com.baomidou.mybatisplus.extension.parser.JsqlParserGlobal;
 import com.baomidou.mybatisplus.extension.plugins.pagination.DialectFactory;
@@ -72,7 +73,6 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
     protected static final Map<String, MappedStatement> countMsCache = new ConcurrentHashMap<>();
     protected final Log logger = LogFactory.getLog(this.getClass());
 
-
     /**
      * 溢出总页数后是否进行处理
      */
@@ -101,6 +101,16 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
      */
     protected boolean optimizeJoin = true;
 
+    /**
+     * executeSharedData 中存储 count 总数的 key，以当前类全限定名作为前缀避免键冲突。
+     */
+    static final String SHARED_KEY_PAGE_TOTAL =
+        PaginationInnerInterceptor.class.getName() + ".PAGE_TOTAL";
+
+    static {
+        SelectReturnTypeHandlerRegistry.register(new IPageReturnTypeHandler());
+    }
+
     public PaginationInnerInterceptor(DbType dbType) {
         this.dbType = dbType;
     }
@@ -113,7 +123,9 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
      * 这里进行count,如果count为0这返回false(就是不再执行sql了)
      */
     @Override
-    public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+    public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds,
+                               ResultHandler resultHandler, BoundSql boundSql,
+                               Map<String, Object> executeSharedData) throws SQLException {
         IPage<?> page = ParameterUtils.findPage(parameter).orElse(null);
         if (page == null || page.getSize() < 0 || !page.searchCount() || resultHandler != Executor.NO_RESULT_HANDLER) {
             return true;
@@ -141,7 +153,7 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
                 total = Long.parseLong(o.toString());
             }
         }
-        page.setTotal(total);
+        executeSharedData.put(SHARED_KEY_PAGE_TOTAL, total);
         return continuePage(page);
     }
 

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/IPageReturnTypeHandler.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/IPageReturnTypeHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.extension.plugins.inner;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.override.SelectReturnTypeHandler;
+import com.baomidou.mybatisplus.core.toolkit.Assert;
+import org.apache.ibatis.binding.MapperMethod;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * IPage 返回类型的默认处理器。
+ * <p>与 {@link PaginationInnerInterceptor} 配套使用——只有配置了分页插件、执行了 count 查询，
+ * {@link IPage#getTotal()} 才有意义。</p>
+ *
+ * @author shanhy
+ * @since 3.5.18
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class IPageReturnTypeHandler implements SelectReturnTypeHandler {
+
+    @Override
+    public Class<?> getType() {
+        return IPage.class;
+    }
+
+    @Override
+    public SelectMethod selectMethod() {
+        return SelectMethod.SELECT_LIST;
+    }
+
+    @Override
+    public Object transform(Object queryResult, Object[] args,
+                            MapperMethod.MethodSignature method,
+                            Map<String, Object> executeSharedData) {
+        IPage result = null;
+        for (Object arg : args) {
+            if (arg instanceof IPage) {
+                result = (IPage) arg;
+                break;
+            }
+        }
+        Assert.notNull(result, "can't found IPage for args!");
+        result.setRecords((List) queryResult);
+        Long total = (Long) executeSharedData.get(PaginationInnerInterceptor.SHARED_KEY_PAGE_TOTAL);
+        if (total != null) {
+            result.setTotal(total);
+        }
+        return result;
+    }
+}

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/plugins/inner/PaginationInnerInterceptor.java
@@ -18,6 +18,7 @@ package com.baomidou.mybatisplus.extension.plugins.inner;
 import com.baomidou.mybatisplus.annotation.DbType;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.metadata.OrderItem;
+import com.baomidou.mybatisplus.core.override.SelectReturnTypeHandlerRegistry;
 import com.baomidou.mybatisplus.core.toolkit.*;
 import com.baomidou.mybatisplus.extension.parser.JsqlParserGlobal;
 import com.baomidou.mybatisplus.extension.plugins.pagination.DialectFactory;
@@ -72,7 +73,6 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
     protected static final Map<String, MappedStatement> countMsCache = new ConcurrentHashMap<>();
     protected final Log logger = LogFactory.getLog(this.getClass());
 
-
     /**
      * 溢出总页数后是否进行处理
      */
@@ -101,6 +101,17 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
      */
     protected boolean optimizeJoin = true;
 
+    /**
+     * executeSharedData 中存储 count 总数的 key，以当前类全限定名作为前缀避免键冲突。
+     */
+    static final String SHARED_KEY_PAGE_TOTAL =
+        PaginationInnerInterceptor.class.getName() + ".PAGE_TOTAL";
+
+    static {
+        // IPage 与分页插件是绑定关系：没有分页插件就没有 count 查询，IPage 的 total 将无意义
+        SelectReturnTypeHandlerRegistry.register(new IPageReturnTypeHandler());
+    }
+
     public PaginationInnerInterceptor(DbType dbType) {
         this.dbType = dbType;
     }
@@ -113,7 +124,9 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
      * 这里进行count,如果count为0这返回false(就是不再执行sql了)
      */
     @Override
-    public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+    public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds,
+                               ResultHandler resultHandler, BoundSql boundSql,
+                               Map<String, Object> executeSharedData) throws SQLException {
         IPage<?> page = ParameterUtils.findPage(parameter).orElse(null);
         if (page == null || page.getSize() < 0 || !page.searchCount() || resultHandler != Executor.NO_RESULT_HANDLER) {
             return true;
@@ -141,7 +154,7 @@ public class PaginationInnerInterceptor implements InnerInterceptor {
                 total = Long.parseLong(o.toString());
             }
         }
-        page.setTotal(total);
+        executeSharedData.put(SHARED_KEY_PAGE_TOTAL, total);
         return continuePage(page);
     }
 

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/puginsome/PluginSomeTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/puginsome/PluginSomeTest.java
@@ -17,6 +17,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author miemie
@@ -37,34 +38,39 @@ public class PluginSomeTest extends BaseDbTest<AMapper> {
         MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
         interceptor.addInnerInterceptor(new InnerInterceptor() {
             @Override
-            public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+            public boolean willDoQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql,
+                                         Map<String, Object> executeSharedData) throws SQLException {
                 System.out.println("willDoQuery");
                 return true;
             }
 
             @Override
-            public void beforeQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+            public void beforeQuery(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql,
+                                       Map<String, Object> executeSharedData) throws SQLException {
                 System.out.println("beforeQuery");
             }
 
             @Override
-            public boolean willDoUpdate(Executor executor, MappedStatement ms, Object parameter) throws SQLException {
+            public boolean willDoUpdate(Executor executor, MappedStatement ms, Object parameter,
+                                          Map<String, Object> executeSharedData) throws SQLException {
                 System.out.println("willDoUpdate");
                 return true;
             }
 
             @Override
-            public void beforeUpdate(Executor executor, MappedStatement ms, Object parameter) throws SQLException {
+            public void beforeUpdate(Executor executor, MappedStatement ms, Object parameter,
+                                       Map<String, Object> executeSharedData) throws SQLException {
                 System.out.println("beforeUpdate");
             }
 
             @Override
-            public void beforePrepare(StatementHandler sh, Connection connection, Integer transactionTimeout) {
+            public void beforePrepare(StatementHandler sh, Connection connection, Integer transactionTimeout,
+                                        Map<String, Object> executeSharedData) {
                 System.out.println("beforePrepare");
             }
 
             @Override
-            public void beforeGetBoundSql(StatementHandler sh) {
+            public void beforeGetBoundSql(StatementHandler sh, Map<String, Object> executeSharedData) {
                 System.out.println("beforeGetBoundSql");
             }
         });


### PR DESCRIPTION
### 概要

本次 PR 引入两大核心能力：

1. **`executeSharedData`** —— 拦截器链数据传递机制，解决 `PaginationInnerInterceptor` 通过方法入参对象传递中间结果（副作用写入）的问题。
2. **`SelectReturnTypeHandler`** —— 返回值扩展机制，替代 `MybatisMapperMethod.execute()` 中对 `IPage` 返回类型的硬编码判断（`IPage.class.isAssignableFrom(...)`），遵循开闭原则。

---

### 背景与动机

#### 问题一：拦截器数据传递（副作用问题）

当前 `PaginationInnerInterceptor.willDoQuery()` 执行 count 查询后，通过 `page.setTotal(total)` **直接修改**方法入参对象，随后 `MybatisMapperMethod.executeForIPage()` 从 args 中找到同一个 `IPage` 引用并返回。这意味着参数对象在拦截器中被中途污染，违反了不可变原则，也使得数据流难以追踪和测试。

#### 问题二：返回值类型扩展（开闭原则问题）

`MybatisMapperMethod.execute()` 的 SELECT 分支中，通过硬编码的方式判断 `IPage.class.isAssignableFrom(method.getReturnType())` 来决定是否走 `executeForIPage` 逻辑。这导致任何新的返回类型扩展都需要修改核心类的 switch/case 逻辑，违反开闭原则。

#### 动机：支持用户自定义返回类型扩展

除了解决 IPage 的硬编码问题之外，更重要的动机是——**让用户能够像 IPage 一样，为自己的任意返回对象扩展处理逻辑**。用户只需要实现 `SelectReturnTypeHandler` 接口并注册到 `SelectReturnTypeHandlerRegistry`，即可在 Mapper 方法返回自定义类型时，自动走 `transform()` 完成结果装配，无需修改 MyBatis-Plus 核心代码，真正实现开闭原则下的扩展能力。

---

### 方案设计

#### 方案一：executeSharedData 数据传递

在 `MybatisMapperMethod` 中定义 `ExecuteSharedDataHolder`（底层为 `ThreadLocal<Map<String, Object>>`），生命周期与 `execute()` 方法一致，在 `finally` 块保证清理。

```
MybatisMapperMethod.execute(sqlSession, args)
  │
  ├─ EXECUTE_SHARED_DATA.set(new HashMap<>())    ← 创建
  │
  ├─ sqlSession.selectList()
  │    └─ MybatisPlusInterceptor.intercept()
  │         ├─ map = MybatisMapperMethod.getExecuteSharedData()  ← 读取
  │         ├─ willDoQuery(..., map)   → put 数据
  │         ├─ beforeQuery(..., map)
  │         └─ executor.query()
  │
  ├─ handler.transform(rawResult, args, method, map)   ← 读取
  │
  └─ EXECUTE_SHARED_DATA.remove()               ← finally 清理
```

**设计要点**：
- 零 ThreadLocal 概念外泄——持有者定义在 `MybatisMapperMethod` 中，职责清晰
- `MybatisPlusInterceptor` 无需创建 Map，直接读取调用方持有的实例
- `InnerInterceptor` 全方法新增带 `executeSharedData` 参数的重载，旧方法通过默认桥接保持向后兼容

#### 方案二：SelectReturnTypeHandler 返回值扩展

定义 `SelectReturnTypeHandler` 接口，包含三个核心职责：

| 职责 | 方法 | 调用方 |
|------|------|--------|
| 声明查询方法 | `selectMethod()` | `MybatisMapperMethod`（决定走 `selectList` 还是 `selectOne`） |
| 声明绑定类型 | `getType()` | `SelectReturnTypeHandlerRegistry`（建立映射） |
| 结果转换 | `transform()` | `MybatisMapperMethod`（在拦截器链全部执行完毕后） |

通过 `SelectReturnTypeHandlerRegistry`（静态注册中心）的 `isAssignableFrom` 匹配机制，自动发现并路由到对应处理器，彻底消除硬编码类型判断。

#### IPage 改造

- `PaginationInnerInterceptor.willDoQuery()` 不再调用 `page.setTotal(total)`，改为 `executeSharedData.put(SHARED_KEY_PAGE_TOTAL, total)`
- 新增 `IPageReturnTypeHandler`，与 `PaginationInnerInterceptor` 同模块、同 package，通过静态块注册
- `IPageReturnTypeHandler.transform()` 从 args 中获取 `IPage` 引用，从 `executeSharedData` 读取 total，完成装配

---

### 主要改造清单

| 文件 | 模块 | 变更 |
|------|------|------|
| `MybatisMapperMethod.java` | mybatis-plus-core | 新增 ExecuteSharedDataHolder；SELECT else 分支使用 SelectReturnTypeHandler 责任链 + transform；finally 清理 |
| `SelectReturnTypeHandler.java` | mybatis-plus-core | **新建** — 定义接口（SelectMethod + selectMethod + getType + transform） |
| `SelectReturnTypeHandlerRegistry.java` | mybatis-plus-core | **新建** — 静态注册中心 |
| `IPageReturnTypeHandler.java` ×3 | mybatis-plus-jsqlparser (×3) | **新建** — IPage 默认处理器 |
| `InnerInterceptor.java` | mybatis-plus-extension | 新增带 executeSharedData 的重载方法 + 默认桥接 |
| `MybatisPlusInterceptor.java` | mybatis-plus-extension | SELECT/UPDATE 路径传入 executeSharedData |
| `PaginationInnerInterceptor.java` ×3 | mybatis-plus-jsqlparser (×3) | 新增常量；willDoQuery 写入 executeSharedData；静态块注册 Handler |

---

### 向后兼容

- ✅ `mapper.selectPage(new Page<>(1, 10), wrapper)` 行为完全一致
- ✅ 已有 `InnerInterceptor` 实现通过默认桥接方法继续工作，无需改动
- ✅ `SelectReturnTypeHandlerRegistry` 为空时，回退到原有 `selectOne` 逻辑
- ✅ `Page.setTotal()` 不再被 `willDoQuery` 调用，但 `Page` 的 setter 仍然存在，不影响外部代码

---

### 扩展示例

**自定义返回值处理器：**

```java
public class MyHandler implements SelectReturnTypeHandler {
    @Override public SelectMethod selectMethod() { return SelectMethod.SELECT_LIST; }
    @Override public Class<?> getType() { return MyResult.class; }

    @Override
    public Object transform(Object queryResult, Object[] args,
                            MapperMethod.MethodSignature method,
                            Map<String, Object> executeSharedData) {
        Object data = executeSharedData.get("my_key");
        return new MyResult((List<?>) queryResult, data);
    }
}
```

**自定义拦截器写入共享数据（含注册 Handler）：**

```java
public class MyInterceptor implements InnerInterceptor {
    static {
        SelectReturnTypeHandlerRegistry.register(new MyHandler());
    }

    @Override
    public boolean willDoQuery(..., Map<String, Object> executeSharedData) {
        executeSharedData.put("my_key", computeSomething());
        return true;
    }
}
```

---


