### PR TITLE
fix: 避免批量 SQL 在 DEBUG 日志中重复输出

### DIFF
--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/parser/JsqlParserSupport.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-4.9/src/main/java/com/baomidou/mybatisplus/extension/parser/JsqlParserSupport.java
@@ -82,7 +82,7 @@ public abstract class JsqlParserSupport {
      */
     protected String processParser(Statement statement, int index, String sql, Object obj) {
         if (logger.isDebugEnabled()) {
-            logger.debug("SQL to parse, SQL: " + sql);
+            logger.debug("SQL to parse, SQL: " + statement);
         }
         if (statement instanceof Insert) {
             this.processInsert((Insert) statement, index, sql, obj);

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/parser/JsqlParserSupport.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser-5.0/src/main/java/com/baomidou/mybatisplus/extension/parser/JsqlParserSupport.java
@@ -82,7 +82,7 @@ public abstract class JsqlParserSupport {
      */
     protected String processParser(Statement statement, int index, String sql, Object obj) {
         if (logger.isDebugEnabled()) {
-            logger.debug("SQL to parse, SQL: " + sql);
+            logger.debug("SQL to parse, SQL: " + statement);
         }
         if (statement instanceof Insert) {
             this.processInsert((Insert) statement, index, sql, obj);

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/parser/JsqlParserSupport.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/main/java/com/baomidou/mybatisplus/extension/parser/JsqlParserSupport.java
@@ -85,7 +85,7 @@ public abstract class JsqlParserSupport {
      */
     protected String processParser(Statement statement, int index, String sql, Object obj) {
         if (logger.isDebugEnabled()) {
-            logger.debug("SQL to parse, SQL: " + sql);
+            logger.debug("SQL to parse, SQL: " + statement);
         }
         if (statement instanceof Insert) {
             this.processInsert((Insert) statement, index, sql, obj);

--- a/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/inner/DataPermissionInterceptorTest.java
+++ b/mybatis-plus-jsqlparser-support/mybatis-plus-jsqlparser/src/test/java/com/baomidou/mybatisplus/test/extension/plugins/inner/DataPermissionInterceptorTest.java
@@ -7,9 +7,13 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import org.apache.ibatis.logging.Log;
+import org.apache.ibatis.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -96,7 +100,87 @@ public class DataPermissionInterceptorTest {
             "SELECT * FROM sys_role WHERE id = 3 AND id = 1 AND role_id IN (SELECT id FROM sys_role)");
     }
 
+    @Test
+    void parserMultiShouldLogCurrentStatementInsteadOfEntireBatch() {
+        CapturingLog.clear();
+        LogFactory.useCustomLogging(CapturingLog.class);
+
+        DataPermissionInterceptor interceptor = new DataPermissionInterceptor();
+        String firstSql = "update sys_user set name = 'a' where id = 1";
+        String secondSql = "delete from sys_role where id = 2";
+        String thirdSql = "update sys_dept set enabled = 1 where id = 3";
+        String batchSql = firstSql + "; " + secondSql + "; " + thirdSql;
+
+        String parsedSql;
+        List<String> sqlToParseLogs;
+        try {
+            parsedSql = interceptor.parserMulti(batchSql, TEST_1);
+            sqlToParseLogs = CapturingLog.debugMessages().stream()
+                .filter(message -> message.startsWith(CapturingLog.SQL_TO_PARSE_PREFIX))
+                .map(message -> message.substring(CapturingLog.SQL_TO_PARSE_PREFIX.length()))
+                .toList();
+        } finally {
+            LogFactory.useSlf4jLogging();
+            CapturingLog.clear();
+        }
+
+        String[] parsedStatements = parsedSql.split(";");
+        assertThat(parsedStatements).hasSize(3);
+        assertThat(sqlToParseLogs).hasSize(3);
+        assertThat(sqlToParseLogs).containsExactly(parsedStatements);
+        assertThat(sqlToParseLogs).noneMatch(batchSql::equals);
+    }
+
     void assertSql(String mappedStatementId, String sql, String targetSql) {
         assertThat(INTERCEPTOR.parserSingle(sql, mappedStatementId)).isEqualTo(targetSql);
+    }
+
+    public static class CapturingLog implements Log {
+
+        private static final String SQL_TO_PARSE_PREFIX = "SQL to parse, SQL: ";
+
+        private static final List<String> DEBUG_MESSAGES = new ArrayList<>();
+
+        public CapturingLog(String clazz) {
+        }
+
+        static void clear() {
+            DEBUG_MESSAGES.clear();
+        }
+
+        static List<String> debugMessages() {
+            return DEBUG_MESSAGES;
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isTraceEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(String s, Throwable e) {
+        }
+
+        @Override
+        public void error(String s) {
+        }
+
+        @Override
+        public void debug(String s) {
+            DEBUG_MESSAGES.add(s);
+        }
+
+        @Override
+        public void trace(String s) {
+        }
+
+        @Override
+        public void warn(String s) {
+        }
     }
 }


### PR DESCRIPTION
## 关联 Issue

Fixes #7155

## 问题原因

`parserMulti` 处理包含多条语句的 SQL 时，会为每个解析出的
`Statement` 调用一次 `processParser`。

当前 `SQL to parse` DEBUG 日志使用完整的原始 SQL，导致批量包含
N 条语句时，完整批量 SQL 被额外重复记录 N 次，产生大量冗余日志。

## 修改内容

- 将 `SQL to parse` DEBUG 日志调整为输出当前 `Statement`。
- 同步修改默认、JSqlParser 4.9 和 JSqlParser 5.0 三个兼容模块。
- 添加包含三条 SQL 的批量解析回归测试。

本次修改保留了传递给 `processInsert`、`processUpdate`、
`processDelete` 和 `processSelect` 等扩展点的原始 `sql` 参数，
不改变 SQL 解析、处理、拼接逻辑及 public/protected API。

## 测试结果

- `DataPermissionInterceptorTest`：7 个测试全部通过
- `mybatis-plus-jsqlparser`：170 个测试通过
- `mybatis-plus-jsqlparser-4.9`：168 个测试通过，1 个跳过
- `mybatis-plus-jsqlparser-5.0`：169 个测试通过，1 个跳过
- `git diff --check`：通过