### PR TITLE
fix(core): restore Implementation-Version in JAR manifests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,18 @@ subprojects {
         logging.captureStandardError LogLevel.DEBUG
     }
 
+    // Restored after 3.5.17 publish script rewrite dropped jar manifest metadata.
+    // MybatisPlusVersion reads Implementation-Version for the startup banner (#7150).
+    jar {
+        manifest {
+            attributes(
+                'Implementation-Title': project.name,
+                'Implementation-Version': project.version,
+                'Automatic-Module-Name': "${project.group}.${project.name.replaceAll("-", ".")}"
+            )
+        }
+    }
+
     plugins.withId('kotlin') {
         tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
             kotlinOptions {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisPlusVersion.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/MybatisPlusVersion.java
@@ -23,6 +23,7 @@ import java.net.URLConnection;
 import java.security.CodeSource;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 
 /**
  * 获取Mybatis-Plus版本
@@ -62,7 +63,8 @@ public class MybatisPlusVersion {
     }
 
     private static String getImplementationVersion(JarFile jarFile) throws IOException {
-        return jarFile.getManifest().getMainAttributes().getValue(Attributes.Name.IMPLEMENTATION_VERSION);
+        Manifest manifest = jarFile.getManifest();
+        return manifest == null ? null : manifest.getMainAttributes().getValue(Attributes.Name.IMPLEMENTATION_VERSION);
     }
 
 }

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/MybatisPlusVersionTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/MybatisPlusVersionTest.java
@@ -1,0 +1,71 @@
+package com.baomidou.mybatisplus.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression for #7150: version must resolve from Implementation-Version in the JAR manifest.
+ */
+class MybatisPlusVersionTest {
+
+    @Test
+    void getVersionDoesNotThrow() {
+        assertThatCode(MybatisPlusVersion::getVersion).doesNotThrowAnyException();
+    }
+
+    @Test
+    void readsImplementationVersionFromJarManifest() throws Exception {
+        Path jarPath = Files.createTempFile("mybatis-plus-version-", ".jar");
+        try {
+            Manifest manifest = new Manifest();
+            manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+            manifest.getMainAttributes().put(Attributes.Name.IMPLEMENTATION_VERSION, "3.5.17");
+            try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarPath), manifest)) {
+                jos.putNextEntry(new ZipEntry("dummy.txt"));
+                jos.write("x".getBytes());
+                jos.closeEntry();
+            }
+            try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+                assertThat(invokeGetImplementationVersion(jarFile)).isEqualTo("3.5.17");
+            }
+        } finally {
+            Files.deleteIfExists(jarPath);
+        }
+    }
+
+    @Test
+    void returnsNullWhenJarHasNoManifest() throws Exception {
+        Path jarPath = Files.createTempFile("mybatis-plus-no-manifest-", ".jar");
+        try {
+            // Zip without META-INF/MANIFEST.MF so JarFile#getManifest() is null
+            try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(jarPath))) {
+                zos.putNextEntry(new ZipEntry("dummy.txt"));
+                zos.write("x".getBytes());
+                zos.closeEntry();
+            }
+            try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+                assertThat(invokeGetImplementationVersion(jarFile)).isNull();
+            }
+        } finally {
+            Files.deleteIfExists(jarPath);
+        }
+    }
+
+    private static String invokeGetImplementationVersion(JarFile jarFile) throws Exception {
+        Method method = MybatisPlusVersion.class.getDeclaredMethod("getImplementationVersion", JarFile.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, jarFile);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7150 — startup banner prints version `null` on 3.5.17 (was fine on 3.5.16).

**Root cause:** commit `db0b3c4bb` (3.5.17 publish script rewrite) dropped the `jar { manifest { ... } }` block that wrote `Implementation-Version` into `META-INF/MANIFEST.MF`. `MybatisPlusVersion.getVersion()` reads that attribute via `Package.getImplementationVersion()` / `JarFile` manifest, so packaged artifacts returned `null`.

**Changes:**
1. Restore JAR manifest attributes on all modules: `Implementation-Title`, `Implementation-Version`, `Automatic-Module-Name` (same source of truth as pre-3.5.17).
2. Null-guard `JarFile#getManifest()` so a missing manifest does not NPE.
3. Regression tests for reading version from a jar with `Implementation-Version`, and for jars without a manifest.

Verified locally: `mybatis-plus-core-3.5.17.jar` MANIFEST.MF contains `Implementation-Version: 3.5.17`.

## Test plan

- [x] `./gradlew :mybatis-plus-core:test --tests com.baomidou.mybatisplus.core.MybatisPlusVersionTest` (3/3)
- [x] Inspect `META-INF/MANIFEST.MF` on `:mybatis-plus-core:jar` and `:mybatis-plus-spring:jar`
- [ ] CI green

Note: prior attempt #7154 (Copilot) was closed unmerged; this is a focused re-fix of the packaging gap without inventing a fake `0.0.0` fallback version.