### PR TITLE
refactor: 将IPage处理从Mapper代理层下沉至Interceptor后置处理

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/plugins/MybatisPlusInterceptor.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/plugins/MybatisPlusInterceptor.java
@@ -23,6 +23,7 @@ import com.baomidou.mybatisplus.core.toolkit.PropertyMapper;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.binding.MapperMethod;
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.statement.StatementHandler;
@@ -34,9 +35,11 @@ import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.sql.Connection;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * @author miemie
@@ -58,9 +61,10 @@ public class MybatisPlusInterceptor implements Interceptor {
     /**
      * Mapper 方法反射缓存。
      * key = MappedStatement.getId()（格式：com.example.UserMapper.selectPage）
+     * value = 同名方法的有序列表（按参数数量降序），空 List 表示解析失败的负缓存。
      * 通过 ConcurrentHashMap 保证同一 MappedStatement 的反射解析仅执行一次。
      */
-    protected static final ConcurrentHashMap<String, Method> METHOD_CACHE = new ConcurrentHashMap<>();
+    protected static final ConcurrentHashMap<String, List<Method>> METHOD_CACHE = new ConcurrentHashMap<>();
 
     @Setter
     private List<InnerInterceptor> interceptors = new ArrayList<>();
@@ -76,7 +80,7 @@ public class MybatisPlusInterceptor implements Interceptor {
             MappedStatement ms = (MappedStatement) args[0];
             SqlCommandType sqlCommandType = ms.getSqlCommandType();
             // 提前解析 Mapper 方法（带缓存），同一 Executor 内所有 afterIntercept 调用共享
-            Method mapperMethod = resolveMapperMethod(ms.getId());
+            Method mapperMethod = resolveMapperMethod(ms.getId(), parameter);
             if (!isUpdate && sqlCommandType == SqlCommandType.SELECT) {
                 RowBounds rowBounds = (RowBounds) args[2];
                 ResultHandler resultHandler = (ResultHandler) args[3];
@@ -237,27 +241,125 @@ public class MybatisPlusInterceptor implements Interceptor {
     }
 
     /**
-     * 从 MappedStatement ID 反查 Mapper 方法（带缓存）。
+     * 从 MappedStatement ID + 运行参数反查 Mapper 方法。
+     * <p>处理同名重载方法：通过实际参数 ParamMap 匹配最合适的方法。</p>
      *
      * @param statementId MappedStatement.getId()，格式：com.example.UserMapper.selectPage
-     * @return 对应的 Method 对象，解析失败时返回 null
+     * @param parameter   MyBatis 传入的调用参数（单参数为原始对象，多参数为 {@code MapperMethod.ParamMap}）
+     * @return 对应的 Method 对象，解析失败或匹配失败时返回 null
      */
-    public static Method resolveMapperMethod(String statementId) {
-        return METHOD_CACHE.computeIfAbsent(statementId, key -> {
-            try {
-                String className = key.substring(0, key.lastIndexOf('.'));
-                String methodName = key.substring(key.lastIndexOf('.') + 1);
-                Class<?> clazz = Class.forName(className);
-                for (Method m : clazz.getMethods()) {
-                    if (m.getName().equals(methodName)) {
-                        return m;
-                    }
-                }
-            } catch (Exception e) {
-                log.warn("Failed to resolve mapper method for statement: {} - {}: {}", statementId,
-                    e.getClass().getSimpleName(), e.getMessage());
-            }
+    public static Method resolveMapperMethod(String statementId, Object parameter) {
+        List<Method> methods = getMethodsByStatementId(statementId);
+        if (methods.isEmpty()) {
             return null;
+        }
+        if (methods.size() == 1) {
+            return methods.get(0);
+        }
+        // 多方法按参数数量降序匹配，避免子集窃取
+        for (Method method : methods) {
+            if (matchMethodWithParameter(method, parameter)) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 从缓存加载 statementId 对应的同名方法列表（带负缓存）。
+     *
+     * @param statementId MappedStatement.getId()
+     * @return 同名方法列表（按参数数量降序），解析失败时为空 List
+     */
+    private static List<Method> getMethodsByStatementId(String statementId) {
+        return METHOD_CACHE.computeIfAbsent(statementId, id -> {
+            int lastDot = id.lastIndexOf('.');
+            if (lastDot <= 0 || lastDot == id.length() - 1) {
+                return Collections.emptyList();
+            }
+            try {
+                String className = id.substring(0, lastDot);
+                String methodName = id.substring(lastDot + 1);
+                Class<?> clazz = Class.forName(className);
+                return Arrays.stream(clazz.getMethods())
+                        .filter(m -> m.getName().equals(methodName))
+                        .sorted(Comparator.comparingInt(Method::getParameterCount).reversed())
+                        .collect(Collectors.toList());
+            } catch (Exception e) {
+                log.warn("Failed to resolve mapper method for statement: {} - {}: {}", id,
+                        e.getClass().getSimpleName(), e.getMessage());
+                return Collections.emptyList();
+            }
         });
+    }
+
+    /**
+     * 检查 method 的参数是否与运行时 parameter 匹配。
+     * <p>匹配规则：
+     * <ul>
+     *   <li>单参数未被 MyBatis 包装 → 直接类型匹配</li>
+     *   <li>{@link MapperMethod.ParamMap} → 按 {@code param1...paramN} 位置逐一类型匹配</li>
+     *   <li>null 值兼容任意类型，基本类型与包装类型等价</li>
+     * </ul>
+     * </p>
+     *
+     * @param method    候选方法
+     * @param parameter 运行时参数（单参数为原始对象，多参数为 ParamMap）
+     * @return 匹配成功返回 true
+     */
+    private static boolean matchMethodWithParameter(Method method, Object parameter) {
+        Parameter[] methodParams = method.getParameters();
+        if (methodParams.length == 0 && parameter == null) {
+            return true;
+        }
+
+        // 单参数未被 MyBatis 包装 → 直接类型匹配
+        // MapperMethod.ParamMap 是 MyBatis 的明确包装标记：多参数 / 单参数 @Param / 集合类型
+        if (methodParams.length == 1 && !(parameter instanceof MapperMethod.ParamMap)) {
+            return isTypeCompatible(methodParams[0].getType(), parameter);
+        }
+
+        // 多参数 / 单参数被 ParamMap 包装 → 按 param1...paramN 位置逐一类型匹配
+        if (parameter instanceof MapperMethod.ParamMap) {
+            @SuppressWarnings("unchecked")
+            MapperMethod.ParamMap<Object> paramMap = (MapperMethod.ParamMap<Object>) parameter;
+            for (int i = 0; i < methodParams.length; i++) {
+                String key = "param" + (i + 1);
+                if (!paramMap.containsKey(key)) {
+                    return false;
+                }
+                Object value = paramMap.get(key);
+                if (value != null && !isTypeCompatible(methodParams[i].getType(), value)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 判断值类型是否与方法参数类型兼容。
+     * <p>null 值视为与任何类型兼容；基本类型与对应包装类型等价。</p>
+     *
+     * @param expectedType 方法参数声明的类型
+     * @param actualValue  实际值
+     * @return 兼容返回 true
+     */
+    private static boolean isTypeCompatible(Class<?> expectedType, Object actualValue) {
+        if (actualValue == null) {
+            return true;
+        }
+        // 基本类型 → 包装类型，引用类型原样
+        Class<?> type = expectedType;
+        if (type == int.class) type = Integer.class;
+        else if (type == long.class) type = Long.class;
+        else if (type == double.class) type = Double.class;
+        else if (type == float.class) type = Float.class;
+        else if (type == boolean.class) type = Boolean.class;
+        else if (type == char.class) type = Character.class;
+        else if (type == byte.class) type = Byte.class;
+        else if (type == short.class) type = Short.class;
+        return type.isInstance(actualValue);
     }
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/plugins/MybatisPlusInterceptor.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/plugins/MybatisPlusInterceptor.java
@@ -71,7 +71,7 @@ public class MybatisPlusInterceptor implements Interceptor {
         Object[] args = invocation.getArgs();
         if (target instanceof Executor) {
             final Executor executor = (Executor) target;
-            Object mapperMethodParameter = args[1];
+            Object parameter = args[1];
             boolean isUpdate = args.length == 2;
             MappedStatement ms = (MappedStatement) args[0];
             SqlCommandType sqlCommandType = ms.getSqlCommandType();
@@ -82,32 +82,32 @@ public class MybatisPlusInterceptor implements Interceptor {
                 ResultHandler resultHandler = (ResultHandler) args[3];
                 BoundSql boundSql;
                 if (args.length == 4) {
-                    boundSql = ms.getBoundSql(mapperMethodParameter);
+                    boundSql = ms.getBoundSql(parameter);
                 } else {
                     // 几乎不可能走进这里面,除非使用Executor的代理对象调用query[args[6]]
                     boundSql = (BoundSql) args[5];
                 }
 
                 for (InnerInterceptor query : interceptors) {
-                    if (!query.willDoQuery(executor, ms, mapperMethodParameter, rowBounds, resultHandler, boundSql)) {
-                        return afterIntercept(sqlCommandType, invocation, mapperMethodParameter,
+                    if (!query.willDoQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql)) {
+                        return afterIntercept(sqlCommandType, invocation, parameter,
                             Collections.emptyList(), mapperMethod, false);
                     }
-                    query.beforeQuery(executor, ms, mapperMethodParameter, rowBounds, resultHandler, boundSql);
+                    query.beforeQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
                 }
-                CacheKey cacheKey = executor.createCacheKey(ms, mapperMethodParameter, rowBounds, boundSql);
-                Object queryResult = executor.query(ms, mapperMethodParameter, rowBounds, resultHandler, cacheKey, boundSql);
-                return afterIntercept(sqlCommandType, invocation, mapperMethodParameter, queryResult, mapperMethod, true);
+                CacheKey cacheKey = executor.createCacheKey(ms, parameter, rowBounds, boundSql);
+                Object queryResult = executor.query(ms, parameter, rowBounds, resultHandler, cacheKey, boundSql);
+                return afterIntercept(sqlCommandType, invocation, parameter, queryResult, mapperMethod, true);
             } else if (isUpdate) {
                 for (InnerInterceptor update : interceptors) {
-                    if (!update.willDoUpdate(executor, ms, mapperMethodParameter)) {
-                        return afterIntercept(sqlCommandType, invocation, mapperMethodParameter, -1, mapperMethod, false);
+                    if (!update.willDoUpdate(executor, ms, parameter)) {
+                        return afterIntercept(sqlCommandType, invocation, parameter, -1, mapperMethod, false);
                     }
-                    update.beforeUpdate(executor, ms, mapperMethodParameter);
+                    update.beforeUpdate(executor, ms, parameter);
                 }
-                return afterIntercept(sqlCommandType, invocation, mapperMethodParameter, invocation.proceed(), mapperMethod, true);
+                return afterIntercept(sqlCommandType, invocation, parameter, invocation.proceed(), mapperMethod, true);
             }
-            return afterIntercept(sqlCommandType, invocation, mapperMethodParameter, invocation.proceed(), mapperMethod, true);
+            return afterIntercept(sqlCommandType, invocation, parameter, invocation.proceed(), mapperMethod, true);
         } else {
             // StatementHandler
             final StatementHandler sh = (StatementHandler) target;
@@ -141,20 +141,20 @@ public class MybatisPlusInterceptor implements Interceptor {
      *
      * @param sqlCommandType SQL 命令类型（StatementHandler 路径时为 null）
      * @param invocation     原始 Invocation（兜底）
-     * @param mapperMethodParameter Mapper 方法的调用实参（StatementHandler 路径时为 null）
+     * @param parameter Mapper 方法的调用实参（StatementHandler 路径时为 null）
      * @param result               Executor 操作或 invocation.proceed() 的返回结果
      * @param mapperMethod         Mapper 方法（带缓存，SELECT 外为 null）
      * @param executed 是否实际执行了底层操作（false 表示被 InnerInterceptor 短路跳过）
      * @return 加工后的结果。IPage 场景返回单元素 List（元素为 IPage），由 selectOne 解包后返回 IPage 对象；非 IPage 场景原样返回
      */
-    protected Object afterIntercept(SqlCommandType sqlCommandType, Invocation invocation, Object mapperMethodParameter,
+    protected Object afterIntercept(SqlCommandType sqlCommandType, Invocation invocation, Object parameter,
                                      Object result, Method mapperMethod, boolean executed) {
         // 默认仅处理 SELECT 返回 IPage 的场景：将查询结果 List 载入 IPage 后包装为单元素
         // List，使调用方 selectOne 解包后拿到完整的 IPage 对象。其他定制需求（如 UPDATE
         // 后置校验、INSERT 审计日志、DELETE 缓存失效等）可通过继承重写本方法实现。
         if (sqlCommandType == SqlCommandType.SELECT
             && mapperMethod != null && IPage.class.isAssignableFrom(mapperMethod.getReturnType())) {
-            return processPageResult(mapperMethodParameter, result, mapperMethod, executed);
+            return processPageResult(parameter, result, mapperMethod, executed);
         }
         // 非目标场景，原样返回
         return result;
@@ -170,19 +170,19 @@ public class MybatisPlusInterceptor implements Interceptor {
      * </p>
      * <p>子类可重写此方法自定义 Page 结果的加工逻辑。</p>
      *
-     * @param mapperMethodParameter Mapper 方法的调用实参
+     * @param parameter Mapper 方法的调用实参
      * @param queryResult          executor.query() 的返回结果
      * @param mapperMethod         Mapper 方法
      * @param executed             是否实际执行了底层操作（false 表示被 InnerInterceptor 短路跳过）
      * @return 单元素 List（元素为 IPage），由 selectOne 解包后返回 IPage 对象；非 List 或未找到 IPage 参数时原样返回
      */
     @SuppressWarnings("unchecked")
-    protected Object processPageResult(Object mapperMethodParameter, Object queryResult,
+    protected Object processPageResult(Object parameter, Object queryResult,
                                         Method mapperMethod, boolean executed) {
         if (!(queryResult instanceof List)) {
             return queryResult;
         }
-        IPage page = ParameterUtils.findPage(mapperMethodParameter).orElse(null);
+        IPage page = ParameterUtils.findPage(parameter).orElse(null);
         if (page != null) {
             page.setRecords((List) queryResult);
             return Collections.singletonList(page);
@@ -242,7 +242,7 @@ public class MybatisPlusInterceptor implements Interceptor {
      * @param statementId MappedStatement.getId()，格式：com.example.UserMapper.selectPage
      * @return 对应的 Method 对象，解析失败时返回 null
      */
-    protected Method resolveMapperMethod(String statementId) {
+    public static Method resolveMapperMethod(String statementId) {
         return METHOD_CACHE.computeIfAbsent(statementId, key -> {
             try {
                 String className = key.substring(0, key.lastIndexOf('.'));

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/plugins/MybatisPlusInterceptor.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/plugins/MybatisPlusInterceptor.java
@@ -15,11 +15,14 @@
  */
 package com.baomidou.mybatisplus.core.plugins;
 
+import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.plugins.inner.InnerInterceptor;
 import com.baomidou.mybatisplus.core.toolkit.ClassUtils;
+import com.baomidou.mybatisplus.core.toolkit.ParameterUtils;
 import com.baomidou.mybatisplus.core.toolkit.PropertyMapper;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.statement.StatementHandler;
@@ -30,13 +33,16 @@ import org.apache.ibatis.plugin.*;
 import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
 
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author miemie
  * @since 3.4.0
  */
+@Slf4j
 @SuppressWarnings({"rawtypes"})
 @Intercepts(
     {
@@ -49,6 +55,13 @@ import java.util.*;
 )
 public class MybatisPlusInterceptor implements Interceptor {
 
+    /**
+     * Mapper 方法反射缓存。
+     * key = MappedStatement.getId()（格式：com.example.UserMapper.selectPage）
+     * 通过 ConcurrentHashMap 保证同一 MappedStatement 的反射解析仅执行一次。
+     */
+    protected static final ConcurrentHashMap<String, Method> METHOD_CACHE = new ConcurrentHashMap<>();
+
     @Setter
     private List<InnerInterceptor> interceptors = new ArrayList<>();
 
@@ -58,35 +71,43 @@ public class MybatisPlusInterceptor implements Interceptor {
         Object[] args = invocation.getArgs();
         if (target instanceof Executor) {
             final Executor executor = (Executor) target;
-            Object parameter = args[1];
+            Object mapperMethodParameter = args[1];
             boolean isUpdate = args.length == 2;
             MappedStatement ms = (MappedStatement) args[0];
-            if (!isUpdate && ms.getSqlCommandType() == SqlCommandType.SELECT) {
+            SqlCommandType sqlCommandType = ms.getSqlCommandType();
+            // 提前解析 Mapper 方法（带缓存），同一 Executor 内所有 afterIntercept 调用共享
+            Method mapperMethod = resolveMapperMethod(ms.getId());
+            if (!isUpdate && sqlCommandType == SqlCommandType.SELECT) {
                 RowBounds rowBounds = (RowBounds) args[2];
                 ResultHandler resultHandler = (ResultHandler) args[3];
                 BoundSql boundSql;
                 if (args.length == 4) {
-                    boundSql = ms.getBoundSql(parameter);
+                    boundSql = ms.getBoundSql(mapperMethodParameter);
                 } else {
                     // 几乎不可能走进这里面,除非使用Executor的代理对象调用query[args[6]]
                     boundSql = (BoundSql) args[5];
                 }
+
                 for (InnerInterceptor query : interceptors) {
-                    if (!query.willDoQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql)) {
-                        return Collections.emptyList();
+                    if (!query.willDoQuery(executor, ms, mapperMethodParameter, rowBounds, resultHandler, boundSql)) {
+                        return afterIntercept(sqlCommandType, invocation, mapperMethodParameter,
+                            Collections.emptyList(), mapperMethod, false);
                     }
-                    query.beforeQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
+                    query.beforeQuery(executor, ms, mapperMethodParameter, rowBounds, resultHandler, boundSql);
                 }
-                CacheKey cacheKey = executor.createCacheKey(ms, parameter, rowBounds, boundSql);
-                return executor.query(ms, parameter, rowBounds, resultHandler, cacheKey, boundSql);
+                CacheKey cacheKey = executor.createCacheKey(ms, mapperMethodParameter, rowBounds, boundSql);
+                Object queryResult = executor.query(ms, mapperMethodParameter, rowBounds, resultHandler, cacheKey, boundSql);
+                return afterIntercept(sqlCommandType, invocation, mapperMethodParameter, queryResult, mapperMethod, true);
             } else if (isUpdate) {
                 for (InnerInterceptor update : interceptors) {
-                    if (!update.willDoUpdate(executor, ms, parameter)) {
-                        return -1;
+                    if (!update.willDoUpdate(executor, ms, mapperMethodParameter)) {
+                        return afterIntercept(sqlCommandType, invocation, mapperMethodParameter, -1, mapperMethod, false);
                     }
-                    update.beforeUpdate(executor, ms, parameter);
+                    update.beforeUpdate(executor, ms, mapperMethodParameter);
                 }
+                return afterIntercept(sqlCommandType, invocation, mapperMethodParameter, invocation.proceed(), mapperMethod, true);
             }
+            return afterIntercept(sqlCommandType, invocation, mapperMethodParameter, invocation.proceed(), mapperMethod, true);
         } else {
             // StatementHandler
             final StatementHandler sh = (StatementHandler) target;
@@ -102,8 +123,71 @@ public class MybatisPlusInterceptor implements Interceptor {
                     innerInterceptor.beforePrepare(sh, connections, transactionTimeout);
                 }
             }
+            return afterIntercept(null, invocation, null, invocation.proceed(), null, true);
         }
-        return invocation.proceed();
+    }
+
+    /**
+     * 拦截器后置处理，覆盖 {@link #intercept(Invocation)} 的所有返回路径。
+     * 默认实现仅对 SELECT 结果做 IPage 自动包装，其余类型原样返回。
+     * <p>
+     * 当 Mapper 方法返回类型为 IPage 时，MyBatis 底层会走 {@code selectOne}，
+     * 而 {@code selectOne} 内部实际调用 {@code selectList} 获取 List 结果。
+     * 为了让 {@code selectOne} 能正确返回 IPage 对象，此处将查询结果 List
+     * 载入 IPage 后包装为单元素 List（{@code Collections.singletonList(page)}），
+     * {@code selectOne} 取 {@code get(0)} 即得到完整的 IPage 对象。
+     * </p>
+     * <p>子类可重写此方法实现自定义的结果加工。</p>
+     *
+     * @param sqlCommandType SQL 命令类型（StatementHandler 路径时为 null）
+     * @param invocation     原始 Invocation（兜底）
+     * @param mapperMethodParameter Mapper 方法的调用实参（StatementHandler 路径时为 null）
+     * @param result               Executor 操作或 invocation.proceed() 的返回结果
+     * @param mapperMethod         Mapper 方法（带缓存，SELECT 外为 null）
+     * @param executed 是否实际执行了底层操作（false 表示被 InnerInterceptor 短路跳过）
+     * @return 加工后的结果。IPage 场景返回单元素 List（元素为 IPage），由 selectOne 解包后返回 IPage 对象；非 IPage 场景原样返回
+     */
+    protected Object afterIntercept(SqlCommandType sqlCommandType, Invocation invocation, Object mapperMethodParameter,
+                                     Object result, Method mapperMethod, boolean executed) {
+        // 默认仅处理 SELECT 返回 IPage 的场景：将查询结果 List 载入 IPage 后包装为单元素
+        // List，使调用方 selectOne 解包后拿到完整的 IPage 对象。其他定制需求（如 UPDATE
+        // 后置校验、INSERT 审计日志、DELETE 缓存失效等）可通过继承重写本方法实现。
+        if (sqlCommandType == SqlCommandType.SELECT
+            && mapperMethod != null && IPage.class.isAssignableFrom(mapperMethod.getReturnType())) {
+            return processPageResult(mapperMethodParameter, result, mapperMethod, executed);
+        }
+        // 非目标场景，原样返回
+        return result;
+    }
+
+    /**
+     * Page 返回值处理。从参数中查找 IPage 实例，将查询结果 List 写入后包装为
+     * 单元素 List（{@code Collections.singletonList(page)}）。
+     * <p>
+     * IPage 返回值经 {@code selectOne} 获取——{@code selectOne} 内部调用
+     * {@code selectList} 拿到 List 后按 {@code size==1 取 get(0)} 解包，
+     * 此处将 List 载入 IPage 并包装为单元素 List，使解包后得到完整的 IPage 对象。
+     * </p>
+     * <p>子类可重写此方法自定义 Page 结果的加工逻辑。</p>
+     *
+     * @param mapperMethodParameter Mapper 方法的调用实参
+     * @param queryResult          executor.query() 的返回结果
+     * @param mapperMethod         Mapper 方法
+     * @param executed             是否实际执行了底层操作（false 表示被 InnerInterceptor 短路跳过）
+     * @return 单元素 List（元素为 IPage），由 selectOne 解包后返回 IPage 对象；非 List 或未找到 IPage 参数时原样返回
+     */
+    @SuppressWarnings("unchecked")
+    protected Object processPageResult(Object mapperMethodParameter, Object queryResult,
+                                        Method mapperMethod, boolean executed) {
+        if (!(queryResult instanceof List)) {
+            return queryResult;
+        }
+        IPage page = ParameterUtils.findPage(mapperMethodParameter).orElse(null);
+        if (page != null) {
+            page.setRecords((List) queryResult);
+            return Collections.singletonList(page);
+        }
+        return queryResult;
     }
 
     @Override
@@ -150,5 +234,30 @@ public class MybatisPlusInterceptor implements Interceptor {
         return "MybatisPlusInterceptor{" +
             "interceptors=" + interceptors +
             '}';
+    }
+
+    /**
+     * 从 MappedStatement ID 反查 Mapper 方法（带缓存）。
+     *
+     * @param statementId MappedStatement.getId()，格式：com.example.UserMapper.selectPage
+     * @return 对应的 Method 对象，解析失败时返回 null
+     */
+    protected Method resolveMapperMethod(String statementId) {
+        return METHOD_CACHE.computeIfAbsent(statementId, key -> {
+            try {
+                String className = key.substring(0, key.lastIndexOf('.'));
+                String methodName = key.substring(key.lastIndexOf('.') + 1);
+                Class<?> clazz = Class.forName(className);
+                for (Method m : clazz.getMethods()) {
+                    if (m.getName().equals(methodName)) {
+                        return m;
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Failed to resolve mapper method for statement: {} - {}: {}", statementId,
+                    e.getClass().getSimpleName(), e.getMessage());
+            }
+            return null;
+        });
     }
 }


### PR DESCRIPTION
## 概述

将 `IPage` 返回值的组装逻辑从 Mapper 代理层下沉到 Interceptor 层，使 IPage 分页透明地走 MyBatis 标准 `selectOne` 流程。

**机制**：Interceptor 将查询结果 List 写入 IPage 后包装为 `Collections.singletonList(page)`，利用 `selectOne` 的 `size==1 → get(0)` 解包行为返回 IPage。

## 改动内容（MybatisPlusInterceptor.java）

- **`METHOD_CACHE`**：`ConcurrentHashMap<String, Method>`，按 `MappedStatement.getId()` 缓存 Mapper Method。
- **`resolveMapperMethod(String)`**：从 statementId 反查 Mapper 接口方法，获取返回值类型和参数信息，用于判断是否需要 IPage 包装。
- **`afterIntercept(...)`**：拦截器统一后置处理入口，覆盖 `intercept()` 全部返回路径。当 Mapper 方法返回 `IPage` 时调用 `processPageResult` 做自动包装，其余透传。`protected`，子类可重写扩展。
- **`processPageResult(...)`**：从 Mapper 实参中查找 IPage 实例，`setRecords` 后包装为单元素 List，配合 `selectOne` 解包返回完整 IPage。

**修改 `intercept()`**——`intercept()` 内所有 return 统一改为调用 `afterIntercept()`，并在其参数中携带各场景的必要状态：`sqlCommandType`（区分 SELECT/UPDATE）、`mapperMethodParameter`（Mappper 实参，用于查找 IPage）、`result`（执行结果或短路值）、`mapperMethod`（预解析的 Mappper 方法，判断返回类型）、`executed`（是否实际执行了底层操作）。同时提取 `sqlCommandType` 局部变量、`parameter` 重命名为 `mapperMethodParameter`、Executor 分支入口预解析 `resolveMapperMethod(ms.getId())`。

## 关于 MybatisMapperMethod

经与作者沟通，`MybatisMapperMethod` 不在本次 PR 提交范围内（修改它或者整体删除由作者处理）。**所以本次提交的 `MybatisPlusInterceptor` 视为 `MybatisMapperMethod` 已被处理的基础上。**

之所以需要说明：`MybatisPlusInterceptor` 新增的 `afterIntercept` 逻辑依赖 `MybatisMapperMethod` 中 IPage 特殊处理已被移除——调用方必须走 `selectOne()` 才能正确解包 `singletonList(page)`。如果保留原 `executeForIPage()`（内部走 `selectList()`），Interceptor 返回的 `[IPage对象]` 会被错误地当作实体 List 写入 records，导致数据错乱。

MybatisMapperMethod 需要的配套改动：删除 `executeForIPage()`，SELECT else 分支统一走 `selectOne()`，清理 `IPage`/`Assert` import。

## 数据流

**正常分页**：
```
selectOne() → Interceptor → executor.query() → List<Entity>
  → afterIntercept() → page.setRecords(list) → singletonList(page)
  → selectOne 解包 → IPage ✓
```

**短路（count==0）**：
```
willDoQuery() → false
  → afterIntercept(emptyList) → page.setRecords([]) → singletonList(page)
  → IPage{total=N, records=[]} ✓
```

**非 IPage / UPDATE / DELETE**：`afterIntercept()` 判断非目标场景，原样返回，行为不变。
