### PR TITLE
fix: keep BaseMapper.selectOne independent of JDBC cursor support

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
@@ -27,7 +27,6 @@ import com.baomidou.mybatisplus.core.metadata.TableInfo;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.core.toolkit.*;
 import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.binding.MapperMethod;
 import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.exceptions.TooManyResultsException;
 import org.apache.ibatis.executor.BatchResult;
@@ -36,7 +35,6 @@ import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
 import java.util.function.BiPredicate;
@@ -329,36 +327,20 @@ public interface BaseMapper<T> extends Mapper<T> {
     /**
      * 根据 entity 条件，查询一条记录，现在会根据{@code throwEx}参数判断是否抛出异常，如果为false就直接返回一条数据
      * <p>查询一条记录，例如 qw.last("limit 1") 限制取一条记录, 注意：多条数据会报异常</p>
-     * <p>数据库必须支持游标查询，如果不支持请切换使用其它方法或者自定义 XML SQL 处理</p>
      *
      * @param queryWrapper 实体对象封装操作类（可以为 null）
      * @param throwEx      boolean 参数，为true如果存在多个结果直接抛出异常
      */
     default T selectOne(Wrapper<T> queryWrapper, boolean throwEx) {
-        MapperProxyMetadata mapperProxyMetadata = MybatisUtils.getMapperProxy(this);
-        SqlSessionFactory factory = MybatisUtils.getSqlSessionFactory(mapperProxyMetadata.getSqlSession());
-        try (SqlSession sqlSession = factory.openSession()) {
-            MapperMethod.ParamMap<Object> param = new MapperMethod.ParamMap<>();
-            param.put(Constants.WRAPPER, queryWrapper);
-            // 使用游标方式查询
-            try (Cursor<T> cursor = sqlSession.selectCursor(mapperProxyMetadata.getMapperInterface().getName() + Constants.DOT +
-                Constants.SELECT_WITH_CURSOR, param)) {
-                Iterator<T> iterator = cursor.iterator();
-                if (!iterator.hasNext()) {
-                    return null;
-                }
-                T first = iterator.next();
-                if (iterator.hasNext()) {
-                    if (throwEx) {
-                        throw new TooManyResultsException("Expected one result (or null) but found more than one");
-                    }
-                }
-                return first;
-            } catch (IOException e) {
-                if (throwEx) {
-                    throw new RuntimeException(e);
-                }
+        List<T> list = this.selectList(queryWrapper);
+        int size = list.size();
+        if (size == 1) {
+            return list.get(0);
+        } else if (size > 1) {
+            if (throwEx) {
+                throw new TooManyResultsException("Expected one result (or null) to be returned by selectOne(), but found: " + size);
             }
+            return list.get(0);
         }
         return null;
     }

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/mapper/BaseMapperSelectOneCompatibilityTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/mapper/BaseMapperSelectOneCompatibilityTest.java
@@ -38,4 +38,21 @@ class BaseMapperSelectOneCompatibilityTest {
         assertThatThrownBy(() -> mapper.selectOne(new QueryWrapper<>()))
             .isInstanceOf(TooManyResultsException.class);
     }
+
+    @Test
+    void selectOneReturnsFirstResultWhenThrowExIsFalse() {
+        BaseMapper<Object> mapper = Mockito.mock(BaseMapper.class, Mockito.CALLS_REAL_METHODS);
+        Object first = new Object();
+        when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of(first, new Object()));
+
+        assertThat(mapper.selectOne(new QueryWrapper<>(), false)).isSameAs(first);
+    }
+
+    @Test
+    void selectOneReturnsNullForAnEmptyList() {
+        BaseMapper<Object> mapper = Mockito.mock(BaseMapper.class, Mockito.CALLS_REAL_METHODS);
+        when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of());
+
+        assertThat(mapper.selectOne(new QueryWrapper<>())).isNull();
+    }
 }

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/mapper/BaseMapperSelectOneCompatibilityTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/test/mapper/BaseMapperSelectOneCompatibilityTest.java
@@ -1,0 +1,41 @@
+package com.baomidou.mybatisplus.test.mapper;
+
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.exceptions.TooManyResultsException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for the 3.5.17 cursor-based selectOne change.
+ */
+class BaseMapperSelectOneCompatibilityTest {
+
+    @Test
+    void selectOneUsesTheListBackedQueryPath() {
+        BaseMapper<Object> mapper = Mockito.mock(BaseMapper.class, Mockito.CALLS_REAL_METHODS);
+        Object first = new Object();
+        when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of(first));
+
+        assertThat(mapper.selectOne(new QueryWrapper<>())).isSameAs(first);
+        verify(mapper).selectList(any(Wrapper.class));
+    }
+
+    @Test
+    void listBackedPathStillPreservesTooManyResultsContract() {
+        BaseMapper<Object> mapper = Mockito.mock(BaseMapper.class, Mockito.CALLS_REAL_METHODS);
+        when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of(new Object(), new Object()));
+
+        assertThatThrownBy(() -> mapper.selectOne(new QueryWrapper<>()))
+            .isInstanceOf(TooManyResultsException.class);
+    }
+}


### PR DESCRIPTION
## 摘要

修复 #7148  
修复 #7162

## 说明

本 PR 统一处理两个由同一处兼容性回归引发的问题。

在 3.5.17 中，`BaseMapper.selectOne` 从基于 `selectList` 的实现改为直接调用 MyBatis 的 `selectCursor`（游标查询）。这导致原本只需要普通查询能力的 `selectOne`，额外依赖 JDBC 驱动、连接池以及数据库对游标 API 的支持。

#7148 和 #7162 报告的厂商侧异常虽然不同，但都发生在新增的游标调用路径中。因此，本 PR 采用一个共同的核心修复，而不是分别进行重复修改：

- 恢复 `selectOne(Wrapper<T>, boolean)` 基于列表查询的语义；
- 保留 `throwEx = true` 时抛出 `TooManyResultsException`（结果过多异常）的约定；
- 保留显式的 `selectWithCursor` API，调用方仍然可以主动选择游标查询；
- 删除“`selectOne` 必须依赖数据库游标支持”的误导性限制说明。

## 依据

相关源码变化可以通过官方标签进行对比：

- `v3.5.16` 中的 `BaseMapper.selectOne` 实现；
- `v3.5.17` 中的 `BaseMapper.selectOne` 实现；
- `v3.5.17` 中新增的 `selectWithCursor` 声明。

## 测试

已在官方 3.0 分支执行以下测试：

```text
./gradlew :mybatis-plus-core:test --tests com.baomidou.mybatisplus.test.mapper.BaseMapperSelectOneCompatibilityTest --no-daemon -Pkotlin.jvm.target.validation.mode=warning
```

执行结果：构建成功。

回归测试覆盖了单条结果查询路径以及现有的多条结果异常约定，并且不依赖 JDBC 游标实现。


本 PR 将这两个问题视为同一处游标兼容性回归，依据包括源码差异、兼容性测试以及两个问题报告。