### PR TITLE
feat: add ChainQuery.one(boolean throwEx)

### DIFF
--- a/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/ChainQuery.java
+++ b/mybatis-plus-extension/src/main/java/com/baomidou/mybatisplus/extension/conditions/query/ChainQuery.java
@@ -62,6 +62,17 @@ public interface ChainQuery<T> extends ChainWrapper<T> {
     /**
      * 获取单个
      *
+     * @param throwEx 多条结果时是否抛出异常，为 false 时返回第一条记录
+     * @return 单个，无结果时返回 null
+     * @since 3.5.17
+     */
+    default T one(boolean throwEx) {
+        return execute(mapper -> mapper.selectOne(getWrapper(), throwEx));
+    }
+
+    /**
+     * 获取单个
+     *
      * @return 单个
      * @since 3.3.0
      */

--- a/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/chainwrapper/ChainWrapperTest.java
+++ b/mybatis-plus/src/test/java/com/baomidou/mybatisplus/test/chainwrapper/ChainWrapperTest.java
@@ -1,7 +1,12 @@
 package com.baomidou.mybatisplus.test.chainwrapper;
 
+import com.baomidou.mybatisplus.extension.toolkit.ChainWrappers;
 import com.baomidou.mybatisplus.test.BaseDbTest;
+import org.apache.ibatis.exceptions.TooManyResultsException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.List;
@@ -27,6 +32,57 @@ public class ChainWrapperTest extends BaseDbTest<EntityMapper> {
         doTest(i -> i.queryChain().groupBy("id").list());
         doTest(i -> i.queryChain().groupBy(List.of("id")).list());
         doTest(i -> i.queryChain().groupBy(List.of("id", "name")).list());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void oneWithNoResults(boolean throwEx) {
+        doTest(mapper -> {
+            Assertions.assertNull(mapper.queryChain().eq("id", 0).one(throwEx));
+            Assertions.assertNull(ChainWrappers.lambdaQueryChain(mapper).eq(Entity::getId, 0).one(throwEx));
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void oneWithSingleResult(boolean throwEx) {
+        doTest(mapper -> {
+            Assertions.assertEquals(Long.valueOf(2), mapper.queryChain().eq("id", 2).one(throwEx).getId());
+            Assertions.assertEquals(Long.valueOf(2),
+                ChainWrappers.lambdaQueryChain(mapper).eq(Entity::getId, 2).one(throwEx).getId());
+        });
+    }
+
+    @Test
+    void oneWithMultipleResultsThrowsWhenRequested() {
+        doTest(mapper -> {
+            Assertions.assertThrows(TooManyResultsException.class, () -> mapper.queryChain().one(true));
+            Assertions.assertThrows(TooManyResultsException.class,
+                () -> ChainWrappers.lambdaQueryChain(mapper).one(true));
+        });
+    }
+
+    @Test
+    void oneWithMultipleResultsReturnsFirstWhenAllowed() {
+        doTest(mapper -> {
+            Assertions.assertEquals(Long.valueOf(2), mapper.queryChain().orderByDesc("id").one(false).getId());
+            Assertions.assertEquals(Long.valueOf(2),
+                ChainWrappers.lambdaQueryChain(mapper).orderByDesc(Entity::getId).one(false).getId());
+        });
+    }
+
+    @Test
+    void oneWithoutArgumentKeepsExistingBehavior() {
+        doTest(mapper -> {
+            Assertions.assertNull(mapper.queryChain().eq("id", 0).one());
+            Assertions.assertEquals(Long.valueOf(2), mapper.queryChain().eq("id", 2).one().getId());
+            Assertions.assertThrows(TooManyResultsException.class, () -> mapper.queryChain().one());
+            Assertions.assertNull(ChainWrappers.lambdaQueryChain(mapper).eq(Entity::getId, 0).one());
+            Assertions.assertEquals(Long.valueOf(2),
+                ChainWrappers.lambdaQueryChain(mapper).eq(Entity::getId, 2).one().getId());
+            Assertions.assertThrows(TooManyResultsException.class,
+                () -> ChainWrappers.lambdaQueryChain(mapper).one());
+        });
     }
 
     @Override


### PR DESCRIPTION
Add `ChainQuery.one(boolean throwEx)` so chain queries can use the same multiple-result policy as `BaseMapper.selectOne(wrapper, throwEx)`. Keep the existing no-argument `one()` implementation unchanged.

Add H2 regression coverage for empty, single and multiple results through both query and lambda query chains, including the existing `one()` behavior.

Validation: JDK 21, `./gradlew :mybatis-plus:test --tests 'com.baomidou.mybatisplus.test.chainwrapper.*'` — 9 tests passed. `git diff --check` passed.

Fixes #7161