### PR TITLE
feat(core): add predicate condition overloads for Compare interface

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java
@@ -18,6 +18,7 @@ package com.baomidou.mybatisplus.core.conditions.interfaces;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 /**
  * 查询条件封装
@@ -107,6 +108,18 @@ public interface Compare<Children, R> extends Serializable {
     /**
      * 等于 =
      *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children eq(Predicate<V> condition, R column, V val) {
+        return eq(condition.test(val), column, val);
+    }
+
+    /**
+     * 等于 =
+     *
      * @param condition 执行条件
      * @param column    字段
      * @param val       值
@@ -123,6 +136,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children eqOrIsNull(R column, Object val) {
         return eqOrIsNull(true, column, val);
+    }
+
+    /**
+     * 等于 = ，值为 null 时自动转为 IS NULL
+     *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children eqOrIsNull(Predicate<V> condition, R column, V val) {
+        return eqOrIsNull(condition.test(val), column, val);
     }
 
     /**
@@ -147,6 +172,18 @@ public interface Compare<Children, R> extends Serializable {
     }
 
     /**
+     * 不等于 <>
+     *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children ne(Predicate<V> condition, R column, V val) {
+        return ne(condition.test(val), column, val);
+    }
+
+    /**
      * 不等于 &lt;&gt;
      *
      * @param condition 执行条件
@@ -165,6 +202,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children gt(R column, Object val) {
         return gt(true, column, val);
+    }
+
+    /**
+     * 大于 >
+     *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children gt(Predicate<V> condition, R column, V val) {
+        return gt(condition.test(val), column, val);
     }
 
     /**
@@ -189,6 +238,18 @@ public interface Compare<Children, R> extends Serializable {
     }
 
     /**
+     * 大于等于 >=
+     *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children ge(Predicate<V> condition, R column, V val) {
+        return ge(condition.test(val), column, val);
+    }
+
+    /**
      * 大于等于 &gt;=
      *
      * @param condition 执行条件
@@ -210,6 +271,18 @@ public interface Compare<Children, R> extends Serializable {
     }
 
     /**
+     * 小于 <
+     *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children lt(Predicate<V> condition, R column, V val) {
+        return lt(condition.test(val), column, val);
+    }
+
+    /**
      * 小于 &lt;
      *
      * @param condition 执行条件
@@ -228,6 +301,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children le(R column, Object val) {
         return le(true, column, val);
+    }
+
+    /**
+     * 小于等于 <=
+     *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children le(Predicate<V> condition, R column, V val) {
+        return le(condition.test(val), column, val);
     }
 
     /**
@@ -301,6 +386,18 @@ public interface Compare<Children, R> extends Serializable {
     /**
      * LIKE '%值%'
      *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children like(Predicate<V> condition, R column, V val) {
+        return like(condition.test(val), column, val);
+    }
+
+    /**
+     * LIKE '%值%'
+     *
      * @param condition 执行条件
      * @param column    字段
      * @param val       值
@@ -317,6 +414,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children notLike(R column, Object val) {
         return notLike(true, column, val);
+    }
+
+    /**
+     * NOT LIKE '%值%'
+     *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children notLike(Predicate<V> condition, R column, V val) {
+        return notLike(condition.test(val), column, val);
     }
 
     /**
@@ -343,6 +452,18 @@ public interface Compare<Children, R> extends Serializable {
     /**
      * NOT LIKE '%值'
      *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children notLikeLeft(Predicate<V> condition, R column, V val) {
+        return notLikeLeft(condition.test(val), column, val);
+    }
+
+    /**
+     * NOT LIKE '%值'
+     *
      * @param condition 执行条件
      * @param column    字段
      * @param val       值
@@ -359,6 +480,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children notLikeRight(R column, Object val) {
         return notLikeRight(true, column, val);
+    }
+
+    /**
+     * NOT LIKE '值%'
+     *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children notLikeRight(Predicate<V> condition, R column, V val) {
+        return notLikeRight(condition.test(val), column, val);
     }
 
     /**
@@ -385,6 +518,18 @@ public interface Compare<Children, R> extends Serializable {
     /**
      * LIKE '%值'
      *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children likeLeft(Predicate<V> condition, R column, V val) {
+        return likeLeft(condition.test(val), column, val);
+    }
+
+    /**
+     * LIKE '%值'
+     *
      * @param condition 执行条件
      * @param column    字段
      * @param val       值
@@ -401,6 +546,18 @@ public interface Compare<Children, R> extends Serializable {
      */
     default Children likeRight(R column, Object val) {
         return likeRight(true, column, val);
+    }
+
+    /**
+     * LIKE '值%'
+     *
+     * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
+     * @param column    字段
+     * @param val       值
+     * @return children
+     */
+    default <V> Children likeRight(Predicate<V> condition, R column, V val) {
+        return likeRight(condition.test(val), column, val);
     }
 
     /**

--- a/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/QueryWrapperTest.java
+++ b/mybatis-plus-core/src/test/java/com/baomidou/mybatisplus/core/conditions/QueryWrapperTest.java
@@ -99,6 +99,24 @@ class QueryWrapperTest extends BaseWrapperTest {
     }
 
     @Test
+    void testComparePredicateCondition() {
+        String companyCode = null;
+        QueryWrapper<Entity> wrapper = new QueryWrapper<Entity>()
+            .eq(v -> v != null, "id", 1)
+            .eq(v -> v != null, "company_code", companyCode)
+            .ne(v -> v > 0, "id", 2)
+            .ne(v -> v > 0, "id", 0)
+            .like(v -> !v.isEmpty(), "name", "abc")
+            .like(v -> !v.isEmpty(), "name", "")
+            .ge(v -> v >= 18, "age", 20)
+            .ge(v -> v >= 18, "age", 10)
+            .le(v -> v <= 100, "age", 80)
+            .le(v -> v <= 100, "age", 200);
+        logSqlWhere("测试 Compare 谓词条件", wrapper,
+            "(id = ? AND id <> ? AND name LIKE ? AND age >= ? AND age <= ?)");
+    }
+
+    @Test
     void testFunc() {
         Entity entity = new Entity();
         QueryWrapper<Entity> queryWrapper = new QueryWrapper<Entity>()


### PR DESCRIPTION
### 该 PR 相关 Issue

Closes #7169

### 背景

目前 `Compare` 接口的条件重载只接受 `boolean condition`，当判断条件依赖值本身时，必须把同一个长表达式写两遍：

```java
// 现状：veryLongVariableName.getCompanyCode() 重复出现
queryWrapper.eq(StringUtils.isNotBlank(veryLongVariableName.getCompanyCode()),
                "a.company_code", veryLongVariableName.getCompanyCode());
```

本 PR 增加一套以 `Predicate<V>` 作为执行条件的 `default` 重载，谓词入参即为值本身：

```java
// 本 PR 之后
queryWrapper.eq(v -> StringUtils.isNotBlank(v),
                "a.company_code", veryLongVariableName.getCompanyCode());
```

### 改动内容

文件：`mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/conditions/interfaces/Compare.java`

为以下 **13 个单值比较方法**各增加一个 `default` 重载：

`eq` `eqOrIsNull` `ne` `gt` `ge` `lt` `le` `like` `notLike` `notLikeLeft` `notLikeRight` `likeLeft` `likeRight`

```java
/**
 * 等于 =
 *
 * @param condition 执行条件, 入参为 val, 返回 true 时才拼接该条件
 * @param column    字段
 * @param val       值
 * @return children
 */
default <V> Children eq(Predicate<V> condition, R column, V val) {
    return eq(condition.test(val), column, val);
}
```

### 设计说明

1. **使用 `Predicate<V>` 而非 issue 中建议的 `Function<Object, Boolean>`**
   语义上是断言而非转换；泛型 `V` 让调用方无需强转，且类型安全（`v` 直接就是 `String` / `Integer`）；与仓库已有的 `allEq(BiPredicate<R, V> filter, ...)` 风格一致。

2. **全部为 `default` 方法，零破坏性**
   不新增、不修改任何抽象方法，`AbstractWrapper` / `LambdaQueryWrapper` / `QueryWrapper` 等实现类无需任何改动，源码与二进制均向后兼容。

3. **未覆盖 `between` / `notBetween`**
   这两个方法存在 `val1` / `val2` 两个值，谓词应作用于哪个值语义不明确（是"任一"、"全部"还是"分别判断"？）。为避免引入有歧义的 API，本次留白。如需支持，建议另行添加 `BiPredicate` 版本，可在本 PR 中补充。

4. **不做隐式空值短路**
   谓词入参可能为 `null`，由调用方在 lambda 中自行处理，与现有 `boolean condition` 版本的行为完全一致，不引入额外魔法。

5. **重载解析无歧义**
   `Predicate<V>` 与现有 `boolean` / `R` 签名类型不相容，不会产生方法调用歧义；已通过全量编译验证。

### 测试

新增 `QueryWrapperTest#testComparePredicateCondition`：

```java
@Test
void testComparePredicateCondition() {
    String companyCode = null;
    QueryWrapper<Entity> wrapper = new QueryWrapper<Entity>()
        .eq(v -> v != null, "id", 1)
        .eq(v -> v != null, "company_code", companyCode)
        .ne(v -> v > 0, "id", 2)
        .ne(v -> v > 0, "id", 0)
        .like(v -> !v.isEmpty(), "name", "abc")
        .like(v -> !v.isEmpty(), "name", "")
        .ge(v -> v >= 18, "age", 20)
        .ge(v -> v >= 18, "age", 10)
        .le(v -> v <= 100, "age", 80)
        .le(v -> v <= 100, "age", 200);
    logSqlWhere("测试 Compare 谓词条件", wrapper,
        "(id = ? AND id <> ? AND name LIKE ? AND age >= ? AND age <= ?)");
}
```

10 次调用中 5 次谓词为 `true`（拼接）、5 次为 `false`（跳过），最终只应生成 5 个条件，`logSqlWhere` 内部使用 AssertJ 真断言。

**本地验证结果**：

```
JAVA_HOME=<jdk-21> ./gradlew :mybatis-plus-core:test
→ BUILD SUCCESSFUL
  44 个测试类 / 189 tests / 0 skipped / 0 failures / 0 errors
```

> 注：`3.0` 分支的测试编译需要 **JDK 21**（`sourceCompatibility` 为 21），使用 JDK 17 会报 `无效的源发行版: 21`。

### 自查清单

- [x] 仅改动 2 个文件（1 个主源 + 1 个测试），+175 行，0 删除
- [x] 未修改任何现有方法签名或行为
- [x] 新增测试已实际执行并通过（非跳过）
- [x] `mybatis-plus-core` 全量测试通过，无回归
