### PR TITLE
fix: clear caches after BaseMapper batch operations

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/mapper/BaseMapper.java
@@ -15,6 +15,7 @@
  */
 package com.baomidou.mybatisplus.core.mapper;
 
+import com.baomidou.mybatisplus.core.batch.BatchMethod;
 import com.baomidou.mybatisplus.core.batch.BatchSqlSession;
 import com.baomidou.mybatisplus.core.batch.MybatisBatch;
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
@@ -519,8 +520,14 @@ public interface BaseMapper<T> extends Mapper<T> {
     default List<BatchResult> insert(Collection<T> entityList, int batchSize) {
         MapperProxyMetadata mapperProxyMetadata = MybatisUtils.getMapperProxy(this);
         MybatisBatch.Method<T> method = new MybatisBatch.Method<>(mapperProxyMetadata.getMapperInterface());
-        SqlSessionFactory sqlSessionFactory = MybatisUtils.getSqlSessionFactory(mapperProxyMetadata.getSqlSession());
-        return MybatisBatchUtils.execute(sqlSessionFactory, entityList, method.insert(), batchSize);
+        BatchMethod<T> batchMethod = method.insert();
+        SqlSession sqlSession = mapperProxyMetadata.getSqlSession();
+        SqlSessionFactory sqlSessionFactory = MybatisUtils.getSqlSessionFactory(sqlSession);
+        try {
+            return MybatisBatchUtils.execute(sqlSessionFactory, entityList, batchMethod, batchSize);
+        } finally {
+            MybatisUtils.clearMapperCache(mapperProxyMetadata, batchMethod.getStatementId());
+        }
     }
 
     /**
@@ -543,8 +550,14 @@ public interface BaseMapper<T> extends Mapper<T> {
     default List<BatchResult> updateById(Collection<T> entityList, int batchSize) {
         MapperProxyMetadata mapperProxyMetadata = MybatisUtils.getMapperProxy(this);
         MybatisBatch.Method<T> method = new MybatisBatch.Method<>(mapperProxyMetadata.getMapperInterface());
-        SqlSessionFactory sqlSessionFactory = MybatisUtils.getSqlSessionFactory(mapperProxyMetadata.getSqlSession());
-        return MybatisBatchUtils.execute(sqlSessionFactory, entityList, method.updateById(), batchSize);
+        BatchMethod<T> batchMethod = method.updateById();
+        SqlSession sqlSession = mapperProxyMetadata.getSqlSession();
+        SqlSessionFactory sqlSessionFactory = MybatisUtils.getSqlSessionFactory(sqlSession);
+        try {
+            return MybatisBatchUtils.execute(sqlSessionFactory, entityList, batchMethod, batchSize);
+        } finally {
+            MybatisUtils.clearMapperCache(mapperProxyMetadata, batchMethod.getStatementId());
+        }
     }
 
     /**
@@ -599,8 +612,16 @@ public interface BaseMapper<T> extends Mapper<T> {
     default List<BatchResult> insertOrUpdate(Collection<T> entityList, BiPredicate<BatchSqlSession, T> insertPredicate, int batchSize) {
         MapperProxyMetadata mapperProxyMetadata = MybatisUtils.getMapperProxy(this);
         MybatisBatch.Method<T> method = new MybatisBatch.Method<>(mapperProxyMetadata.getMapperInterface());
-        SqlSessionFactory sqlSessionFactory = MybatisUtils.getSqlSessionFactory(mapperProxyMetadata.getSqlSession());
-        return MybatisBatchUtils.saveOrUpdate(sqlSessionFactory, entityList, method.insert(), insertPredicate, method.updateById(), batchSize);
+        BatchMethod<T> insertMethod = method.insert();
+        BatchMethod<T> updateMethod = method.updateById();
+        SqlSession sqlSession = mapperProxyMetadata.getSqlSession();
+        SqlSessionFactory sqlSessionFactory = MybatisUtils.getSqlSessionFactory(sqlSession);
+        try {
+            return MybatisBatchUtils.saveOrUpdate(sqlSessionFactory, entityList, insertMethod, insertPredicate,
+                updateMethod, batchSize);
+        } finally {
+            MybatisUtils.clearMapperCache(mapperProxyMetadata, insertMethod.getStatementId());
+        }
     }
 
 }

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/spi/CompatibleSet.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/spi/CompatibleSet.java
@@ -34,6 +34,18 @@ public interface CompatibleSet {
     boolean executeBatch(SqlSessionFactory sqlSessionFactory, Log log, Function<SqlSession, Integer> execFunc);
 
     /**
+     * 批量操作后清理 Mapper 调用会话缓存。
+     * <p>默认清理一级缓存，平台实现可根据实际事务会话清理指定语句关联的事务性二级缓存。</p>
+     *
+     * @param sqlSession  Mapper 调用会话
+     * @param statementId {@link org.apache.ibatis.mapping.MappedStatement} ID
+     * @since 3.5.18
+     */
+    default void clearMapperCache(SqlSession sqlSession, String statementId) {
+        sqlSession.clearCache();
+    }
+
+    /**
      * @deprecated 3.5.12 无需实现
      */
     @Deprecated

--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/MybatisUtils.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/toolkit/MybatisUtils.java
@@ -23,6 +23,10 @@ import com.baomidou.mybatisplus.core.override.MybatisMapperProxy;
 import com.baomidou.mybatisplus.core.spi.CompatibleHelper;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.cache.Cache;
+import org.apache.ibatis.cache.TransactionalCacheManager;
+import org.apache.ibatis.executor.CachingExecutor;
+import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.SystemMetaObject;
 import org.apache.ibatis.session.Configuration;
@@ -134,6 +138,50 @@ public class MybatisUtils {
         SqlSessionFactory sqlSessionFactory = GlobalConfigUtils.getGlobalConfig(sqlSession.getConfiguration()).getSqlSessionFactory();
         Assert.isTrue(sqlSessionFactory != null, "Please implement access to the sqlSessionFactory property or bind sqlSessionFactory to global access.");
         return sqlSessionFactory;
+    }
+
+    /**
+     * 清理 Mapper 调用会话中指定语句关联的一级和二级缓存。
+     *
+     * @param mapperProxyMetadata Mapper 代理元数据
+     * @param statementId         {@link org.apache.ibatis.mapping.MappedStatement} ID
+     * @since 3.5.18
+     */
+    public static void clearMapperCache(MapperProxyMetadata mapperProxyMetadata, String statementId) {
+        SqlSession sqlSession = mapperProxyMetadata.getSqlSession();
+        if (CompatibleHelper.hasCompatibleSet()) {
+            CompatibleHelper.getCompatibleSet().clearMapperCache(sqlSession, statementId);
+        } else {
+            clearMapperCache(sqlSession, statementId);
+        }
+    }
+
+    /**
+     * 清理指定会话的一级缓存，并使指定语句关联的二级缓存随当前事务失效。
+     *
+     * @param sqlSession  MyBatis 会话
+     * @param statementId {@link org.apache.ibatis.mapping.MappedStatement} ID
+     * @since 3.5.18
+     */
+    public static void clearMapperCache(SqlSession sqlSession, String statementId) {
+        sqlSession.clearCache();
+        Cache cache = sqlSession.getConfiguration().getMappedStatement(statementId).getCache();
+        if (cache == null) {
+            return;
+        }
+        MetaObject sqlSessionMetaObject = PluginUtils.getMetaObject(sqlSession);
+        Assert.isTrue(sqlSessionMetaObject.hasGetter("executor"),
+            "Please implement access to the executor property in the custom SqlSession.");
+        Executor executor = PluginUtils.realTarget(sqlSessionMetaObject.getValue("executor"));
+        if (executor instanceof CachingExecutor) {
+            // clearCache 仅清理一级缓存，这里还需丢弃当前事务中尚未提交的二级缓存条目。
+            MetaObject executorMetaObject = PluginUtils.getMetaObject(executor);
+            Assert.isTrue(executorMetaObject.hasGetter("tcm"),
+                "Unable to access the transactional cache manager in CachingExecutor.");
+            TransactionalCacheManager transactionalCacheManager =
+                (TransactionalCacheManager) executorMetaObject.getValue("tcm");
+            transactionalCacheManager.clear(cache);
+        }
     }
 
     /**

--- a/mybatis-plus-spring/src/main/java/com/baomidou/mybatisplus/spring/spi/SpringCompatibleSet.java
+++ b/mybatis-plus-spring/src/main/java/com/baomidou/mybatisplus/spring/spi/SpringCompatibleSet.java
@@ -18,8 +18,10 @@ package com.baomidou.mybatisplus.spring.spi;
 import com.baomidou.mybatisplus.core.spi.CompatibleSet;
 import com.baomidou.mybatisplus.core.toolkit.AopUtils;
 import com.baomidou.mybatisplus.core.toolkit.ExceptionUtils;
+import com.baomidou.mybatisplus.core.toolkit.MybatisUtils;
 import com.baomidou.mybatisplus.extension.toolkit.SqlHelper;
 import lombok.SneakyThrows;
+import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
@@ -29,14 +31,19 @@ import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.MyBatisExceptionTranslator;
 import org.mybatis.spring.SqlSessionHolder;
+import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.SqlSessionUtils;
 import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -93,6 +100,59 @@ public class SpringCompatibleSet implements CompatibleSet {
         } finally {
             if (!transaction) {
                 sqlSession.close();
+            }
+        }
+    }
+
+    @Override
+    public void clearMapperCache(SqlSession sqlSession, String statementId) {
+        if (sqlSession instanceof SqlSessionTemplate) {
+            SqlSessionFactory sqlSessionFactory = MybatisUtils.getSqlSessionFactory(sqlSession);
+            clearCacheOnRollback(sqlSessionFactory, statementId);
+            SqlSessionHolder holder =
+                (SqlSessionHolder) TransactionSynchronizationManager.getResource(sqlSessionFactory);
+            if (holder != null) {
+                MybatisUtils.clearMapperCache(holder.getSqlSession(), statementId);
+            }
+            return;
+        }
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            clearCacheOnRollback(MybatisUtils.getSqlSessionFactory(sqlSession), statementId);
+        }
+        MybatisUtils.clearMapperCache(sqlSession, statementId);
+    }
+
+    private void clearCacheOnRollback(SqlSessionFactory sqlSessionFactory, String statementId) {
+        Cache cache = sqlSessionFactory.getConfiguration().getMappedStatement(statementId).getCache();
+        if (cache == null || !TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+        for (TransactionSynchronization synchronization : TransactionSynchronizationManager.getSynchronizations()) {
+            if (synchronization instanceof CacheCleanupSynchronization) {
+                ((CacheCleanupSynchronization) synchronization).add(cache);
+                return;
+            }
+        }
+        // MyBatis-Spring 可能在 JDBC 回滚前关闭会话并发布二级缓存，因此回滚完成后需再次清理。
+        TransactionSynchronizationManager.registerSynchronization(new CacheCleanupSynchronization(cache));
+    }
+
+    private static class CacheCleanupSynchronization implements TransactionSynchronization {
+
+        private final Set<Cache> caches = Collections.newSetFromMap(new IdentityHashMap<>());
+
+        private CacheCleanupSynchronization(Cache cache) {
+            add(cache);
+        }
+
+        private void add(Cache cache) {
+            caches.add(cache);
+        }
+
+        @Override
+        public void afterCompletion(int status) {
+            if (status != TransactionSynchronization.STATUS_COMMITTED) {
+                caches.forEach(Cache::clear);
             }
         }
     }

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/batch/BatchTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/batch/BatchTest.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.session.ExecutorType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +28,19 @@ class BatchTest extends BaseDbTest<EntityMapper> {
 
         doTest(i -> {
             assertThat(i.selectCount(null)).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void baseMapperBatchClearsCallingSessionCache() {
+        Entity entity = new Entity("batch");
+        entity.setId(100L);
+        doTest(mapper -> {
+            assertThat(mapper.selectById(entity.getId())).isNull();
+
+            mapper.insert(Collections.singletonList(entity));
+
+            assertThat(mapper.selectById(entity.getId())).extracting(Entity::getName).isEqualTo("batch");
         });
     }
 

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/cache/CacheTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/cache/CacheTest.java
@@ -5,15 +5,22 @@ import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.metadata.OrderItem;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.test.h2.cache.mapper.CacheMapper;
+import com.baomidou.mybatisplus.test.h2.cache.mapper.CacheRefMapper;
 import com.baomidou.mybatisplus.test.h2.cache.model.CacheModel;
 import com.baomidou.mybatisplus.test.h2.cache.service.ICacheService;
 import org.apache.ibatis.cache.Cache;
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mybatis.spring.SqlSessionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -28,6 +35,15 @@ class CacheTest {
 
     @Autowired
     private SqlSessionFactory sqlSessionFactory;
+
+    @Autowired
+    private CacheMapper cacheMapper;
+
+    @Autowired
+    private CacheRefMapper cacheRefMapper;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
 
     @Test
     @Order(1)
@@ -159,6 +175,181 @@ class CacheTest {
         CacheModel cacheModel = cacheService.getById(id);
         Assertions.assertEquals(1, cache.getSize());
         Assertions.assertNull(cacheModel);
+    }
+
+    @Test
+    @Order(10)
+    @Transactional
+    void testBaseMapperBatchInsertClearsFirstLevelCache() {
+        CacheModel model = new CacheModel(10001L, "batch-insert");
+        Assertions.assertNull(cacheMapper.selectById(model.getId()));
+
+        cacheMapper.insert(Collections.singletonList(model));
+
+        Assertions.assertEquals("batch-insert", cacheMapper.selectById(model.getId()).getName());
+    }
+
+    @Test
+    @Order(11)
+    @Transactional
+    void testBaseMapperBatchUpdateClearsFirstLevelCache() {
+        CacheModel model = new CacheModel(10002L, "before-batch");
+        cacheMapper.insert(model);
+        Assertions.assertEquals("before-batch", cacheMapper.selectById(model.getId()).getName());
+
+        cacheMapper.updateById(Collections.singletonList(new CacheModel(model.getId(), "after-batch")));
+
+        Assertions.assertEquals("after-batch", cacheMapper.selectById(model.getId()).getName());
+    }
+
+    @Test
+    @Order(12)
+    @Transactional
+    void testBaseMapperBatchInsertOrUpdateClearsFirstLevelCacheAfterInsert() {
+        CacheModel model = new CacheModel(10003L, "batch-insert-or-update");
+        Assertions.assertNull(cacheMapper.selectById(model.getId()));
+
+        cacheMapper.insertOrUpdate(Collections.singletonList(model));
+
+        Assertions.assertEquals("batch-insert-or-update", cacheMapper.selectById(model.getId()).getName());
+    }
+
+    @Test
+    @Order(13)
+    @Transactional
+    void testBaseMapperBatchInsertOrUpdateClearsFirstLevelCacheAfterUpdate() {
+        CacheModel model = new CacheModel(10004L, "before-batch");
+        cacheMapper.insert(model);
+        Assertions.assertEquals("before-batch", cacheMapper.selectById(model.getId()).getName());
+
+        cacheMapper.insertOrUpdate(Collections.singletonList(new CacheModel(model.getId(), "after-batch")));
+
+        Assertions.assertEquals("after-batch", cacheMapper.selectById(model.getId()).getName());
+    }
+
+    @Test
+    @Order(14)
+    void testBaseMapperBatchClearsSecondLevelCache() {
+        Cache cache = getCache();
+        cache.clear();
+        CacheModel model = new CacheModel("before-batch");
+        cacheMapper.insert(model);
+        cacheMapper.selectById(model.getId());
+        Assertions.assertEquals(1, cache.getSize());
+
+        cacheMapper.updateById(Collections.singletonList(new CacheModel(model.getId(), "after-batch")));
+
+        Assertions.assertEquals(0, cache.getSize());
+        Assertions.assertEquals("after-batch", cacheMapper.selectById(model.getId()).getName());
+    }
+
+    @Test
+    @Order(15)
+    @Transactional
+    void testBaseMapperBatchClearsFirstLevelCacheAfterPartialFailure() {
+        CacheModel inserted = new CacheModel(10005L, "inserted-before-failure");
+        Assertions.assertNull(cacheMapper.selectById(inserted.getId()));
+        CacheModel duplicate = new CacheModel(1L, "duplicate");
+
+        Assertions.assertThrows(PersistenceException.class,
+            () -> cacheMapper.insert(Arrays.asList(inserted, duplicate), 1));
+
+        Assertions.assertEquals("inserted-before-failure", cacheMapper.selectById(inserted.getId()).getName());
+    }
+
+    @Test
+    @Order(16)
+    void testBaseMapperBatchDoesNotPublishStaleSecondLevelCacheOnCommit() {
+        Cache cache = getCache();
+        cache.clear();
+        Long id = new TransactionTemplate(transactionManager).execute(status -> {
+            CacheModel model = new CacheModel(10006L, "before-batch");
+            cacheMapper.insert(model);
+            Assertions.assertEquals("before-batch", cacheMapper.selectById(model.getId()).getName());
+
+            cacheMapper.updateById(Collections.singletonList(new CacheModel(model.getId(), "after-batch")));
+            return model.getId();
+        });
+
+        Assertions.assertEquals("after-batch", cacheMapper.selectById(id).getName());
+    }
+
+    @Test
+    @Order(17)
+    void testBaseMapperBatchClearsReferencedSecondLevelCache() {
+        Cache cache = getCache();
+        cache.clear();
+        Long id = new TransactionTemplate(transactionManager).execute(status -> {
+            CacheModel model = new CacheModel(10007L, "before-batch");
+            cacheMapper.insert(model);
+            Assertions.assertEquals("before-batch", cacheRefMapper.selectById(model.getId()).getName());
+
+            cacheRefMapper.updateById(Collections.singletonList(new CacheModel(model.getId(), "after-batch")));
+            return model.getId();
+        });
+
+        Assertions.assertEquals("after-batch", cacheMapper.selectById(id).getName());
+    }
+
+    @Test
+    @Order(18)
+    void testBaseMapperBatchCacheInvalidationRollsBackWithTransaction() {
+        Cache cache = getCache();
+        cache.clear();
+        CacheModel model = new CacheModel(10008L, "before-batch");
+        cacheMapper.insert(model);
+        Assertions.assertEquals("before-batch", cacheMapper.selectById(model.getId()).getName());
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            cacheMapper.updateById(Collections.singletonList(new CacheModel(model.getId(), "after-batch")));
+            Assertions.assertEquals("after-batch", cacheMapper.selectById(model.getId()).getName());
+            status.setRollbackOnly();
+        });
+
+        Assertions.assertEquals("before-batch", cacheMapper.selectById(model.getId()).getName());
+    }
+
+    @Test
+    @Order(19)
+    void testBaseMapperBatchPublishesFreshSecondLevelCacheOnCommit() {
+        Cache cache = getCache();
+        cache.clear();
+        Long id = new TransactionTemplate(transactionManager).execute(status -> {
+            CacheModel model = new CacheModel(10009L, "before-batch");
+            cacheMapper.insert(model);
+            Assertions.assertEquals("before-batch", cacheMapper.selectById(model.getId()).getName());
+
+            cacheMapper.updateById(Collections.singletonList(new CacheModel(model.getId(), "after-batch")));
+            Assertions.assertEquals("after-batch", cacheMapper.selectById(model.getId()).getName());
+            return model.getId();
+        });
+
+        Assertions.assertEquals(1, cache.getSize());
+        Assertions.assertEquals("after-batch", cacheMapper.selectById(id).getName());
+    }
+
+    @Test
+    @Order(20)
+    void testDirectSpringSqlSessionDoesNotPublishBatchResultOnRollback() {
+        Cache cache = getCache();
+        cache.clear();
+        CacheModel model = new CacheModel(10010L, "before-batch");
+        cacheMapper.insert(model);
+        Assertions.assertEquals("before-batch", cacheMapper.selectById(model.getId()).getName());
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            SqlSession sqlSession = SqlSessionUtils.getSqlSession(sqlSessionFactory);
+            try {
+                CacheMapper mapper = sqlSession.getMapper(CacheMapper.class);
+                mapper.updateById(Collections.singletonList(new CacheModel(model.getId(), "after-batch")));
+                Assertions.assertEquals("after-batch", mapper.selectById(model.getId()).getName());
+                status.setRollbackOnly();
+            } finally {
+                SqlSessionUtils.closeSqlSession(sqlSession, sqlSessionFactory);
+            }
+        });
+
+        Assertions.assertEquals("before-batch", cacheMapper.selectById(model.getId()).getName());
     }
 
     @Test

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/cache/mapper/CacheRefMapper.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/h2/cache/mapper/CacheRefMapper.java
@@ -1,0 +1,10 @@
+package com.baomidou.mybatisplus.test.h2.cache.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.test.h2.cache.model.CacheModel;
+import org.apache.ibatis.annotations.CacheNamespaceRef;
+
+@CacheNamespaceRef(CacheMapper.class)
+public interface CacheRefMapper extends BaseMapper<CacheModel> {
+
+}


### PR DESCRIPTION
## 问题

`BaseMapper.insert(Collection)`、`updateById(Collection)` 和 `insertOrUpdate(Collection)` 使用独立的 `ExecutorType.BATCH` 会话执行写入，但普通 Mapper 查询仍使用调用方 `SqlSession`。

因此，调用方会话可能继续返回批量操作前的一级缓存（local cache，本地缓存）结果；事务提交时，`CachingExecutor` 中尚未提交的旧查询结果还可能重新进入二级缓存（second-level cache，二级缓存）。仅调用 `SqlSession.clearCache()` 只能解决一级缓存，不能处理当前事务内待提交的二级缓存状态。

该问题已在当前 `3.0` 分支 HEAD 上通过最小回归测试复现，并非仅依据历史 Issue 判断。

## 修改

- 三个 `BaseMapper` 集合批量入口均在 `finally` 中清理调用方缓存，覆盖成功、异常和部分执行失败路径；
- 根据实际 `MappedStatement` 定位关联缓存，并处理 `@CacheNamespaceRef`；
- 清理调用方会话的一级缓存，同时通过 `TransactionalCacheManager` 使当前事务内对应二级缓存失效；
- Spring 环境下解析事务实际绑定的 `SqlSession`，同时覆盖 `SqlSessionTemplate` 和通过 `SqlSessionUtils` 获取会话的路径；
- 事务回滚完成后再次清理可能被会话关闭流程发布的二级缓存，正常提交仍可保留合法的新缓存结果；
- 通过 `CompatibleSet` 默认方法保持已有平台实现的二进制兼容。

该实现不会主动调用 `commit`、`rollback` 或 `flushStatements`，不会改变调用方的事务边界，也不会提前执行调用方会话中无关的批量 SQL。

MyBatis 当前没有公开 API 可以只清理事务中待提交的二级缓存状态，因此这里沿用项目已有的 `MetaObject` 访问方式定位 `CachingExecutor` 的 `TransactionalCacheManager`；缺少预期内部属性时会直接失败，避免静默保留错误缓存。

## 测试

新增回归测试覆盖：

- 原生 MyBatis 与 Spring 事务中的一级缓存；
- 批量插入、批量更新及 `insertOrUpdate` 的插入/更新分支；
- 二级缓存失效、事务提交和事务回滚；
- 部分批处理失败后的缓存清理；
- `@CacheNamespaceRef`；
- `SqlSessionTemplate` 与直接 Spring `SqlSession` 两种调用方式。

JDK 21 下验证：

```text
./gradlew build --rerun-tasks --no-daemon
BUILD SUCCESSFUL

./gradlew :mybatis-plus:test \
  --tests com.baomidou.mybatisplus.test.h2.cache.CacheTest \
  --tests com.baomidou.mybatisplus.test.batch.BatchTest \
  --rerun-tasks --no-daemon
24 tests, 0 failures
```

Fixes #6188