### PR TITLE
feat: 增强 MybatisMapperMethod 扩展能力，支持用户自定义 MapperMethod 行为

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisConfiguration.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisConfiguration.java
@@ -18,6 +18,8 @@ package com.baomidou.mybatisplus.core;
 import com.baomidou.mybatisplus.core.handlers.CompositeEnumTypeHandler;
 import com.baomidou.mybatisplus.core.mapper.Mapper;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.core.override.DefaultMybatisMapperMethodFactory;
+import com.baomidou.mybatisplus.core.override.MybatisMapperMethodFactory;
 import com.baomidou.mybatisplus.core.toolkit.GlobalConfigUtils;
 import com.baomidou.mybatisplus.core.toolkit.ReflectionKit;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
@@ -78,6 +80,20 @@ public class MybatisConfiguration extends Configuration {
     @Setter
     @Getter
     private boolean useGeneratedShortKey = true;
+
+    /**
+     * MybatisMapperMethod 工厂。
+     * <p>
+     * 允许用户自定义 {@link com.baomidou.mybatisplus.core.override.MybatisMapperMethod} 的创建逻辑。
+     * 默认为 {@link com.baomidou.mybatisplus.core.override.DefaultMybatisMapperMethodFactory}，
+     * 行为与原逻辑完全一致。
+     * </p>
+     *
+     * @since 3.5.18
+     */
+    @Setter
+    @Getter
+    protected MybatisMapperMethodFactory mybatisMapperMethodFactory = new DefaultMybatisMapperMethodFactory();
 
     public MybatisConfiguration(Environment environment) {
         this();

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisMapperRegistry.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisMapperRegistry.java
@@ -15,6 +15,8 @@
  */
 package com.baomidou.mybatisplus.core;
 
+import com.baomidou.mybatisplus.core.override.DefaultMybatisMapperMethodFactory;
+import com.baomidou.mybatisplus.core.override.MybatisMapperMethodFactory;
 import com.baomidou.mybatisplus.core.override.MybatisMapperProxyFactory;
 import org.apache.ibatis.binding.BindingException;
 import org.apache.ibatis.binding.MapperRegistry;
@@ -82,7 +84,7 @@ public class MybatisMapperRegistry extends MapperRegistry {
             }
             boolean loadCompleted = false;
             try {
-                knownMappers.put(type, new MybatisMapperProxyFactory<>(type));
+                knownMappers.put(type, new MybatisMapperProxyFactory<>(type, getMapperMethodFactory()));
                 // It's important that the type is added before the parser is run
                 // otherwise the binding may automatically be attempted by the
                 // mapper parser. If the type is already known, it won't try.
@@ -103,6 +105,25 @@ public class MybatisMapperRegistry extends MapperRegistry {
     @Override
     public Collection<Class<?>> getMappers() {
         return Collections.unmodifiableCollection(knownMappers.keySet());
+    }
+
+    /**
+     * 从 MybatisConfiguration 中获取 MybatisMapperMethodFactory。
+     * <p>
+     * 若 config 非 MybatisConfiguration 实例或未设置工厂，回退到默认实现。
+     * </p>
+     *
+     * @return MybatisMapperMethodFactory 实例
+     * @since 3.5.18
+     */
+    private MybatisMapperMethodFactory getMapperMethodFactory() {
+        if (config instanceof MybatisConfiguration) {
+            MybatisMapperMethodFactory factory = ((MybatisConfiguration) config).getMybatisMapperMethodFactory();
+            if (factory != null) {
+                return factory;
+            }
+        }
+        return new DefaultMybatisMapperMethodFactory();
     }
 
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/DefaultMybatisMapperMethodFactory.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/DefaultMybatisMapperMethodFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.override;
+
+import org.apache.ibatis.session.Configuration;
+
+import java.lang.reflect.Method;
+
+/**
+ * 默认的 MybatisMapperMethod 工厂实现。
+ * <p>
+ * 保持与原有行为完全一致，确保向后兼容。
+ * 当用户未自定义 {@link MybatisMapperMethodFactory} 时使用此默认实现。
+ * </p>
+ *
+ * @author xzxiaoshan
+ * @since 3.5.18
+ */
+public class DefaultMybatisMapperMethodFactory implements MybatisMapperMethodFactory {
+
+    @Override
+    public MybatisMapperMethod create(Class<?> mapperInterface, Method method, Configuration config) {
+        return new MybatisMapperMethod(mapperInterface, method, config);
+    }
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperMethodFactory.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperMethodFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.override;
+
+import org.apache.ibatis.session.Configuration;
+
+import java.lang.reflect.Method;
+
+/**
+ * MybatisMapperMethod 工厂接口。
+ * <p>
+ * 允许用户自定义 {@link MybatisMapperMethod} 的创建逻辑，
+ * 实现自定义的 Mapper 方法执行行为（如审计日志、结果包装、参数预处理等）。
+ * </p>
+ *
+ * @author xzxiaoshan
+ * @since 3.5.18
+ */
+public interface MybatisMapperMethodFactory {
+
+    /**
+     * 创建 MybatisMapperMethod 实例。
+     *
+     * @param mapperInterface Mapper 接口类
+     * @param method          Mapper 方法
+     * @param config          MyBatis Configuration
+     * @return MybatisMapperMethod 实例
+     */
+    MybatisMapperMethod create(Class<?> mapperInterface, Method method, Configuration config);
+}

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperProxy.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperProxy.java
@@ -51,11 +51,19 @@ public class MybatisMapperProxy<T> implements InvocationHandler, Serializable {
     private final SqlSession sqlSession;
     private final Class<T> mapperInterface;
     private final Map<Method, MapperMethodInvoker> methodCache;
+    private final MybatisMapperMethodFactory methodFactory;
 
     public MybatisMapperProxy(SqlSession sqlSession, Class<T> mapperInterface, Map<Method, MapperMethodInvoker> methodCache) {
+        this(sqlSession, mapperInterface, methodCache, new DefaultMybatisMapperMethodFactory());
+    }
+
+    public MybatisMapperProxy(SqlSession sqlSession, Class<T> mapperInterface,
+                              Map<Method, MapperMethodInvoker> methodCache,
+                              MybatisMapperMethodFactory methodFactory) {
         this.sqlSession = sqlSession;
         this.mapperInterface = mapperInterface;
         this.methodCache = methodCache;
+        this.methodFactory = methodFactory;
     }
 
     static {
@@ -100,7 +108,7 @@ public class MybatisMapperProxy<T> implements InvocationHandler, Serializable {
         try {
             return MapUtil.computeIfAbsent(methodCache, method, m -> {
                 if (!m.isDefault()) {
-                    return new PlainMethodInvoker(new MybatisMapperMethod(mapperInterface, method, sqlSession.getConfiguration()));
+                    return new PlainMethodInvoker(methodFactory.create(mapperInterface, method, sqlSession.getConfiguration()));
                 }
                 try {
                     if (privateLookupInMethod == null) {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperProxyFactory.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperProxyFactory.java
@@ -37,9 +37,15 @@ public class MybatisMapperProxyFactory<T> {
     private final Class<T> mapperInterface;
     @Getter
     private final Map<Method, MybatisMapperProxy.MapperMethodInvoker> methodCache = new ConcurrentHashMap<>();
+    private final MybatisMapperMethodFactory methodFactory;
 
     public MybatisMapperProxyFactory(Class<T> mapperInterface) {
+        this(mapperInterface, new DefaultMybatisMapperMethodFactory());
+    }
+
+    public MybatisMapperProxyFactory(Class<T> mapperInterface, MybatisMapperMethodFactory methodFactory) {
         this.mapperInterface = mapperInterface;
+        this.methodFactory = methodFactory;
     }
 
     @SuppressWarnings("unchecked")
@@ -48,7 +54,7 @@ public class MybatisMapperProxyFactory<T> {
     }
 
     public T newInstance(SqlSession sqlSession) {
-        final MybatisMapperProxy<T> mapperProxy = new MybatisMapperProxy<>(sqlSession, mapperInterface, methodCache);
+        final MybatisMapperProxy<T> mapperProxy = new MybatisMapperProxy<>(sqlSession, mapperInterface, methodCache, methodFactory);
         return newInstance(mapperProxy);
     }
 }


### PR DESCRIPTION
## 概述

增强 `MybatisMapperMethod` 的可扩展性，允许用户通过自定义工厂来扩展 Mapper 方法的执行行为。

## 背景

目前 `MybatisMapperProxy` 内部通过 `new MybatisMapperMethod(...)` 硬编码创建实例，用户无法扩展 Mapper 方法的执行逻辑（如自定义结果包装、审计日志、参数预处理等）。现有的 Interceptor 机制仅能干预 Executor / StatementHandler 层，无法覆盖 MapperMethod 层的参数绑定和结果映射阶段。

## 方案

引入 `MybatisMapperMethodFactory` 工厂接口，通过 `MybatisConfiguration` 暴露扩展点：

- 新增 `MybatisMapperMethodFactory` 接口（`create(mapperInterface, method, config)`）
- 新增 `DefaultMybatisMapperMethodFactory` 默认实现（行为与原逻辑完全一致）
- `MybatisConfiguration` 新增 `mybatisMapperMethodFactory` 属性，用户可通过 `ConfigurationCustomizer` 注入自定义工厂

**工厂传递路径**（内部透明，用户无需感知）：

```
MybatisConfiguration → MybatisMapperRegistry → MybatisMapperProxyFactory → MybatisMapperProxy
```

## 改动文件

| 文件 | 类型 | 说明 |
|------|------|------|
| `override/MybatisMapperMethodFactory.java` | 新增 | 工厂接口定义 |
| `override/DefaultMybatisMapperMethodFactory.java` | 新增 | 默认工厂实现（保持兼容） |
| `override/MybatisMapperProxy.java` | 修改 | 接收并持有工厂，替代硬编码 `new MybatisMapperMethod` |
| `override/MybatisMapperProxyFactory.java` | 修改 | 接收工厂实例，传递给 Proxy |
| `MybatisMapperRegistry.java` | 修改 | 从 `this.config` 读取工厂，传递给 ProxyFactory |
| `MybatisConfiguration.java` | 修改 | 新增 `mapperMethodFactory` 属性 |

## 兼容性

- **不影响 MyBatis-Plus 自身任何执行逻辑，完全向后兼容**
- 默认 `DefaultMybatisMapperMethodFactory` **保持与原行为 100% 一致**
- 所有现有测试无需修改，全部通过
- 改动点极少，仅提供扩展点，不改变任何现有流程

## 用法示例

```java
// 1. 自定义 MybatisMapperMethod
public class AuditMapperMethod extends MybatisMapperMethod {
    @Override
    public Object execute(SqlSession sqlSession, Object[] args) {
        // 前置/后置自定义逻辑
        return super.execute(sqlSession, args);
    }
}

// 2. 通过 ConfigurationCustomizer 注入
@Bean
public ConfigurationCustomizer customizer() {
    return configuration -> {
        if (configuration instanceof MybatisConfiguration c) {
            c.setMybatisMapperMethodFactory(AuditMapperMethod::new);
        }
    };
}
```
