### PR TITLE
refactor: scope IPage result processing to mapper execution

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperMethod.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/override/MybatisMapperMethod.java
@@ -17,6 +17,7 @@ package com.baomidou.mybatisplus.core.override;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.toolkit.Assert;
+import com.baomidou.mybatisplus.core.toolkit.PageExecutionContext;
 import org.apache.ibatis.binding.BindingException;
 import org.apache.ibatis.binding.MapperMethod;
 import org.apache.ibatis.cursor.Cursor;
@@ -116,9 +117,14 @@ public class MybatisMapperMethod {
         }
         Assert.notNull(result, "can't found IPage for args!");
         Object param = method.convertArgsToSqlCommandParam(args);
-        List<E> list = sqlSession.selectList(command.getName(), param);
-        result.setRecords(list);
-        return result;
+        try (PageExecutionContext ignored = PageExecutionContext.open(command.getName(), result)) {
+            List<?> queryResult = sqlSession.selectList(command.getName(), param);
+            if (queryResult.size() == 1 && queryResult.get(0) == result) {
+                return result;
+            }
+            result.setRecords((List<E>) queryResult);
+            return result;
+        }
     }
 
     private Object rowCountResult(int rowCount) {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/plugins/MybatisPlusInterceptor.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/plugins/MybatisPlusInterceptor.java
@@ -17,6 +17,7 @@ package com.baomidou.mybatisplus.core.plugins;
 
 import com.baomidou.mybatisplus.core.plugins.inner.InnerInterceptor;
 import com.baomidou.mybatisplus.core.toolkit.ClassUtils;
+import com.baomidou.mybatisplus.core.toolkit.PageExecutionContext;
 import com.baomidou.mybatisplus.core.toolkit.PropertyMapper;
 import com.baomidou.mybatisplus.core.toolkit.StringPool;
 import lombok.Setter;
@@ -78,7 +79,8 @@ public class MybatisPlusInterceptor implements Interceptor {
                     query.beforeQuery(executor, ms, parameter, rowBounds, resultHandler, boundSql);
                 }
                 CacheKey cacheKey = executor.createCacheKey(ms, parameter, rowBounds, boundSql);
-                return executor.query(ms, parameter, rowBounds, resultHandler, cacheKey, boundSql);
+                Object queryResult = executor.query(ms, parameter, rowBounds, resultHandler, cacheKey, boundSql);
+                return PageExecutionContext.processResult(ms.getId(), queryResult);
             } else if (isUpdate) {
                 for (InnerInterceptor update : interceptors) {
                     if (!update.willDoUpdate(executor, ms, parameter)) {

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/PageExecutionContext.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/PageExecutionContext.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.toolkit;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Explicit execution scope used to transfer a mapper page result to the executor interceptor.
+ *
+ * <p>The scope is intentionally statement-specific. This prevents nested count queries from
+ * being treated as the data query and avoids reflection-based mapper method discovery.</p>
+ */
+public final class PageExecutionContext implements AutoCloseable {
+
+    private static final ThreadLocal<PageExecutionContext> CURRENT = new ThreadLocal<>();
+
+    private final String statementId;
+    private final IPage<?> page;
+    private final PageExecutionContext previous;
+    private boolean closed;
+
+    private PageExecutionContext(String statementId, IPage<?> page, PageExecutionContext previous) {
+        this.statementId = statementId;
+        this.page = page;
+        this.previous = previous;
+    }
+
+    public static PageExecutionContext open(String statementId, IPage<?> page) {
+        Objects.requireNonNull(statementId, "statementId must not be null");
+        Objects.requireNonNull(page, "page must not be null");
+        PageExecutionContext context = new PageExecutionContext(statementId, page, CURRENT.get());
+        CURRENT.set(context);
+        return context;
+    }
+
+    /**
+     * Converts the raw query list to the selectList-compatible page envelope when this query
+     * belongs to the active mapper page scope.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static Object processResult(String statementId, Object result) {
+        PageExecutionContext context = CURRENT.get();
+        if (context == null || !context.statementId.equals(statementId) || !(result instanceof List)) {
+            return result;
+        }
+        List<?> records = (List<?>) result;
+        if (records.size() == 1 && records.get(0) == context.page) {
+            return result;
+        }
+        context.page.setRecords((List) records);
+        return Collections.singletonList(context.page);
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            throw new IllegalStateException("Page execution context is already closed");
+        }
+        if (CURRENT.get() != this) {
+            throw new IllegalStateException("Page execution context closed out of order");
+        }
+        closed = true;
+        if (previous == null) {
+            CURRENT.remove();
+        } else {
+            CURRENT.set(previous);
+        }
+    }
+}

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/mapper/BaseMapperSelectOneCompatibilityTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/mapper/BaseMapperSelectOneCompatibilityTest.java
@@ -1,0 +1,41 @@
+package com.baomidou.mybatisplus.test.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import org.apache.ibatis.exceptions.TooManyResultsException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for the 3.5.17 cursor-based selectOne change.
+ * BaseMapper.selectOne must remain list-backed so drivers without cursor support are usable.
+ */
+class BaseMapperSelectOneCompatibilityTest {
+
+    @Test
+    void selectOneUsesTheListBackedQueryPath() {
+        BaseMapper<Object> mapper = Mockito.mock(BaseMapper.class, Mockito.CALLS_REAL_METHODS);
+        Object first = new Object();
+        when(mapper.selectList(any(QueryWrapper.class))).thenReturn(List.of(first));
+
+        assertThat(mapper.selectOne(new QueryWrapper<>())).isSameAs(first);
+        verify(mapper).selectList(any(QueryWrapper.class));
+    }
+
+    @Test
+    void listBackedPathStillPreservesTooManyResultsContract() {
+        BaseMapper<Object> mapper = Mockito.mock(BaseMapper.class, Mockito.CALLS_REAL_METHODS);
+        when(mapper.selectList(any(QueryWrapper.class))).thenReturn(List.of(new Object(), new Object()));
+
+        assertThatThrownBy(() -> mapper.selectOne(new QueryWrapper<>()))
+            .isInstanceOf(TooManyResultsException.class);
+    }
+}

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/toolkit/PageExecutionContextTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/toolkit/PageExecutionContextTest.java
@@ -1,0 +1,46 @@
+package com.baomidou.mybatisplus.test.toolkit;
+
+import com.baomidou.mybatisplus.core.plugins.pagination.Page;
+import com.baomidou.mybatisplus.core.toolkit.PageExecutionContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+class PageExecutionContextTest {
+
+    @Test
+    void processesOnlyTheBoundStatementAndUnwrapsExactlyOnce() {
+        Page<String> page = new Page<>(1, 10);
+        List<String> records = List.of("one", "two");
+
+        try (PageExecutionContext ignored = PageExecutionContext.open("demo.selectPage", page)) {
+            assertThat(PageExecutionContext.processResult("demo.count", records)).isSameAs(records);
+
+            Object processed = PageExecutionContext.processResult("demo.selectPage", records);
+            assertThat(processed).isInstanceOf(List.class);
+            assertThat((List<?>) processed).hasSize(1);
+            assertThat(((List<?>) processed).get(0)).isSameAs(page);
+            assertThat(page.getRecords()).containsExactly("one", "two");
+
+            assertThat(PageExecutionContext.processResult("demo.selectPage", processed))
+                .isSameAs(processed);
+        }
+    }
+
+    @Test
+    void restoresNestedContextAndRejectsOutOfOrderClose() {
+        Page<String> outer = new Page<>();
+        Page<String> inner = new Page<>();
+        PageExecutionContext outerContext = PageExecutionContext.open("outer", outer);
+        PageExecutionContext innerContext = PageExecutionContext.open("inner", inner);
+
+        assertThatIllegalStateException().isThrownBy(outerContext::close);
+        innerContext.close();
+        assertThat(PageExecutionContext.processResult("outer", List.of("record")))
+            .isEqualTo(List.of(outer));
+        outerContext.close();
+    }
+}

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserMapperTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/H2UserMapperTest.java
@@ -489,6 +489,19 @@ class H2UserMapperTest extends BaseTest {
     }
 
     @Test
+    void selectPageDoesNotNestThePageAsARecord() {
+        Page<H2User> page = new Page<>(1, 2);
+
+        IPage<H2User> result = userMapper.selectPage(page);
+
+        Assertions.assertSame(page, result);
+        Assertions.assertEquals(2, result.getRecords().size());
+        Assertions.assertFalse(result.getRecords().stream().anyMatch(IPage.class::isInstance));
+        Assertions.assertTrue(result.getRecords().stream().allMatch(H2User.class::isInstance));
+        Assertions.assertTrue(result.getTotal() >= result.getRecords().size());
+    }
+
+    @Test
     void testCountLong() {
         Long count = userMapper.selectCountLong();
         System.out.println(count);

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/mapper/H2UserMapper.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/mapper/H2UserMapper.java
@@ -79,6 +79,9 @@ public interface H2UserMapper extends SuperMapper<H2User> {
     IPage<H2User> testPage1(@Param(value = "user") H2User h2User, @Param(value = "page") Page page);
 
     @Select("select * from h2user")
+    IPage<H2User> selectPage(IPage<H2User> page);
+
+    @Select("select * from h2user")
     IPage<H2User> testPage2(@Param(value = "user") Page page, @Param(value = "page") H2User h2User);
 
     @Select("select count(*) from h2user")


### PR DESCRIPTION

## 背景

The mapper proxy currently handles an `IPage` return value in `MybatisMapperMethod.executeForIPage`, while the related interceptor refactor moves page packaging into `MybatisPlusInterceptor`. If the old mapper-side assignment and interceptor-side `[page]` envelope are both active, the page can be written into its own `records` list as an `IPage` value.

## 方案

- Add an explicit statement-scoped `PageExecutionContext` between `MybatisMapperMethod` and `MybatisPlusInterceptor`.
- Process results only when the `MappedStatement` id matches the active page scope.
- Keep count and nested queries untouched because their statement ids do not match the data statement.
- Use page identity to make the packaging operation exactly-once and prevent `List<IPage>` records.
- Preserve the no-interceptor `selectList` fallback in `executeForIPage`.
- Reject out-of-order or repeated context closing immediately.

This avoids reflection-based mapper-method discovery and keeps the mapper/interceptor contract explicit.

## 验证

```text
./gradlew :mybatis-plus-core:test --tests com.baomidou.mybatisplus.test.toolkit.PageExecutionContextTest --tests com.baomidou.mybatisplus.test.mapper.BaseMapperSelectOneCompatibilityTest --no-daemon
BUILD SUCCESSFUL

./gradlew :mybatis-plus:test --tests com.baomidou.mybatisplus.test.h2.H2UserMapperTest.selectPageDoesNotNestThePageAsARecord --no-daemon -Pkotlin.jvm.target.validation.mode=warning
BUILD SUCCESSFUL
```

The H2 end-to-end test calls an `IPage<H2User>` mapper method, verifies the returned page identity, verifies two entity records, and asserts that no record is itself an `IPage`.
